### PR TITLE
[AB#37116] Support added for additional licensing urls for entitlement webhook to enable video playback

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
     "codegen",
     "Dockerized",
     "Downloadability",
+    "fairplay",
     "geolocation",
     "Inflector",
     "loglevel",
@@ -22,6 +23,7 @@
     "pilets",
     "Piral",
     "Piral's",
+    "playready",
     "postgraphile",
     "prefetch",
     "RABBITMQ",
@@ -33,6 +35,7 @@
     "upsert",
     "urljoin",
     "vhosts",
+    "widevine",
     "zapatos"
   ],
   "[markdown]": {

--- a/services/entitlement/service/.env.template
+++ b/services/entitlement/service/.env.template
@@ -45,3 +45,14 @@ SERVICE_ACCOUNT_CLIENT_SECRET=####
 # In development, fill the values using `yarn setup:webhooks` script
 ENTITLEMENT_WEBHOOK_SECRET=####
 MANIFEST_WEBHOOK_SECRET=####
+
+# URLs to DRM License services to be returned by the `/entitlement` webhook endpoint
+WIDEVINE_LICENSE_SERVICE_URL=https://drm-widevine-licensing.axtest.net/AcquireLicense
+PLAYREADY_LICENSE_SERVICE_URL=https://drm-playready-licensing.axtest.net/AcquireLicense
+FAIRPLAY_LICENSE_SERVICE_URL=https://drm-fairplay-licensing.axtest.net/AcquireLicense
+
+# An Apple-issued certificate to enable playback of FairPlay DRM-protected videos.
+# Please request your own certificate from Apple for production purposes, as
+# testing one has limitations.
+# More information: https://portal.axinom.com/mosaic/documentation/drm/fairplay-and-axinom-drm
+FAIRPLAY_STREAMING_CERTIFICATE_URL=https://vtb.axinom.com/FPScert/fairplay.cer

--- a/services/entitlement/service/src/common/config/config-definitions.ts
+++ b/services/entitlement/service/src/common/config/config-definitions.ts
@@ -63,6 +63,15 @@ export const getConfigDefinitions = (
 
     manifestWebhookSecret: () => env.get('MANIFEST_WEBHOOK_SECRET').asString(),
 
+    widevineLicenseServiceUrl: () =>
+      env.get('WIDEVINE_LICENSE_SERVICE_URL').asUrlString(),
+    playreadyLicenseServiceUrl: () =>
+      env.get('PLAYREADY_LICENSE_SERVICE_URL').asUrlString(),
+    fairplayLicenseServiceUrl: () =>
+      env.get('FAIRPLAY_LICENSE_SERVICE_URL').asUrlString(),
+    fairplayStreamingCertificateUrl: () =>
+      env.get('FAIRPLAY_STREAMING_CERTIFICATE_URL').asUrlString(),
+
     /**
      * Optional User Service GraphQL Endpoint, used to get user auth token
      * during development

--- a/services/entitlement/service/src/domains/encoding/video-playback-middlewares.ts
+++ b/services/entitlement/service/src/domains/encoding/video-playback-middlewares.ts
@@ -70,7 +70,14 @@ export const setupEntitlementWebhookEndpoint = (
         const jwt = generateEntitlementMessageJwt(keyIds, [], config, 'STRICT');
         const response =
           generateWebhookResponse<EntitlementWebhookResponsePayload>({
-            payload: { entitlement_message_jwt: jwt },
+            payload: {
+              entitlement_message_jwt: jwt,
+              widevine_license_service_url: config.widevineLicenseServiceUrl,
+              playready_license_service_url: config.playreadyLicenseServiceUrl,
+              fairplay_license_service_url: config.fairplayLicenseServiceUrl,
+              fairplay_streaming_certificate_url:
+                config.fairplayStreamingCertificateUrl,
+            },
           });
         res.status(200).send(response);
       } catch (error) {


### PR DESCRIPTION
3 new env variables added for different license services (one for each DRM technology) and one for Fairplay Certificate.
Configured values are returned by the `/entitlement` webhook together with the entitlement JWT.