### PR TITLE
[AB#37614] Navigation panel category grouping update

### DIFF
--- a/services/media/workflows/src/Stations/Collections/registrations.tsx
+++ b/services/media/workflows/src/Stations/Collections/registrations.tsx
@@ -14,13 +14,24 @@ import { CollectionSnapshotDetailsCrumb } from './CollectionSnapshotDetails/Coll
 import { CollectionSnapshots } from './CollectionSnapshots/CollectionSnapshots';
 
 export function register(app: PiletApi, extensions: Extensions): void {
-  app.registerTile({
-    kind: 'home',
+  const collectionsNav = {
     name: 'collections',
     path: '/collections',
     label: 'Collections',
     icon: <MediaIcons icon={MediaIconName.Collections} />,
-    type: 'small',
+  };
+  app.registerTile(
+    {
+      ...collectionsNav,
+      kind: 'home',
+      type: 'small',
+    },
+    false,
+  );
+
+  app.registerNavigationItem({
+    ...collectionsNav,
+    categoryName: 'Curation',
   });
 
   app.registerPage('/collections', Collections, {

--- a/services/media/workflows/src/Stations/Episodes/registrations.tsx
+++ b/services/media/workflows/src/Stations/Episodes/registrations.tsx
@@ -16,12 +16,24 @@ import { EpisodeSnapshots } from './EpisodeSnapshots/EpisodeSnapshots';
 import { EpisodeVideoManagement } from './EpisodeVideoManagement/EpisodeVideoManagement';
 
 export function register(app: PiletApi, extensions: Extensions): void {
-  app.registerTile({
-    kind: 'home',
+  const episodesNav = {
     path: '/episodes',
     label: 'Episodes',
     icon: <MediaIcons icon={MediaIconName.Episodes} />,
-    type: 'large',
+  };
+
+  app.registerTile(
+    {
+      ...episodesNav,
+      kind: 'home',
+      type: 'large',
+    },
+    false,
+  );
+
+  app.registerNavigationItem({
+    ...episodesNav,
+    categoryName: 'Content',
   });
 
   app.registerPage('/episodes', Episodes, {

--- a/services/media/workflows/src/Stations/Ingest/registrations.tsx
+++ b/services/media/workflows/src/Stations/Ingest/registrations.tsx
@@ -11,12 +11,23 @@ import { IngestDocuments } from './IngestDocumentsExplorer/IngestDocuments';
 import { IngestDocumentUpload } from './IngestDocumentUpload/IngestDocumentUpload';
 
 export function register(app: PiletApi, extensions: Extensions): void {
-  app.registerTile({
-    kind: 'home',
+  const ingestNav = {
     path: '/ingest',
     label: 'Ingest',
     icon: <MediaIcons icon={MediaIconName.Ingest} />,
-    type: 'small',
+  };
+  app.registerTile(
+    {
+      ...ingestNav,
+      kind: 'home',
+      type: 'small',
+    },
+    false,
+  );
+
+  app.registerNavigationItem({
+    ...ingestNav,
+    categoryName: 'Processing',
   });
 
   app.registerPage('/ingest', IngestDocuments, {

--- a/services/media/workflows/src/Stations/Movies/registrations.tsx
+++ b/services/media/workflows/src/Stations/Movies/registrations.tsx
@@ -1,7 +1,10 @@
 import { PiletApi } from '@axinom/mosaic-portal';
 import React from 'react';
 import { Extensions, ExtensionsContext } from '../../externals';
-import { settingsGroupName } from '../../index';
+import {
+  mediaManagementParentName as parentName,
+  settingsGroupName,
+} from '../../index';
 import { MediaIconName, MediaIcons } from '../../MediaIcons';
 import { MovieCreate } from './MovieCreate/MovieCreate';
 import { MovieDetails } from './MovieDetails/MovieDetails';
@@ -122,12 +125,25 @@ export function register(app: PiletApi, extensions: Extensions): void {
     },
   );
 
-  app.registerTile({
-    kind: 'settings',
-    groupName: settingsGroupName,
+  const movieSettingsNav = {
     path: '/settings/media/moviegenres',
     label: 'Movie Genres',
     icon: <MediaIcons icon={MediaIconName.MovieGenres} />,
+  };
+
+  app.registerTile(
+    {
+      ...movieSettingsNav,
+      kind: 'settings',
+      groupName: settingsGroupName,
+    },
+    false,
+  );
+
+  app.registerNavigationItem({
+    ...movieSettingsNav,
+    parentName: parentName,
+    categoryName: 'Settings',
   });
 
   app.registerPage('/settings/media/moviegenres', MovieGenres, {

--- a/services/media/workflows/src/Stations/Movies/registrations.tsx
+++ b/services/media/workflows/src/Stations/Movies/registrations.tsx
@@ -21,12 +21,24 @@ import { MovieSnapshots } from './MovieSnapshots/MovieSnapshots';
 import { MovieVideoManagement } from './MovieVideoManagement/MovieVideoManagement';
 
 export function register(app: PiletApi, extensions: Extensions): void {
-  app.registerTile({
-    kind: 'home',
+  const moviesNav = {
     path: '/movies',
     label: 'Movies',
     icon: <MediaIcons icon={MediaIconName.Movie} />,
-    type: 'large',
+  };
+
+  app.registerTile(
+    {
+      ...moviesNav,
+      kind: 'home',
+      type: 'large',
+    },
+    false,
+  );
+
+  app.registerNavigationItem({
+    ...moviesNav,
+    categoryName: 'Content',
   });
 
   app.registerPage('/movies', Movies, {

--- a/services/media/workflows/src/Stations/Publishing/registrations.tsx
+++ b/services/media/workflows/src/Stations/Publishing/registrations.tsx
@@ -6,12 +6,24 @@ import { MediaIcons } from '../../MediaIcons/MediaIcons';
 import { SnapshotRegistry } from './SnapshotRegistryExplorer/SnapshotRegistry';
 
 export function register(app: PiletApi, _extensions: Extensions): void {
-  app.registerTile({
-    kind: 'home',
+  const snapshotsNav = {
     path: '/snapshots',
     label: 'Snapshot Registry',
     icon: <MediaIcons icon={MediaIconName.Snapshots} />,
-    type: 'small',
+  };
+
+  app.registerTile(
+    {
+      ...snapshotsNav,
+      kind: 'home',
+      type: 'small',
+    },
+    false,
+  );
+
+  app.registerNavigationItem({
+    ...snapshotsNav,
+    categoryName: 'Processing',
   });
 
   app.registerPage('/snapshots', SnapshotRegistry, {

--- a/services/media/workflows/src/Stations/Seasons/registrations.tsx
+++ b/services/media/workflows/src/Stations/Seasons/registrations.tsx
@@ -17,12 +17,24 @@ import { SeasonSnapshots } from './SeasonSnapshots/SeasonSnapshots';
 import { SeasonVideoManagement } from './SeasonVideoManagement/SeasonVideoManagement';
 
 export function register(app: PiletApi, extensions: Extensions): void {
-  app.registerTile({
-    kind: 'home',
+  const seasonsNav = {
     path: '/seasons',
     label: 'Seasons',
     icon: <MediaIcons icon={MediaIconName.Seasons} />,
-    type: 'large',
+  };
+
+  app.registerTile(
+    {
+      ...seasonsNav,
+      kind: 'home',
+      type: 'large',
+    },
+    false,
+  );
+
+  app.registerNavigationItem({
+    ...seasonsNav,
+    categoryName: 'Content',
   });
 
   app.registerPage('/seasons', Seasons, {

--- a/services/media/workflows/src/Stations/TvShows/registrations.tsx
+++ b/services/media/workflows/src/Stations/TvShows/registrations.tsx
@@ -1,7 +1,10 @@
 import { PiletApi } from '@axinom/mosaic-portal';
 import React from 'react';
 import { Extensions, ExtensionsContext } from '../../externals';
-import { settingsGroupName } from '../../index';
+import {
+  mediaManagementParentName as parentName,
+  settingsGroupName,
+} from '../../index';
 import { MediaIconName, MediaIcons } from '../../MediaIcons';
 import { TvShowCreate } from './TvShowCreate/TvShowCreate';
 import { TvShowDetails } from './TvShowDetails/TvShowDetails';
@@ -129,12 +132,25 @@ export function register(app: PiletApi, extensions: Extensions): void {
     permissions: { 'media-service': ['ADMIN', 'TVSHOWS_EDIT', 'TVSHOWS_VIEW'] },
   });
 
-  app.registerTile({
-    kind: 'settings',
-    groupName: settingsGroupName,
+  const tvshowSettingsNav = {
     path: '/settings/media/tvshowgenres',
     label: 'TV Show Genres',
     icon: <MediaIcons icon={MediaIconName.TvShowGenres} />,
+  };
+
+  app.registerTile(
+    {
+      ...tvshowSettingsNav,
+      kind: 'settings',
+      groupName: settingsGroupName,
+    },
+    false,
+  );
+
+  app.registerNavigationItem({
+    ...tvshowSettingsNav,
+    parentName: parentName,
+    categoryName: 'Settings',
   });
 
   app.registerPage('/settings/media/tvshowgenres', TvShowGenres, {

--- a/services/media/workflows/src/Stations/TvShows/registrations.tsx
+++ b/services/media/workflows/src/Stations/TvShows/registrations.tsx
@@ -22,12 +22,24 @@ import { TvShowSnapshots } from './TvShowSnapshots/TvShowSnapshots';
 import { TvShowVideoManagement } from './TvShowVideoManagement/TvShowVideoManagement';
 
 export function register(app: PiletApi, extensions: Extensions): void {
-  app.registerTile({
-    kind: 'home',
+  const tvshowNav = {
     path: '/tvshows',
     label: 'TV Shows',
     icon: <MediaIcons icon={MediaIconName.TV} />,
-    type: 'large',
+  };
+
+  app.registerTile(
+    {
+      ...tvshowNav,
+      kind: 'home',
+      type: 'large',
+    },
+    false,
+  );
+
+  app.registerNavigationItem({
+    ...tvshowNav,
+    categoryName: 'Content',
   });
 
   app.registerPage('/tvshows', TvShows, {

--- a/services/media/workflows/src/index.tsx
+++ b/services/media/workflows/src/index.tsx
@@ -1,7 +1,9 @@
 import { PiletApi } from '@axinom/mosaic-portal';
+import React from 'react';
 import { initializeApolloClient } from './apolloClient/apolloClient';
 import { bindExtensions } from './externals/piralExtensions';
 import './global.scss';
+import { MediaIconName, MediaIcons } from './MediaIcons';
 import { initializeConfig, piletConfig } from './piletConfig';
 import { sortTiles } from './sortTiles/sortTiles';
 import { register as registerCollections } from './Stations/Collections/registrations';
@@ -14,6 +16,7 @@ import { register as registerTvShows } from './Stations/TvShows/registrations';
 import { transformNavigationItems } from './transformNavigation/transformNavigation';
 
 export const settingsGroupName = 'Media Management';
+export const mediaManagementParentName = 'media-management';
 
 export function setup(app: PiletApi): void {
   initializeConfig(app.meta.custom);
@@ -31,6 +34,13 @@ export function setup(app: PiletApi): void {
   app.setHomeTileSorter(sortTiles);
 
   app.setNavigationItemsTransformer(transformNavigationItems);
+
+  app.registerNavigationItem({
+    icon: <MediaIcons icon={MediaIconName.Movie} />,
+    label: settingsGroupName,
+    name: mediaManagementParentName,
+    categoryName: 'Settings',
+  });
 
   // Registering all items (Pages, Tiles, Extensions,...) this pilet provides
   registerMovies(app, extensions);

--- a/services/media/workflows/src/index.tsx
+++ b/services/media/workflows/src/index.tsx
@@ -11,6 +11,7 @@ import { register as registerMovies } from './Stations/Movies/registrations';
 import { register as registerSnapshotRegistry } from './Stations/Publishing/registrations';
 import { register as registerSeasons } from './Stations/Seasons/registrations';
 import { register as registerTvShows } from './Stations/TvShows/registrations';
+import { transformNavigationItems } from './transformNavigation/transformNavigation';
 
 export const settingsGroupName = 'Media Management';
 
@@ -28,6 +29,8 @@ export function setup(app: PiletApi): void {
   const extensions = bindExtensions(app);
 
   app.setHomeTileSorter(sortTiles);
+
+  app.setNavigationItemsTransformer(transformNavigationItems);
 
   // Registering all items (Pages, Tiles, Extensions,...) this pilet provides
   registerMovies(app, extensions);

--- a/services/media/workflows/src/transformNavigation/transformNavigation.ts
+++ b/services/media/workflows/src/transformNavigation/transformNavigation.ts
@@ -1,0 +1,25 @@
+import { NavigationItem } from '@axinom/mosaic-portal';
+
+const processingCategoryItemName = 'videos';
+const contentCategoryItemName = 'images';
+const curationCategoryItemNames = [
+  'monetization',
+  'monetization-subscriptionplans',
+  'monetization-claimsets',
+  'channels',
+];
+
+export const transformNavigationItems = (
+  items: NavigationItem[],
+): NavigationItem[] => {
+  items.forEach((item) => {
+    if (item.name === contentCategoryItemName) {
+      item.categoryName = 'Content';
+    } else if (item.name === processingCategoryItemName) {
+      item.categoryName = 'Processing';
+    } else if (curationCategoryItemNames.includes(item.name)) {
+      item.categoryName = 'Curation';
+    }
+  });
+  return items;
+};


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Description

- added navigation panel item registration for stations that have tile registered on home view (collections, episodes, ingest, etc.)
- added custom transformer to customize navigation panel categories
