### PR TITLE
[AB#38605] Empty key ids are now excluded from entitlement message

### DIFF
--- a/services/entitlement/service/src/domains/encoding/video-playback-middlewares.ts
+++ b/services/entitlement/service/src/domains/encoding/video-playback-middlewares.ts
@@ -66,7 +66,7 @@ export const setupEntitlementWebhookEndpoint = (
         const keyIds =
           req.body?.payload?.video?.video_encoding?.video_streams?.map(
             (s) => s.key_id,
-          ) ?? [];
+          );
         const jwt = generateEntitlementMessageJwt(keyIds, [], config, 'STRICT');
         const response =
           generateWebhookResponse<EntitlementWebhookResponsePayload>({

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.db.spec.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.db.spec.ts
@@ -97,6 +97,33 @@ describe('EntitlementEndpointPlugin', () => {
         iv: 'E32805950106648E',
         languageCode: null,
       },
+      {
+        keyId: null,
+        file: 'dash/subtitle-de_init.mp4',
+        format: 'DASH',
+        label: 'subtitle',
+        bitrateInKbps: 0,
+        iv: null,
+        languageCode: 'de',
+      },
+      {
+        keyId: undefined,
+        file: 'dash/caption-en_init.mp4',
+        format: 'DASH',
+        label: 'closed-caption',
+        bitrateInKbps: 0,
+        iv: null,
+        languageCode: 'en',
+      },
+      {
+        keyId: '',
+        file: 'dash/caption-de_init.mp4',
+        format: 'DASH',
+        label: 'closed-caption',
+        bitrateInKbps: 0,
+        iv: null,
+        languageCode: 'de',
+      },
     ],
   };
 
@@ -501,6 +528,7 @@ describe('EntitlementEndpointPlugin', () => {
     it.each([
       { isProtected: false },
       { isProtected: true },
+      { isProtected: true, videoStreams: { nodes: null } },
       { isProtected: true, videoStreams: { nodes: [] } },
       {
         isProtected: true,

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.ts
@@ -83,7 +83,7 @@ export const EntitlementEndpointPlugin = makeExtendSchemaPlugin(() => {
               ownerPool,
             );
             const entitlementMessageJwt = generateEntitlementMessageJwt(
-              video.videoStreams.nodes?.map((videoStream) => videoStream.keyId),
+              video.videoStreams?.nodes?.map((stream) => stream.keyId),
               claims,
               config,
               config.isDev ? 'DEV' : 'DEFAULT',

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/catalog-service-communication.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/catalog-service-communication.ts
@@ -86,10 +86,11 @@ const getCatalogResponseVideo = (
     });
   }
 
+  const [video] = videos;
   if (
-    !videos[0].isProtected ||
-    !videos[0].videoStreams ||
-    (videos[0].videoStreams?.nodes ?? []) // A protected video will always have at least one stream with non-empty Key ID
+    !video.isProtected ||
+    !video.videoStreams?.nodes?.length ||
+    video.videoStreams.nodes // A protected video will always have at least one stream with non-empty Key ID
       .map((videoStream) => videoStream.keyId)
       .filter((keyId) => !isNullOrWhitespace(keyId)).length === 0
   ) {
@@ -99,7 +100,7 @@ const getCatalogResponseVideo = (
     });
   }
 
-  return videos[0];
+  return video;
 };
 
 export const getEntityType = (id: string): EntityWithVideoType => {

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/catalog-service-communication.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/catalog-service-communication.ts
@@ -89,8 +89,7 @@ const getCatalogResponseVideo = (
   if (
     !videos[0].isProtected ||
     !videos[0].videoStreams ||
-    videos[0].videoStreams.nodes.length === 0 || // A protected video will always have a video_streams record
-    videos[0].videoStreams.nodes
+    (videos[0].videoStreams?.nodes ?? []) // A protected video will always have at least one stream with non-empty Key ID
       .map((videoStream) => videoStream.keyId)
       .filter((keyId) => !isNullOrWhitespace(keyId)).length === 0
   ) {

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/entitlement-message-generation.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/entitlement-message-generation.ts
@@ -68,7 +68,7 @@ export const getPolicy = (mode: PolicyMode): Dict<unknown> => {
 };
 
 export const generateEntitlementMessageJwt = (
-  keyIds: (MovieVideoStream | EpisodeVideoStream)['keyId'][],
+  keyIds: (MovieVideoStream | EpisodeVideoStream)['keyId'][] | undefined,
   claims: string[],
   config: Config,
   policyMode: PolicyMode,
@@ -84,7 +84,7 @@ export const generateEntitlementMessageJwt = (
         allow_persistence: claims.includes(ENABLE_VIDEOS_DOWNLOAD), // Allows to specify whether the license can be persisted on the playback device.
       },
       content_keys_source: {
-        inline: [...new Set(keyIds ?? [])].map((id) => ({
+        inline: [...new Set(keyIds?.filter(Boolean) ?? [])].map((id) => ({
           id,
           usage_policy: 'Policy A',
         })),


### PR DESCRIPTION
[[AB#38605](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/38605)]

<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

Subtitle and Closed Caption streams do not have a keyId values, but were previously included during the generation of the entitlement message. Empty keyId values are now excluded.
