### PR TITLE
[AB#39854] Removed References to `ajv-v6` in Media Service

### DIFF
--- a/libs/media-messages/schemas/payloads/common.json
+++ b/libs/media-messages/schemas/payloads/common.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "common",
   "description": "Common definitions.",
   "definitions": {

--- a/libs/media-messages/schemas/payloads/common/commands/bulk-entity-command.json
+++ b/libs/media-messages/schemas/payloads/common/commands/bulk-entity-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bulk_entity_command",
   "description": "Service state change command schema.",
   "additionalProperties": false,

--- a/libs/media-messages/schemas/payloads/media/commands/check-finish-ingest-document-command.json
+++ b/libs/media-messages/schemas/payloads/media/commands/check-finish-ingest-document-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "check_finish_ingest_document_command",
   "description": "Check finish ingest document command schema.",

--- a/libs/media-messages/schemas/payloads/media/commands/check-finish-ingest-item-command.json
+++ b/libs/media-messages/schemas/payloads/media/commands/check-finish-ingest-item-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type":"object",
   "title": "check_finish_ingest_item_command",
   "description": "Check finish ingest item command schema.",

--- a/libs/media-messages/schemas/payloads/media/commands/commands-common.json
+++ b/libs/media-messages/schemas/payloads/media/commands/commands-common.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Common definitions for media service related messages.",
   "title": "media_commands_common",
 

--- a/libs/media-messages/schemas/payloads/media/commands/delete-entity-command.json
+++ b/libs/media-messages/schemas/payloads/media/commands/delete-entity-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type":"object",
   "title": "delete_entity_command",
   "description": "Delete a single entity command schema.",

--- a/libs/media-messages/schemas/payloads/media/commands/publish-entity-command.json
+++ b/libs/media-messages/schemas/payloads/media/commands/publish-entity-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type":"object",
   "title": "publish_entity_command",
   "description": "Command to publish an entity.",

--- a/libs/media-messages/schemas/payloads/media/commands/start-ingest-command.json
+++ b/libs/media-messages/schemas/payloads/media/commands/start-ingest-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type":"object",
   "title": "start_ingest_command",
   "description": "Start ingest command schema.",

--- a/libs/media-messages/schemas/payloads/media/commands/start-ingest-item-command.json
+++ b/libs/media-messages/schemas/payloads/media/commands/start-ingest-item-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type":"object",
   "title": "start_ingest_item_command",
   "description": "Start ingest item command schema.",

--- a/libs/media-messages/schemas/payloads/media/commands/unpublish-entity-command.json
+++ b/libs/media-messages/schemas/payloads/media/commands/unpublish-entity-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type":"object",
   "title": "unpublish_entity_command",
   "description": "Unpublish a single entity command schema.",

--- a/libs/media-messages/schemas/payloads/media/commands/update-metadata-command.json
+++ b/libs/media-messages/schemas/payloads/media/commands/update-metadata-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type":"object",
   "title": "update_metadata_command",
   "description": "Update metadata command schema.",

--- a/libs/media-messages/schemas/payloads/media/common.json
+++ b/libs/media-messages/schemas/payloads/media/common.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "common",
   "description": "Common definitions.",
   "definitions": {

--- a/libs/media-messages/schemas/payloads/media/event/entity-deleted-event.json
+++ b/libs/media-messages/schemas/payloads/media/event/entity-deleted-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type":"object",
   "title": "entity_deleted_event",
   "description": "An entity was deleted as part of a background job schema.",

--- a/libs/media-messages/schemas/payloads/publish/collection-published-event.json
+++ b/libs/media-messages/schemas/payloads/publish/collection-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "collection_published_event",
   "description": "Definition of the collection publish format.",

--- a/libs/media-messages/schemas/payloads/publish/collection-unpublished-event.json
+++ b/libs/media-messages/schemas/payloads/publish/collection-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "collection_unpublished_event",
   "description": "Collection unpublished event.",

--- a/libs/media-messages/schemas/payloads/publish/common.json
+++ b/libs/media-messages/schemas/payloads/publish/common.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "common",
   "description": "Common definitions in published feed metadata.",
   "definitions": {

--- a/libs/media-messages/schemas/payloads/publish/episode-published-event.json
+++ b/libs/media-messages/schemas/payloads/publish/episode-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "episode_published_event",
   "description": "Definition of the TV show episode publish format.",

--- a/libs/media-messages/schemas/payloads/publish/episode-unpublished-event.json
+++ b/libs/media-messages/schemas/payloads/publish/episode-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "episode_unpublished_event",
   "description": "Episode unpublished event.",

--- a/libs/media-messages/schemas/payloads/publish/movie-genres-published-event.json
+++ b/libs/media-messages/schemas/payloads/publish/movie-genres-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "movie_genres_published_event",
   "description": "Definition of the movie genre publish format.",

--- a/libs/media-messages/schemas/payloads/publish/movie-genres-unpublished-event.json
+++ b/libs/media-messages/schemas/payloads/publish/movie-genres-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "movie_genres_unpublished_event",
   "description": "Movie genres unpublished event.",

--- a/libs/media-messages/schemas/payloads/publish/movie-published-event.json
+++ b/libs/media-messages/schemas/payloads/publish/movie-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "description": "Definition of the movie publish format.",
   "title": "movie_published_event",

--- a/libs/media-messages/schemas/payloads/publish/movie-unpublished-event.json
+++ b/libs/media-messages/schemas/payloads/publish/movie-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "movie_unpublished_event",
   "description": "Movie unpublished event.",

--- a/libs/media-messages/schemas/payloads/publish/season-published-event.json
+++ b/libs/media-messages/schemas/payloads/publish/season-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "season_published_event",
   "description": "Definition of the TV show season publish format.",

--- a/libs/media-messages/schemas/payloads/publish/season-unpublished-event.json
+++ b/libs/media-messages/schemas/payloads/publish/season-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "season_unpublished_event",
   "description": "Season unpublished event.",

--- a/libs/media-messages/schemas/payloads/publish/tvshow-genres-published-event.json
+++ b/libs/media-messages/schemas/payloads/publish/tvshow-genres-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "tvshow_genres_published_event",
   "description": "Definition of the TV show genre publish format.",

--- a/libs/media-messages/schemas/payloads/publish/tvshow-genres-unpublished-event.json
+++ b/libs/media-messages/schemas/payloads/publish/tvshow-genres-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "tvshow_genres_unpublished_event",
   "description": "TV show genre unpublished event.",

--- a/libs/media-messages/schemas/payloads/publish/tvshow-published-event.json
+++ b/libs/media-messages/schemas/payloads/publish/tvshow-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "tvshow_published_event",
   "description": "Definition of the TV show publish format.",

--- a/libs/media-messages/schemas/payloads/publish/tvshow-unpublished-event.json
+++ b/libs/media-messages/schemas/payloads/publish/tvshow-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "tvshow_unpublished_event",
   "description": "TV show unpublished event.",

--- a/libs/media-messages/src/generated/schemas/payloads/media/commands/check-finish-ingest-document-command.json
+++ b/libs/media-messages/src/generated/schemas/payloads/media/commands/check-finish-ingest-document-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "check_finish_ingest_document_command",
   "description": "Check finish ingest document command schema.",

--- a/libs/media-messages/src/generated/schemas/payloads/media/commands/check-finish-ingest-item-command.json
+++ b/libs/media-messages/src/generated/schemas/payloads/media/commands/check-finish-ingest-item-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "check_finish_ingest_item_command",
   "description": "Check finish ingest item command schema.",

--- a/libs/media-messages/src/generated/schemas/payloads/media/commands/delete-entity-command.json
+++ b/libs/media-messages/src/generated/schemas/payloads/media/commands/delete-entity-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "delete_entity_command",
   "description": "Delete a single entity command schema.",

--- a/libs/media-messages/src/generated/schemas/payloads/media/commands/publish-entity-command.json
+++ b/libs/media-messages/src/generated/schemas/payloads/media/commands/publish-entity-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "publish_entity_command",
   "description": "Command to publish an entity.",

--- a/libs/media-messages/src/generated/schemas/payloads/media/commands/start-ingest-command.json
+++ b/libs/media-messages/src/generated/schemas/payloads/media/commands/start-ingest-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "start_ingest_command",
   "description": "Start ingest command schema.",

--- a/libs/media-messages/src/generated/schemas/payloads/media/commands/start-ingest-item-command.json
+++ b/libs/media-messages/src/generated/schemas/payloads/media/commands/start-ingest-item-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "start_ingest_item_command",
   "description": "Start ingest item command schema.",

--- a/libs/media-messages/src/generated/schemas/payloads/media/commands/unpublish-entity-command.json
+++ b/libs/media-messages/src/generated/schemas/payloads/media/commands/unpublish-entity-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "unpublish_entity_command",
   "description": "Unpublish a single entity command schema.",

--- a/libs/media-messages/src/generated/schemas/payloads/media/commands/update-metadata-command.json
+++ b/libs/media-messages/src/generated/schemas/payloads/media/commands/update-metadata-command.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "update_metadata_command",
   "description": "Update metadata command schema.",

--- a/libs/media-messages/src/generated/schemas/payloads/media/events/entity-deleted-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/media/events/entity-deleted-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "entity_deleted_event",
   "description": "An entity was deleted as part of a background job schema.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/collection-published-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/collection-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "collection_published_event",
   "description": "Definition of the collection publish format.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/collection-unpublished-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/collection-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "collection_unpublished_event",
   "description": "Collection unpublished event.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/episode-published-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/episode-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "episode_published_event",
   "description": "Definition of the TV show episode publish format.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/episode-unpublished-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/episode-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "episode_unpublished_event",
   "description": "Episode unpublished event.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/movie-genres-published-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/movie-genres-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "movie_genres_published_event",
   "description": "Definition of the movie genre publish format.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/movie-genres-unpublished-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/movie-genres-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "movie_genres_unpublished_event",
   "description": "Movie genres unpublished event.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/movie-published-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/movie-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "description": "Definition of the movie publish format.",
   "title": "movie_published_event",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/movie-unpublished-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/movie-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "movie_unpublished_event",
   "description": "Movie unpublished event.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/season-published-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/season-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "season_published_event",
   "description": "Definition of the TV show season publish format.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/season-unpublished-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/season-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "season_unpublished_event",
   "description": "Season unpublished event.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/tvshow-genres-published-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/tvshow-genres-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "tvshow_genres_published_event",
   "description": "Definition of the TV show genre publish format.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/tvshow-genres-unpublished-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/tvshow-genres-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "tvshow_genres_unpublished_event",
   "description": "TV show genre unpublished event.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/tvshow-published-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/tvshow-published-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "tvshow_published_event",
   "description": "Definition of the TV show publish format.",

--- a/libs/media-messages/src/generated/schemas/payloads/publish/events/tvshow-unpublished-event.json
+++ b/libs/media-messages/src/generated/schemas/payloads/publish/events/tvshow-unpublished-event.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "tvshow_unpublished_event",
   "description": "TV show unpublished event.",

--- a/services/media/service/package.json
+++ b/services/media/service/package.json
@@ -56,7 +56,6 @@
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "ajv": "^7.2.4",
     "ajv-formats": "^1.6.1",
-    "ajv-v6": "npm:ajv@^6.12.6",
     "altair-express-middleware": "^2.5.2",
     "amqplib": "^0.6.0",
     "axios": "^0.24.0",

--- a/services/media/service/src/domains/movies/handlers/publishing-movie-processor.db.spec.ts
+++ b/services/media/service/src/domains/movies/handlers/publishing-movie-processor.db.spec.ts
@@ -297,17 +297,17 @@ describe('publishingMovieProcessor', () => {
         },
         {
           context: 'METADATA',
-          message: `Property 'images' is required.`,
-          severity: 'ERROR',
-        },
-        {
-          context: 'METADATA',
           message: `Property 'licenses' is required.`,
           severity: 'ERROR',
         },
         {
           context: 'METADATA',
           message: `Property 'genre_ids' is required.`,
+          severity: 'ERROR',
+        },
+        {
+          context: 'METADATA',
+          message: `Property 'images' is required.`,
           severity: 'ERROR',
         },
         {
@@ -405,12 +405,12 @@ describe('publishingMovieProcessor', () => {
         },
         {
           context: 'METADATA',
-          message: `Property 'is_protected' of the first video is required.`,
+          message: `Property 'output_format' of the first video is required.`,
           severity: 'ERROR',
         },
         {
           context: 'METADATA',
-          message: `Property 'output_format' of the first video is required.`,
+          message: `Property 'is_protected' of the first video is required.`,
           severity: 'ERROR',
         },
       ]);

--- a/services/media/service/src/domains/tvshows/handlers/publishing-episode-processor.db.spec.ts
+++ b/services/media/service/src/domains/tvshows/handlers/publishing-episode-processor.db.spec.ts
@@ -313,17 +313,17 @@ describe('publishingEpisodeProcessor', () => {
         },
         {
           context: 'METADATA',
-          message: `Property 'images' is required.`,
-          severity: 'ERROR',
-        },
-        {
-          context: 'METADATA',
           message: `Property 'licenses' is required.`,
           severity: 'ERROR',
         },
         {
           context: 'METADATA',
           message: `Property 'genre_ids' is required.`,
+          severity: 'ERROR',
+        },
+        {
+          context: 'METADATA',
+          message: `Property 'images' is required.`,
           severity: 'ERROR',
         },
         {
@@ -413,7 +413,7 @@ describe('publishingEpisodeProcessor', () => {
         },
         {
           context: 'METADATA',
-          message: `Property 'index' should be a positive number.`,
+          message: `Property 'index' should be greater than 1.`,
           severity: 'ERROR',
         },
         {
@@ -433,12 +433,12 @@ describe('publishingEpisodeProcessor', () => {
         },
         {
           context: 'METADATA',
-          message: `Property 'is_protected' of the first video is required.`,
+          message: `Property 'output_format' of the first video is required.`,
           severity: 'ERROR',
         },
         {
           context: 'METADATA',
-          message: `Property 'output_format' of the first video is required.`,
+          message: `Property 'is_protected' of the first video is required.`,
           severity: 'ERROR',
         },
       ]);

--- a/services/media/service/src/domains/tvshows/handlers/publishing-season-processor.db.spec.ts
+++ b/services/media/service/src/domains/tvshows/handlers/publishing-season-processor.db.spec.ts
@@ -297,17 +297,17 @@ describe('publishingSeasonProcessor', () => {
         },
         {
           context: 'METADATA',
-          message: `Property 'images' is required.`,
-          severity: 'ERROR',
-        },
-        {
-          context: 'METADATA',
           message: `Property 'licenses' is required.`,
           severity: 'ERROR',
         },
         {
           context: 'METADATA',
           message: `Property 'genre_ids' is required.`,
+          severity: 'ERROR',
+        },
+        {
+          context: 'METADATA',
+          message: `Property 'images' is required.`,
           severity: 'ERROR',
         },
         {
@@ -396,7 +396,7 @@ describe('publishingSeasonProcessor', () => {
         },
         {
           context: 'METADATA',
-          message: `Property 'index' should be a positive number.`,
+          message: `Property 'index' should be greater than 1.`,
           severity: 'ERROR',
         },
         {
@@ -411,12 +411,12 @@ describe('publishingSeasonProcessor', () => {
         },
         {
           context: 'METADATA',
-          message: `Property 'is_protected' of the first video is required.`,
+          message: `Property 'output_format' of the first video is required.`,
           severity: 'ERROR',
         },
         {
           context: 'METADATA',
-          message: `Property 'output_format' of the first video is required.`,
+          message: `Property 'is_protected' of the first video is required.`,
           severity: 'ERROR',
         },
       ]);

--- a/services/media/service/src/domains/tvshows/handlers/publishing-tvshow-processor.db.spec.ts
+++ b/services/media/service/src/domains/tvshows/handlers/publishing-tvshow-processor.db.spec.ts
@@ -292,17 +292,17 @@ describe('publishingTvshowProcessor', () => {
         },
         {
           context: 'METADATA',
-          message: `Property 'images' is required.`,
-          severity: 'ERROR',
-        },
-        {
-          context: 'METADATA',
           message: `Property 'licenses' is required.`,
           severity: 'ERROR',
         },
         {
           context: 'METADATA',
           message: `Property 'genre_ids' is required.`,
+          severity: 'ERROR',
+        },
+        {
+          context: 'METADATA',
+          message: `Property 'images' is required.`,
           severity: 'ERROR',
         },
         {
@@ -400,12 +400,12 @@ describe('publishingTvshowProcessor', () => {
         },
         {
           context: 'METADATA',
-          message: `Property 'is_protected' of the first video is required.`,
+          message: `Property 'output_format' of the first video is required.`,
           severity: 'ERROR',
         },
         {
           context: 'METADATA',
-          message: `Property 'output_format' of the first video is required.`,
+          message: `Property 'is_protected' of the first video is required.`,
           severity: 'ERROR',
         },
       ]);

--- a/services/media/service/src/publishing/utils/publishing-common.ts
+++ b/services/media/service/src/publishing/utils/publishing-common.ts
@@ -1,5 +1,5 @@
-import Ajv from 'ajv-v6';
-import * as draft04 from 'ajv-v6/lib/refs/json-schema-draft-04.json';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
 import { singularize } from 'graphile-build';
 import { PublishEntityCommand } from 'media-messages';
 import { v4 as uuidv4 } from 'uuid';
@@ -31,22 +31,20 @@ export function buildPublishingId(
   return `${singularize(table)}-${entityId}`;
 }
 
-let ajv: Ajv.Ajv;
+let ajv: Ajv;
 /**
- * Returns an Ajv (v6) instance that's configured to use draft-04 meta schema.
+ * Returns an Ajv instance.
  */
-export function getAjv(): Ajv.Ajv {
+export function getAjv(): Ajv {
   if (ajv) {
     return ajv;
   }
 
   ajv = new Ajv({
-    schemaId: 'id',
     allErrors: true,
-    jsonPointers: true,
+    strict: true,
   });
-  ajv.addMetaSchema(draft04);
-
+  addFormats(ajv);
   return ajv;
 }
 

--- a/services/media/service/src/tests/ingest/mock-publish-processor.ts
+++ b/services/media/service/src/tests/ingest/mock-publish-processor.ts
@@ -3,7 +3,7 @@ import { PublishServiceMessagingSettings } from 'media-messages';
 import { EntityPublishingProcessor } from '../../publishing';
 
 export const testAllowAllSchema = {
-  $schema: 'http://json-schema.org/draft-04/schema#',
+  $schema: 'http://json-schema.org/draft-07/schema#',
   title: 'allow_all_published_event',
   description: 'This is a mock schema that allows any json.',
   properties: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -3841,7 +3841,7 @@ ajv-oai@1.2.0:
   dependencies:
     decimal.js "^10.2.0"
 
-"ajv-v6@npm:ajv@^6.12.6", ajv@6.12.6, ajv@^6.10.0, ajv@^6.10.1, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
+ajv@6.12.6, ajv@^6.10.0, ajv@^6.10.1, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description
- JSON schemas for messaging update to use `draft-07`
- During asset publish validation - errors related to JSON schema validation are now reported in slightly different order
- Some wording of JSON schema validation errors changed. Example: was `Property 'index' should be a positive number.`, became: `Property 'index' should be greater than 1.`
