### PR TITLE
[AB#38773], [AB#38981] Main video filter for Movie/Episode Explorers

### DIFF
--- a/services/media/workflows/src/Stations/Episodes/EpisodeExplorerBase/EpisodeExplorer.filters.ts
+++ b/services/media/workflows/src/Stations/Episodes/EpisodeExplorerBase/EpisodeExplorer.filters.ts
@@ -17,10 +17,8 @@ export function useEpisodesFilters(): {
     excludeItems?: number[],
   ) => EpisodeFilter | undefined;
 } {
-  const [
-    createFromDateFilterValidator,
-    createToDateFilterValidator,
-  ] = createDateRangeFilterValidators<EpisodeData>();
+  const [createFromDateFilterValidator, createToDateFilterValidator] =
+    createDateRangeFilterValidators<EpisodeData>();
 
   const filterOptions: FilterType<EpisodeData>[] = [
     {
@@ -118,6 +116,21 @@ export function useEpisodesFilters(): {
       property: 'id',
       type: FilterTypes.Numeric,
     },
+    {
+      label: 'Main Video',
+      property: 'mainVideoId',
+      type: FilterTypes.Options,
+      options: [
+        {
+          label: 'Assigned',
+          value: true,
+        },
+        {
+          label: 'Not Assigned',
+          value: false,
+        },
+      ],
+    },
   ];
 
   const transformFilters = (
@@ -157,6 +170,9 @@ export function useEpisodesFilters(): {
       released: transformRange,
       createdDate: transformRange,
       publishedDate: transformRange,
+      mainVideoId: (value) => ({
+        isNull: !value,
+      }),
     });
   };
 

--- a/services/media/workflows/src/Stations/Movies/MovieExplorerBase/MovieExplorer.filters.ts
+++ b/services/media/workflows/src/Stations/Movies/MovieExplorerBase/MovieExplorer.filters.ts
@@ -17,10 +17,8 @@ export function useMoviesFilters(): {
     excludeItems?: number[],
   ) => MovieFilter | undefined;
 } {
-  const [
-    createFromDateFilterValidator,
-    createToDateFilterValidator,
-  ] = createDateRangeFilterValidators<MovieData>();
+  const [createFromDateFilterValidator, createToDateFilterValidator] =
+    createDateRangeFilterValidators<MovieData>();
 
   const filterOptions: FilterType<MovieData>[] = [
     {
@@ -113,6 +111,21 @@ export function useMoviesFilters(): {
       property: 'id',
       type: FilterTypes.Numeric,
     },
+    {
+      label: 'Main Video',
+      property: 'mainVideoId',
+      type: FilterTypes.Options,
+      options: [
+        {
+          label: 'Assigned',
+          value: true,
+        },
+        {
+          label: 'Not Assigned',
+          value: false,
+        },
+      ],
+    },
   ];
 
   const transformFilters = (
@@ -151,6 +164,9 @@ export function useMoviesFilters(): {
       released: transformRange,
       createdDate: transformRange,
       publishedDate: transformRange,
+      mainVideoId: (value) => ({
+        isNull: !value,
+      }),
     });
   };
 

--- a/services/media/workflows/src/providers/registrations.tsx
+++ b/services/media/workflows/src/providers/registrations.tsx
@@ -1,4 +1,5 @@
 import { PiletApi } from '@axinom/mosaic-portal';
+import { IconName } from '@axinom/mosaic-ui';
 import React from 'react';
 import { EpisodeExplorer } from '../Stations/Episodes/EpisodeExplorerBase/EpisodeExplorer';
 import { MovieExplorer } from '../Stations/Movies/MovieExplorerBase/MovieExplorer';
@@ -7,7 +8,7 @@ export function register(app: PiletApi): void {
   app.addProvider('fast-provider', {
     type: 'Movie',
     label: 'Movie',
-    selectionComponent: ({ onSelected }) => (
+    selectionComponent: ({ onSelected, onClose }) => (
       <MovieExplorer
         kind="SelectionExplorer"
         title="Select Movie"
@@ -17,6 +18,13 @@ export function register(app: PiletApi): void {
         defaultFilterValues={{
           mainVideoId: true,
         }}
+        actions={[
+          {
+            label: 'Cancel',
+            icon: IconName.X,
+            onClick: onClose,
+          },
+        ]}
         onSelection={(selection) => {
           const items =
             selection.mode === 'SINGLE_ITEMS' ? selection.items ?? [] : [];
@@ -37,7 +45,7 @@ export function register(app: PiletApi): void {
   app.addProvider('fast-provider', {
     type: 'Episode',
     label: 'Episode',
-    selectionComponent: ({ onSelected }) => (
+    selectionComponent: ({ onSelected, onClose }) => (
       <EpisodeExplorer
         kind="SelectionExplorer"
         title="Select Episode"
@@ -47,6 +55,13 @@ export function register(app: PiletApi): void {
         defaultFilterValues={{
           mainVideoId: true,
         }}
+        actions={[
+          {
+            label: 'Cancel',
+            icon: IconName.X,
+            onClick: onClose,
+          },
+        ]}
         onSelection={(selection) => {
           const items =
             selection.mode === 'SINGLE_ITEMS' ? selection.items ?? [] : [];

--- a/services/media/workflows/src/providers/registrations.tsx
+++ b/services/media/workflows/src/providers/registrations.tsx
@@ -14,6 +14,9 @@ export function register(app: PiletApi): void {
         stationKey="FASTMovieSelection"
         allowBulkSelect={false}
         enableSelectAll={false}
+        defaultFilterValues={{
+          mainVideoId: true,
+        }}
         onSelection={(selection) => {
           const items =
             selection.mode === 'SINGLE_ITEMS' ? selection.items ?? [] : [];
@@ -41,6 +44,9 @@ export function register(app: PiletApi): void {
         stationKey="FASTEpisodeSelection"
         allowBulkSelect={false}
         enableSelectAll={false}
+        defaultFilterValues={{
+          mainVideoId: true,
+        }}
         onSelection={(selection) => {
           const items =
             selection.mode === 'SINGLE_ITEMS' ? selection.items ?? [] : [];


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->
# Pull Request

[[AB#38773](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/38773)], [[AB#38981](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/38981)]

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

A new filter will be added for both `MovieExplorer` and `EpisodeExplorer`. The filter will allow entities that have videos assigned or not assigned to be filtered out.

This new filter is set by default for certain selection explorers.

Added missing 'Cancel' action for certain selection explorers.
<!-- describe your changes here -->
