### PR TITLE
[AB#39028] fix: exclude jest config from build output

### DIFF
--- a/services/media/service/tsconfig.build.json
+++ b/services/media/service/tsconfig.build.json
@@ -4,5 +4,12 @@
   "compilerOptions": {
     "noEmit": false
   },
-  "exclude": ["node_modules", "dist", "scripts", "**/tests", "**/*spec.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "scripts",
+    "**/tests",
+    "**/*spec.ts",
+    "jest.*"
+  ]
 }


### PR DESCRIPTION
#39028

<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

During node18 migration, jest.config.js was renamed to jest.config.ts in media service, but not exluded from build output, which changed the build output structure (adding src folder into it). This broke the `yarn dev` script. This PR fixes this.
