### PR TITLE
[AB#39241] render anchor tags for navigation actions in details stations

### DIFF
--- a/services/media/workflows/package.json
+++ b/services/media/workflows/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.9",
-    "@axinom/mosaic-ui": "0.30.0-rc.0",
+    "@axinom/mosaic-ui": "0.31.0-rc.1",
     "apollo-upload-client": "^14.1.3",
     "clsx": "^1.2.1",
     "env-cmd": "^10.1.0",

--- a/services/media/workflows/src/Stations/Collections/CollectionDetails/CollectionDetails.actions.ts
+++ b/services/media/workflows/src/Stations/Collections/CollectionDetails/CollectionDetails.actions.ts
@@ -1,4 +1,4 @@
-import { ActionData, ActionType, IconName } from '@axinom/mosaic-ui';
+import { ActionData, IconName } from '@axinom/mosaic-ui';
 import { useMemo } from 'react';
 import { useHistory } from 'react-router';
 import { client } from '../../../apolloClient';
@@ -8,9 +8,7 @@ import {
   useUnpublishCollectionMutation,
 } from '../../../generated/graphql';
 
-export function useCollectionDetailsActions(
-  id: number,
-): {
+export function useCollectionDetailsActions(id: number): {
   readonly actions: ActionData[];
 } {
   const history = useHistory();
@@ -39,28 +37,26 @@ export function useCollectionDetailsActions(
     const actions: ActionData[] = [
       {
         label: 'Manage Entities',
-        onActionSelected: () => history.push(`/collections/${id}/entities`),
+        path: `/collections/${id}/entities`,
       },
       {
         label: 'Manage Cover Image',
-        onActionSelected: () => history.push(`/collections/${id}/images`),
+        path: `/collections/${id}/images`,
       },
       {
         label: 'Publish Now',
         confirmationMode: 'Simple',
-        actionType: ActionType.Context,
         onActionSelected: async () => {
           await publishCollectionMutation({ variables: { id } });
         },
       },
       {
         label: 'Publishing Snapshots',
-        onActionSelected: () => history.push(`/collections/${id}/snapshots`),
+        path: `/collections/${id}/snapshots`,
       },
       {
         label: 'Unpublish',
         confirmationMode: 'Simple',
-        actionType: ActionType.Context,
         onActionSelected: async () => {
           await unpublishCollectionMutation({ variables: { id } });
         },

--- a/services/media/workflows/src/Stations/Episodes/EpisodeDetails/EpisodeDetails.actions.ts
+++ b/services/media/workflows/src/Stations/Episodes/EpisodeDetails/EpisodeDetails.actions.ts
@@ -1,4 +1,4 @@
-import { ActionType, FormActionData, IconName } from '@axinom/mosaic-ui';
+import { FormActionData, IconName } from '@axinom/mosaic-ui';
 import { useHistory } from 'react-router';
 import { client } from '../../../apolloClient';
 import {
@@ -8,9 +8,7 @@ import {
 } from '../../../generated/graphql';
 import { EpisodeDetailsFormData } from './EpisodeDetails.types';
 
-export function useEpisodeDetailsActions(
-  id: number,
-): {
+export function useEpisodeDetailsActions(id: number): {
   readonly actions: FormActionData<EpisodeDetailsFormData>[];
 } {
   const history = useHistory();
@@ -38,32 +36,30 @@ export function useEpisodeDetailsActions(
   const actions: FormActionData<EpisodeDetailsFormData>[] = [
     {
       label: 'Manage Videos',
-      onActionSelected: () => history.push(`/episodes/${id}/videos`),
+      path: `/episodes/${id}/videos`,
     },
     {
       label: 'Manage Images',
-      onActionSelected: () => history.push(`/episodes/${id}/images`),
+      path: `/episodes/${id}/images`,
     },
     {
       label: 'Licensing',
-      onActionSelected: () => history.push(`/episodes/${id}/licenses`),
+      path: `/episodes/${id}/licenses`,
     },
     {
       label: 'Publish Now',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await publishEpisodeMutation({ variables: { id } });
       },
     },
     {
       label: 'Publishing Snapshots',
-      onActionSelected: () => history.push(`/episodes/${id}/snapshots`),
+      path: `/episodes/${id}/snapshots`,
     },
     {
       label: 'Unpublish',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await unpublishEpisodeMutation({ variables: { id } });
       },

--- a/services/media/workflows/src/Stations/Movies/MovieDetails/MovieDetails.actions.ts
+++ b/services/media/workflows/src/Stations/Movies/MovieDetails/MovieDetails.actions.ts
@@ -1,4 +1,4 @@
-import { ActionType, FormActionData, IconName } from '@axinom/mosaic-ui';
+import { FormActionData, IconName } from '@axinom/mosaic-ui';
 import { useHistory } from 'react-router';
 import { client } from '../../../apolloClient';
 import {
@@ -8,9 +8,7 @@ import {
 } from '../../../generated/graphql';
 import { MovieDetailsFormData } from './MovieDetails.types';
 
-export function useMovieDetailsActions(
-  id: number,
-): {
+export function useMovieDetailsActions(id: number): {
   readonly actions: FormActionData<MovieDetailsFormData>[];
 } {
   const history = useHistory();
@@ -38,32 +36,30 @@ export function useMovieDetailsActions(
   const actions: FormActionData<MovieDetailsFormData>[] = [
     {
       label: 'Manage Videos',
-      onActionSelected: () => history.push(`/movies/${id}/videos`),
+      path: `/movies/${id}/videos`,
     },
     {
       label: 'Manage Images',
-      onActionSelected: () => history.push(`/movies/${id}/images`),
+      path: `/movies/${id}/images`,
     },
     {
       label: 'Licensing',
-      onActionSelected: () => history.push(`/movies/${id}/licenses`),
+      path: `/movies/${id}/licenses`,
     },
     {
       label: 'Publish Now',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await publishMovieMutation({ variables: { id } });
       },
     },
     {
       label: 'Publishing Snapshots',
-      onActionSelected: () => history.push(`/movies/${id}/snapshots`),
+      path: `/movies/${id}/snapshots`,
     },
     {
       label: 'Unpublish',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await unpublishMovieMutation({ variables: { id } });
       },

--- a/services/media/workflows/src/Stations/Movies/MovieGenres/MovieGenres.actions.ts
+++ b/services/media/workflows/src/Stations/Movies/MovieGenres/MovieGenres.actions.ts
@@ -1,5 +1,4 @@
-import { ActionType, FormActionData } from '@axinom/mosaic-ui';
-import { useHistory } from 'react-router';
+import { FormActionData } from '@axinom/mosaic-ui';
 import { client } from '../../../apolloClient';
 import {
   usePublishMovieGenresMutation,
@@ -10,8 +9,6 @@ import { MovieGenresFormData } from './MovieGenres.types';
 export function useMovieGenresActions(): {
   readonly actions: FormActionData<MovieGenresFormData>[];
 } {
-  const history = useHistory();
-
   const [publishMovieGenresMutation] = usePublishMovieGenresMutation({
     client,
     fetchPolicy: 'no-cache',
@@ -26,20 +23,17 @@ export function useMovieGenresActions(): {
     {
       label: 'Publish Now',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await publishMovieGenresMutation();
       },
     },
     {
       label: 'Publishing Snapshots',
-      onActionSelected: () =>
-        history.push(`/settings/media/moviegenres/snapshots`),
+      path: `/settings/media/moviegenres/snapshots`,
     },
     {
       label: 'Unpublish',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await unpublishMovieGenresMutation();
       },

--- a/services/media/workflows/src/Stations/Seasons/SeasonDetails/SeasonDetails.actions.ts
+++ b/services/media/workflows/src/Stations/Seasons/SeasonDetails/SeasonDetails.actions.ts
@@ -1,4 +1,4 @@
-import { ActionType, FormActionData, IconName } from '@axinom/mosaic-ui';
+import { FormActionData, IconName } from '@axinom/mosaic-ui';
 import { useHistory } from 'react-router';
 import { client } from '../../../apolloClient';
 import {
@@ -8,9 +8,7 @@ import {
 } from '../../../generated/graphql';
 import { SeasonDetailsFormData } from './SeasonDetails.types';
 
-export function useSeasonDetailsActions(
-  id: number,
-): {
+export function useSeasonDetailsActions(id: number): {
   readonly actions: FormActionData<SeasonDetailsFormData>[];
 } {
   const history = useHistory();
@@ -38,36 +36,34 @@ export function useSeasonDetailsActions(
   const actions: FormActionData<SeasonDetailsFormData>[] = [
     {
       label: 'Manage Episodes',
-      onActionSelected: () => history.push(`/seasons/${id}/episodes`),
+      path: `/seasons/${id}/episodes`,
     },
     {
       label: 'Manage Trailers',
-      onActionSelected: () => history.push(`/seasons/${id}/videos`),
+      path: `/seasons/${id}/videos`,
     },
     {
       label: 'Manage Images',
-      onActionSelected: () => history.push(`/seasons/${id}/images`),
+      path: `/seasons/${id}/images`,
     },
     {
       label: 'Licensing',
-      onActionSelected: () => history.push(`/seasons/${id}/licenses`),
+      path: `/seasons/${id}/licenses`,
     },
     {
       label: 'Publish Now',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await publishSeasonMutation({ variables: { id } });
       },
     },
     {
       label: 'Publishing Snapshots',
-      onActionSelected: () => history.push(`/seasons/${id}/snapshots`),
+      path: `/seasons/${id}/snapshots`,
     },
     {
       label: 'Unpublish',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await unpublishSeasonMutation({ variables: { id } });
       },

--- a/services/media/workflows/src/Stations/TvShows/TvShowDetails/TvShowDetails.actions.ts
+++ b/services/media/workflows/src/Stations/TvShows/TvShowDetails/TvShowDetails.actions.ts
@@ -1,4 +1,4 @@
-import { ActionType, FormActionData, IconName } from '@axinom/mosaic-ui';
+import { FormActionData, IconName } from '@axinom/mosaic-ui';
 import { useHistory } from 'react-router';
 import { client } from '../../../apolloClient';
 import {
@@ -8,9 +8,7 @@ import {
 } from '../../../generated/graphql';
 import { TvShowDetailsFormData } from './TvShowDetails.types';
 
-export function useTvShowDetailsActions(
-  id: number,
-): {
+export function useTvShowDetailsActions(id: number): {
   readonly actions: FormActionData<TvShowDetailsFormData>[];
 } {
   const history = useHistory();
@@ -38,36 +36,34 @@ export function useTvShowDetailsActions(
   const actions: FormActionData<TvShowDetailsFormData>[] = [
     {
       label: 'Manage Seasons',
-      onActionSelected: () => history.push(`/tvshows/${id}/seasons`),
+      path: `/tvshows/${id}/seasons`,
     },
     {
       label: 'Manage Trailers',
-      onActionSelected: () => history.push(`/tvshows/${id}/videos`),
+      path: `/tvshows/${id}/videos`,
     },
     {
       label: 'Manage Images',
-      onActionSelected: () => history.push(`/tvshows/${id}/images`),
+      path: `/tvshows/${id}/images`,
     },
     {
       label: 'Licensing',
-      onActionSelected: () => history.push(`/tvshows/${id}/licenses`),
+      path: `/tvshows/${id}/licenses`,
     },
     {
       label: 'Publish Now',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await publishTvShowMutation({ variables: { id } });
       },
     },
     {
       label: 'Publishing Snapshots',
-      onActionSelected: () => history.push(`/tvshows/${id}/snapshots`),
+      path: `/tvshows/${id}/snapshots`,
     },
     {
       label: 'Unpublish',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await unpublishTvShowMutation({ variables: { id } });
       },

--- a/services/media/workflows/src/Stations/TvShows/TvShowGenres/TvShowGenres.actions.ts
+++ b/services/media/workflows/src/Stations/TvShows/TvShowGenres/TvShowGenres.actions.ts
@@ -1,5 +1,4 @@
-import { ActionType, FormActionData } from '@axinom/mosaic-ui';
-import { useHistory } from 'react-router';
+import { FormActionData } from '@axinom/mosaic-ui';
 import { client } from '../../../apolloClient';
 import {
   usePublishTvShowGenresMutation,
@@ -10,8 +9,6 @@ import { TvShowGenresFormData } from './TvShowGenres.types';
 export function useTvShowGenresActions(): {
   readonly actions: FormActionData<TvShowGenresFormData>[];
 } {
-  const history = useHistory();
-
   const [publishTvShowGenresMutation] = usePublishTvShowGenresMutation({
     client,
     fetchPolicy: 'no-cache',
@@ -26,20 +23,17 @@ export function useTvShowGenresActions(): {
     {
       label: 'Publish Now',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await publishTvShowGenresMutation();
       },
     },
     {
       label: 'Publishing Snapshots',
-      onActionSelected: () =>
-        history.push(`/settings/media/tvshowgenres/snapshots`),
+      path: `/settings/media/tvshowgenres/snapshots`,
     },
     {
       label: 'Unpublish',
       confirmationMode: 'Simple',
-      actionType: ActionType.Context,
       onActionSelected: async () => {
         await unpublishTvShowGenresMutation();
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,6 +173,11 @@
   resolved "https://registry.yarnpkg.com/@axinom/mosaic-core/-/mosaic-core-0.4.3-rc.0.tgz#af87ca14f90937572eeab02150dc94f21a996611"
   integrity sha512-9DDH8nNDEHC9LG+/LiDhQn79nJYesdTrWNwQFQyRDqZZdTpjjcDGb7hWaoOyMyxlTYXrkQ5IefjtH5lE9QObzQ==
 
+"@axinom/mosaic-core@^0.4.4-rc.1":
+  version "0.4.4-rc.1"
+  resolved "https://registry.yarnpkg.com/@axinom/mosaic-core/-/mosaic-core-0.4.4-rc.1.tgz#2c9d1281a92d3af9b5aa3c157fa92408a37e4dcd"
+  integrity sha512-CaN06agU+QsAs4d+lQUredSlLz0/qdxpItEYV8Q4UR1qTC7M11U832vdW8p5Ay0Egx7uyOLf9orc+eNuRgfWoQ==
+
 "@axinom/mosaic-db-common@0.24.2-rc.0":
   version "0.24.2-rc.0"
   resolved "https://registry.yarnpkg.com/@axinom/mosaic-db-common/-/mosaic-db-common-0.24.2-rc.0.tgz#981f20e4994ed68bd95a420a72afaf5ea8b8964f"
@@ -289,12 +294,12 @@
     uuid-encoder "^1.2.0"
     verror "^1.10.1"
 
-"@axinom/mosaic-ui@0.30.0-rc.0":
-  version "0.30.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@axinom/mosaic-ui/-/mosaic-ui-0.30.0-rc.0.tgz#4093ec2cd794fd4797200cfbf85816de16959dc1"
-  integrity sha512-8PjDORgOa1w4sxcK5yLbdnHkqtfEbZJU3LaPHU8KHxviLtNgGww3lpKBy7ah3u4txuc/HxoRJv6A2s9i445O3A==
+"@axinom/mosaic-ui@0.31.0-rc.1":
+  version "0.31.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@axinom/mosaic-ui/-/mosaic-ui-0.31.0-rc.1.tgz#52c101e30b77af236ec8d2dc75bcb24f2106ac80"
+  integrity sha512-BAy0n2gN1pE3Y9cYrOVTbtjYglpJdJ2036oPmrIkOWHtBY66OsAHZ7xEBZ520PylyfTjVGyucra/84cKHhgUpQ==
   dependencies:
-    "@axinom/mosaic-core" "^0.4.3-rc.0"
+    "@axinom/mosaic-core" "^0.4.4-rc.1"
     "@faker-js/faker" "^7.4.0"
     "@popperjs/core" "^2.9.2"
     clsx "^1.1.0"


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description
Support anchor tag rendering for navigation actions and remove deprecated property from context actions.
Following changes were done:
- remove deprecated  `actionType` from `ActionData` and `FormActionData` objects
- use `path` property instead of `onActionSelected` for navigation actions
