### PR TITLE
[AB#39557] Add 'new'  action to select explorers

### DIFF
--- a/services/media/workflows/src/Stations/Episodes/EpisodeSelectExplorerModal/EpisodeSelectExplorerModal.tsx
+++ b/services/media/workflows/src/Stations/Episodes/EpisodeSelectExplorerModal/EpisodeSelectExplorerModal.tsx
@@ -20,6 +20,13 @@ export const useEpisodeSelectExplorerModal = ({
       excludeItems={excludeItems}
       actions={[
         {
+          label: 'New',
+          icon: IconName.External,
+          onClick: () => {
+            window.open('/episodes/create', '_blank');
+          },
+        },
+        {
           label: 'Cancel',
           icon: IconName.X,
           onClick: closeModal,

--- a/services/media/workflows/src/Stations/Movies/MovieSelectExplorerModal/MovieSelectExplorerModal.tsx
+++ b/services/media/workflows/src/Stations/Movies/MovieSelectExplorerModal/MovieSelectExplorerModal.tsx
@@ -20,6 +20,13 @@ export const useMovieSelectExplorerModal = ({
       excludeItems={excludeItems}
       actions={[
         {
+          label: 'New',
+          icon: IconName.External,
+          onClick: () => {
+            window.open('/movies/create', '_blank');
+          },
+        },
+        {
           label: 'Cancel',
           icon: IconName.X,
           onClick: closeModal,

--- a/services/media/workflows/src/Stations/Seasons/SeasonSelectExplorerModal/SeasonSelectExplorerModal.tsx
+++ b/services/media/workflows/src/Stations/Seasons/SeasonSelectExplorerModal/SeasonSelectExplorerModal.tsx
@@ -20,6 +20,13 @@ export const useSeasonSelectExplorerModal = ({
       excludeItems={excludeItems}
       actions={[
         {
+          label: 'New',
+          icon: IconName.External,
+          onClick: () => {
+            window.open('/seasons/create', '_blank');
+          },
+        },
+        {
           label: 'Cancel',
           icon: IconName.X,
           onClick: closeModal,

--- a/services/media/workflows/src/Stations/TvShows/TvShowSelectExplorerModal/TvShowSelectExplorerModal.tsx
+++ b/services/media/workflows/src/Stations/TvShows/TvShowSelectExplorerModal/TvShowSelectExplorerModal.tsx
@@ -20,6 +20,13 @@ export const useTvShowSelectExplorerModal = ({
       excludeItems={excludeItems}
       actions={[
         {
+          label: 'New',
+          icon: IconName.External,
+          onClick: () => {
+            window.open('/tvshows/create', '_blank');
+          },
+        },
+        {
           label: 'Cancel',
           icon: IconName.X,
           onClick: closeModal,

--- a/services/media/workflows/src/providers/registrations.tsx
+++ b/services/media/workflows/src/providers/registrations.tsx
@@ -20,6 +20,13 @@ export function register(app: PiletApi): void {
         }}
         actions={[
           {
+            label: 'New',
+            icon: IconName.External,
+            onClick: () => {
+              window.open('/movies/create', '_blank');
+            },
+          },
+          {
             label: 'Cancel',
             icon: IconName.X,
             onClick: onClose,
@@ -56,6 +63,13 @@ export function register(app: PiletApi): void {
           mainVideoId: true,
         }}
         actions={[
+          {
+            label: 'New',
+            icon: IconName.External,
+            onClick: () => {
+              window.open('/episodes/create', '_blank');
+            },
+          },
           {
             label: 'Cancel',
             icon: IconName.X,


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

<!-- describe your changes here -->
Adding a 'New' action to the select explorers, giving users the option to navigate to the create station of the entity right from the select explorer