### PR TITLE
[AB#38796] Fix issue in safari where SeverityRenderer icon is huge

### DIFF
--- a/services/media/workflows/src/Stations/Publishing/PublishingSnapshotDetails/SeverityRenderer/SeverityRenderer.tsx
+++ b/services/media/workflows/src/Stations/Publishing/PublishingSnapshotDetails/SeverityRenderer/SeverityRenderer.tsx
@@ -29,7 +29,7 @@ export const SeverityRenderer: ColumnRenderer<Data> = (val): ReactNode => {
 
     return (
       <div className={classes.container}>
-        {image}
+        <div>{image}</div>
         {formatTitleCase(val as string)}
       </div>
     );

--- a/services/media/workflows/src/components/StatusIcons/StatusIcons.tsx
+++ b/services/media/workflows/src/components/StatusIcons/StatusIcons.tsx
@@ -32,7 +32,7 @@ export const StatusIcons: React.FC<StatusIconsProps> = ({
         version="1.1"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 40 40"
-      ></svg>
+      />
     );
 
   return actionIcon;


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

This PR addresses issues with `SeverityRenderer` showing an enlarged icon in Safari browser.
