### PR TITLE
[AB#40182] entitlement service now supports channels

### DIFF
--- a/services/entitlement/service/src/common/errors/common-errors.ts
+++ b/services/entitlement/service/src/common/errors/common-errors.ts
@@ -63,7 +63,7 @@ export const CommonErrors = {
   },
   InvalidEntityId: {
     message:
-      "The provided entity ID '%s' is invalid. It must start with 'movie-' or 'episode-' followed by a number.",
+      "The provided entity ID '%s' is invalid. It must be either a UUID, or start with 'movie-' or 'episode-' followed by a number.",
     code: 'INVALID_ENTITY_ID',
   },
   EntityNotFound: {
@@ -75,6 +75,11 @@ export const CommonErrors = {
     message:
       'The requested video for the %s is not protected. An entitlement message to receive a DRM license is therefore not required.',
     code: 'VIDEO_NOT_PROTECTED',
+  },
+  ChannelStreamUnavailable: {
+    message:
+      'The requested data for the %s does not have the required stream URLs. It is possible that the channel is still being processed.',
+    code: 'CHANNEL_STREAM_UNAVAILABLE',
   },
   SubscriptionValidationError: {
     message:

--- a/services/entitlement/service/src/common/utils/index.ts
+++ b/services/entitlement/service/src/common/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './sanitize-string-array';
 export * from './token-utils';

--- a/services/entitlement/service/src/common/utils/sanitize-string-array.ts
+++ b/services/entitlement/service/src/common/utils/sanitize-string-array.ts
@@ -1,0 +1,19 @@
+import { isNullOrWhitespace } from '@axinom/mosaic-service-common';
+
+/**
+ * Takes an optional array, removes all empty and duplicate values from it and
+ * returns a string array with remaining values
+ */
+export const sanitizeStringArray = (
+  array?: (string | null | undefined)[] | null,
+): string[] => {
+  if (!array) {
+    return [];
+  }
+  return array.reduce<string[]>((array, item) => {
+    if (!isNullOrWhitespace(item) && !array.includes(item)) {
+      array.push(item);
+    }
+    return array;
+  }, []);
+};

--- a/services/entitlement/service/src/domains/encoding/video-playback-middlewares.ts
+++ b/services/entitlement/service/src/domains/encoding/video-playback-middlewares.ts
@@ -18,7 +18,7 @@ import {
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { Express, json, NextFunction, Request, Response } from 'express';
-import { CommonErrors, Config } from '../../common';
+import { CommonErrors, Config, sanitizeStringArray } from '../../common';
 import { generateEntitlementMessageJwt } from '../../graphql/plugins/entitlement-endpoint/entitlement-message-generation';
 
 // Feel free to adjust the implementation of this middleware to something more
@@ -116,10 +116,11 @@ export const setupEntitlementWebhookEndpoint = (
       next: NextFunction,
     ) => {
       try {
-        const keyIds =
+        const keyIds = sanitizeStringArray(
           req.body?.payload?.video?.video_encoding?.video_streams?.map(
             (s) => s.key_id,
-          );
+          ),
+        );
         const jwt = generateEntitlementMessageJwt(keyIds, [], config, 'STRICT');
         const response =
           generateWebhookResponse<EntitlementWebhookResponsePayload>({

--- a/services/entitlement/service/src/domains/monetization/claim-definition-groups.ts
+++ b/services/entitlement/service/src/domains/monetization/claim-definition-groups.ts
@@ -13,6 +13,10 @@ export const ENTITY_TYPE_MOVIES = 'ENTITY_TYPE_MOVIES';
  */
 export const ENTITY_TYPE_EPISODES = 'ENTITY_TYPE_EPISODES';
 /**
+ * A claim that is responsible for allowing playback of all Channel streams.
+ */
+export const ENTITY_TYPE_CHANNELS = 'ENTITY_TYPE_CHANNELS';
+/**
  * A prefix to easily find country-specific claims, after which a 2-letter country code is added.
  */
 export const COUNTRY_CLAIM_PREFIX = 'COUNTRY_';
@@ -58,6 +62,10 @@ export const claimDefinitionGroups: ClaimDefinitionGroup[] = [
       {
         claim: ENTITY_TYPE_EPISODES,
         title: 'All Episodes',
+      },
+      {
+        claim: ENTITY_TYPE_CHANNELS,
+        title: 'All Channels',
       },
     ],
   },

--- a/services/entitlement/service/src/generated/graphql/billing.ts
+++ b/services/entitlement/service/src/generated/graphql/billing.ts
@@ -1026,36 +1026,6 @@ export enum PaymentPlanProviderConfigsOrderBy {
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
 
-/** A filter to be used against many `PaymentPlanPrice` object types. All fields are combined with a logical ‘and.’ */
-export type PaymentPlanToManyPaymentPlanPriceFilter = {
-  /** Every related `PaymentPlanPrice` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  every?: InputMaybe<PaymentPlanPriceFilter>;
-  /** No related `PaymentPlanPrice` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  none?: InputMaybe<PaymentPlanPriceFilter>;
-  /** Some related `PaymentPlanPrice` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  some?: InputMaybe<PaymentPlanPriceFilter>;
-};
-
-/** A filter to be used against many `PaymentPlanProviderConfig` object types. All fields are combined with a logical ‘and.’ */
-export type PaymentPlanToManyPaymentPlanProviderConfigFilter = {
-  /** Every related `PaymentPlanProviderConfig` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  every?: InputMaybe<PaymentPlanProviderConfigFilter>;
-  /** No related `PaymentPlanProviderConfig` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  none?: InputMaybe<PaymentPlanProviderConfigFilter>;
-  /** Some related `PaymentPlanProviderConfig` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  some?: InputMaybe<PaymentPlanProviderConfigFilter>;
-};
-
-/** A filter to be used against many `SubscriptionType` object types. All fields are combined with a logical ‘and.’ */
-export type PaymentPlanToManySubscriptionTypeFilter = {
-  /** Every related `SubscriptionType` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  every?: InputMaybe<SubscriptionTypeFilter>;
-  /** No related `SubscriptionType` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  none?: InputMaybe<SubscriptionTypeFilter>;
-  /** Some related `SubscriptionType` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  some?: InputMaybe<SubscriptionTypeFilter>;
-};
-
 /** A connection to a list of `PaymentPlan` values. */
 export type PaymentPlansConnection = {
   __typename?: 'PaymentPlansConnection';
@@ -1099,17 +1069,49 @@ export enum PaymentPlansOrderBy {
   TitleDesc = 'TITLE_DESC'
 }
 
+/** A filter to be used against many `PaymentPlanPrice` object types. All fields are combined with a logical ‘and.’ */
+export type PaymentPlanToManyPaymentPlanPriceFilter = {
+  /** Every related `PaymentPlanPrice` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: InputMaybe<PaymentPlanPriceFilter>;
+  /** No related `PaymentPlanPrice` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: InputMaybe<PaymentPlanPriceFilter>;
+  /** Some related `PaymentPlanPrice` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: InputMaybe<PaymentPlanPriceFilter>;
+};
+
+/** A filter to be used against many `PaymentPlanProviderConfig` object types. All fields are combined with a logical ‘and.’ */
+export type PaymentPlanToManyPaymentPlanProviderConfigFilter = {
+  /** Every related `PaymentPlanProviderConfig` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: InputMaybe<PaymentPlanProviderConfigFilter>;
+  /** No related `PaymentPlanProviderConfig` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: InputMaybe<PaymentPlanProviderConfigFilter>;
+  /** Some related `PaymentPlanProviderConfig` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: InputMaybe<PaymentPlanProviderConfigFilter>;
+};
+
+/** A filter to be used against many `SubscriptionType` object types. All fields are combined with a logical ‘and.’ */
+export type PaymentPlanToManySubscriptionTypeFilter = {
+  /** Every related `SubscriptionType` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: InputMaybe<SubscriptionTypeFilter>;
+  /** No related `SubscriptionType` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: InputMaybe<SubscriptionTypeFilter>;
+  /** Some related `SubscriptionType` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: InputMaybe<SubscriptionTypeFilter>;
+};
+
 export type PaymentProvider = {
   __typename?: 'PaymentProvider';
   key: Scalars['String'];
   /** Reads and enables pagination through a set of `PaymentPlanProviderConfig`. */
   paymentPlanProviderConfigs: PaymentPlanProviderConfigsConnection;
+  /** Reads a single `PaypalSetting` that is related to this `PaymentProvider`. */
+  paypalSettings?: Maybe<PaypalSetting>;
   /** Reads and enables pagination through a set of `SubscriptionPlanProviderConfig`. */
   subscriptionPlanProviderConfigs: SubscriptionPlanProviderConfigsConnection;
-  /** Reads and enables pagination through a set of `SubscriptionTransaction`. */
-  subscriptionTransactions: SubscriptionTransactionsConnection;
   /** Reads and enables pagination through a set of `SubscriptionType`. */
   subscriptions: SubscriptionTypesConnection;
+  /** Reads and enables pagination through a set of `SubscriptionTransaction`. */
+  subscriptionTransactions: SubscriptionTransactionsConnection;
   title: Scalars['String'];
 };
 
@@ -1138,18 +1140,6 @@ export type PaymentProviderSubscriptionPlanProviderConfigsArgs = {
 };
 
 
-export type PaymentProviderSubscriptionTransactionsArgs = {
-  after?: InputMaybe<Scalars['Cursor']>;
-  before?: InputMaybe<Scalars['Cursor']>;
-  condition?: InputMaybe<SubscriptionTransactionCondition>;
-  filter?: InputMaybe<SubscriptionTransactionFilter>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Array<SubscriptionTransactionsOrderBy>>;
-};
-
-
 export type PaymentProviderSubscriptionsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -1159,6 +1149,18 @@ export type PaymentProviderSubscriptionsArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<SubscriptionTypesOrderBy>>;
+};
+
+
+export type PaymentProviderSubscriptionTransactionsArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<SubscriptionTransactionCondition>;
+  filter?: InputMaybe<SubscriptionTransactionFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<SubscriptionTransactionsOrderBy>>;
 };
 
 /**
@@ -1189,21 +1191,58 @@ export type PaymentProviderFilter = {
   paymentPlanProviderConfigs?: InputMaybe<PaymentProviderToManyPaymentPlanProviderConfigFilter>;
   /** Some related `paymentPlanProviderConfigs` exist. */
   paymentPlanProviderConfigsExist?: InputMaybe<Scalars['Boolean']>;
+  /** Filter by the object’s `paypalSettings` relation. */
+  paypalSettings?: InputMaybe<PaypalSettingFilter>;
+  /** A related `paypalSettings` exists. */
+  paypalSettingsExists?: InputMaybe<Scalars['Boolean']>;
   /** Filter by the object’s `subscriptionPlanProviderConfigs` relation. */
   subscriptionPlanProviderConfigs?: InputMaybe<PaymentProviderToManySubscriptionPlanProviderConfigFilter>;
   /** Some related `subscriptionPlanProviderConfigs` exist. */
   subscriptionPlanProviderConfigsExist?: InputMaybe<Scalars['Boolean']>;
-  /** Filter by the object’s `subscriptionTransactions` relation. */
-  subscriptionTransactions?: InputMaybe<PaymentProviderToManySubscriptionTransactionFilter>;
-  /** Some related `subscriptionTransactions` exist. */
-  subscriptionTransactionsExist?: InputMaybe<Scalars['Boolean']>;
   /** Filter by the object’s `subscriptions` relation. */
   subscriptions?: InputMaybe<PaymentProviderToManySubscriptionTypeFilter>;
   /** Some related `subscriptions` exist. */
   subscriptionsExist?: InputMaybe<Scalars['Boolean']>;
+  /** Filter by the object’s `subscriptionTransactions` relation. */
+  subscriptionTransactions?: InputMaybe<PaymentProviderToManySubscriptionTransactionFilter>;
+  /** Some related `subscriptionTransactions` exist. */
+  subscriptionTransactionsExist?: InputMaybe<Scalars['Boolean']>;
   /** Filter by the object’s `title` field. */
   title?: InputMaybe<StringFilter>;
 };
+
+/** A connection to a list of `PaymentProvider` values. */
+export type PaymentProvidersConnection = {
+  __typename?: 'PaymentProvidersConnection';
+  /** A list of edges which contains the `PaymentProvider` and cursor to aid in pagination. */
+  edges: Array<PaymentProvidersEdge>;
+  /** A list of `PaymentProvider` objects. */
+  nodes: Array<PaymentProvider>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `PaymentProvider` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `PaymentProvider` edge in the connection. */
+export type PaymentProvidersEdge = {
+  __typename?: 'PaymentProvidersEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `PaymentProvider` at the end of the edge. */
+  node: PaymentProvider;
+};
+
+/** Methods to use when ordering `PaymentProvider`. */
+export enum PaymentProvidersOrderBy {
+  KeyAsc = 'KEY_ASC',
+  KeyDesc = 'KEY_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  TitleAsc = 'TITLE_ASC',
+  TitleDesc = 'TITLE_DESC'
+}
 
 /** A filter to be used against many `PaymentPlanProviderConfig` object types. All fields are combined with a logical ‘and.’ */
 export type PaymentProviderToManyPaymentPlanProviderConfigFilter = {
@@ -1245,39 +1284,6 @@ export type PaymentProviderToManySubscriptionTypeFilter = {
   some?: InputMaybe<SubscriptionTypeFilter>;
 };
 
-/** A connection to a list of `PaymentProvider` values. */
-export type PaymentProvidersConnection = {
-  __typename?: 'PaymentProvidersConnection';
-  /** A list of edges which contains the `PaymentProvider` and cursor to aid in pagination. */
-  edges: Array<PaymentProvidersEdge>;
-  /** A list of `PaymentProvider` objects. */
-  nodes: Array<PaymentProvider>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `PaymentProvider` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `PaymentProvider` edge in the connection. */
-export type PaymentProvidersEdge = {
-  __typename?: 'PaymentProvidersEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `PaymentProvider` at the end of the edge. */
-  node: PaymentProvider;
-};
-
-/** Methods to use when ordering `PaymentProvider`. */
-export enum PaymentProvidersOrderBy {
-  KeyAsc = 'KEY_ASC',
-  KeyDesc = 'KEY_DESC',
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
-  TitleAsc = 'TITLE_ASC',
-  TitleDesc = 'TITLE_DESC'
-}
-
 export type PaypalActivateSubscriptionInput = {
   paypalSubscriptionId: Scalars['String'];
 };
@@ -1301,6 +1307,84 @@ export enum PaypalPurchaseFlow {
   Popup = 'POPUP',
   /** Use the redirect based purchase flow */
   Redirect = 'REDIRECT'
+}
+
+export type PaypalSetting = {
+  __typename?: 'PaypalSetting';
+  clientId?: Maybe<Scalars['String']>;
+  isSandbox?: Maybe<Scalars['Boolean']>;
+  /** Reads a single `PaymentProvider` that is related to this `PaypalSetting`. */
+  paymentProvider?: Maybe<PaymentProvider>;
+  paymentProviderKey: Scalars['String'];
+};
+
+/**
+ * A condition to be used against `PaypalSetting` object types. All fields are
+ * tested for equality and combined with a logical ‘and.’
+ */
+export type PaypalSettingCondition = {
+  /** Checks for equality with the object’s `clientId` field. */
+  clientId?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `isSandbox` field. */
+  isSandbox?: InputMaybe<Scalars['Boolean']>;
+  /**
+   * Checks for equality with the object’s `paymentProviderKey` field.
+   * @hasAllowedValue()
+   */
+  paymentProviderKey?: InputMaybe<Scalars['String']>;
+};
+
+/** A filter to be used against `PaypalSetting` object types. All fields are combined with a logical ‘and.’ */
+export type PaypalSettingFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<PaypalSettingFilter>>;
+  /** Filter by the object’s `clientId` field. */
+  clientId?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `isSandbox` field. */
+  isSandbox?: InputMaybe<BooleanFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<PaypalSettingFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<PaypalSettingFilter>>;
+  /** Filter by the object’s `paymentProvider` relation. */
+  paymentProvider?: InputMaybe<PaymentProviderFilter>;
+  /** Filter by the object’s `paymentProviderKey` field. */
+  paymentProviderKey?: InputMaybe<StringFilter>;
+};
+
+/** A connection to a list of `PaypalSetting` values. */
+export type PaypalSettingsConnection = {
+  __typename?: 'PaypalSettingsConnection';
+  /** A list of edges which contains the `PaypalSetting` and cursor to aid in pagination. */
+  edges: Array<PaypalSettingsEdge>;
+  /** A list of `PaypalSetting` objects. */
+  nodes: Array<PaypalSetting>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `PaypalSetting` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `PaypalSetting` edge in the connection. */
+export type PaypalSettingsEdge = {
+  __typename?: 'PaypalSettingsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `PaypalSetting` at the end of the edge. */
+  node: PaypalSetting;
+};
+
+/** Methods to use when ordering `PaypalSetting`. */
+export enum PaypalSettingsOrderBy {
+  ClientIdAsc = 'CLIENT_ID_ASC',
+  ClientIdDesc = 'CLIENT_ID_DESC',
+  IsSandboxAsc = 'IS_SANDBOX_ASC',
+  IsSandboxDesc = 'IS_SANDBOX_DESC',
+  Natural = 'NATURAL',
+  PaymentProviderKeyAsc = 'PAYMENT_PROVIDER_KEY_ASC',
+  PaymentProviderKeyDesc = 'PAYMENT_PROVIDER_KEY_DESC',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
 
 /** The input details for subscribing via PayPal. */
@@ -1384,6 +1468,9 @@ export type Query = {
   paymentProvider?: Maybe<PaymentProvider>;
   /** Reads and enables pagination through a set of `PaymentProvider`. */
   paymentProviders?: Maybe<PaymentProvidersConnection>;
+  paypalSetting?: Maybe<PaypalSetting>;
+  /** Reads and enables pagination through a set of `PaypalSetting`. */
+  paypalSettings?: Maybe<PaypalSettingsConnection>;
   /**
    * Exposes the root query type nested one level down. This is helpful for Relay 1
    * which can only query top level fields if they are in a particular form.
@@ -1393,11 +1480,11 @@ export type Query = {
   subscriptionPlan?: Maybe<SubscriptionPlan>;
   /** Reads and enables pagination through a set of `SubscriptionPlan`. */
   subscriptionPlans?: Maybe<SubscriptionPlansConnection>;
+  /** Reads and enables pagination through a set of `SubscriptionType`. */
+  subscriptions?: Maybe<SubscriptionTypesConnection>;
   subscriptionTransaction?: Maybe<SubscriptionTransaction>;
   /** Reads and enables pagination through a set of `SubscriptionTransaction`. */
   subscriptionTransactions?: Maybe<SubscriptionTransactionsConnection>;
-  /** Reads and enables pagination through a set of `SubscriptionType`. */
-  subscriptions?: Maybe<SubscriptionTypesConnection>;
 };
 
 
@@ -1440,6 +1527,25 @@ export type QueryPaymentProvidersArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
+export type QueryPaypalSettingArgs = {
+  paymentProviderKey: Scalars['String'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryPaypalSettingsArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<PaypalSettingCondition>;
+  filter?: InputMaybe<PaypalSettingFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<PaypalSettingsOrderBy>>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
 export type QuerySubscriptionArgs = {
   id: Scalars['UUID'];
 };
@@ -1465,6 +1571,19 @@ export type QuerySubscriptionPlansArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
+export type QuerySubscriptionsArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<SubscriptionTypeCondition>;
+  filter?: InputMaybe<SubscriptionTypeFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<SubscriptionTypesOrderBy>>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
 export type QuerySubscriptionTransactionArgs = {
   id: Scalars['UUID'];
 };
@@ -1480,19 +1599,6 @@ export type QuerySubscriptionTransactionsArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<SubscriptionTransactionsOrderBy>>;
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QuerySubscriptionsArgs = {
-  after?: InputMaybe<Scalars['Cursor']>;
-  before?: InputMaybe<Scalars['Cursor']>;
-  condition?: InputMaybe<SubscriptionTypeCondition>;
-  filter?: InputMaybe<SubscriptionTypeFilter>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Array<SubscriptionTypesOrderBy>>;
 };
 
 /** A filter to be used against String fields. All fields are combined with a logical ‘and.’ */
@@ -1519,12 +1625,12 @@ export type StringFilter = {
   greaterThanOrEqualToInsensitive?: InputMaybe<Scalars['String']>;
   /** Included in the specified list. */
   in?: InputMaybe<Array<Scalars['String']>>;
-  /** Included in the specified list (case-insensitive). */
-  inInsensitive?: InputMaybe<Array<Scalars['String']>>;
   /** Contains the specified string (case-sensitive). */
   includes?: InputMaybe<Scalars['String']>;
   /** Contains the specified string (case-insensitive). */
   includesInsensitive?: InputMaybe<Scalars['String']>;
+  /** Included in the specified list (case-insensitive). */
+  inInsensitive?: InputMaybe<Array<Scalars['String']>>;
   /** Is null (if `true` is specified) or is not null (if `false` is specified). */
   isNull?: InputMaybe<Scalars['Boolean']>;
   /** Less than the specified value. */
@@ -1553,12 +1659,12 @@ export type StringFilter = {
   notEqualToInsensitive?: InputMaybe<Scalars['String']>;
   /** Not included in the specified list. */
   notIn?: InputMaybe<Array<Scalars['String']>>;
-  /** Not included in the specified list (case-insensitive). */
-  notInInsensitive?: InputMaybe<Array<Scalars['String']>>;
   /** Does not contain the specified string (case-sensitive). */
   notIncludes?: InputMaybe<Scalars['String']>;
   /** Does not contain the specified string (case-insensitive). */
   notIncludesInsensitive?: InputMaybe<Scalars['String']>;
+  /** Not included in the specified list (case-insensitive). */
+  notInInsensitive?: InputMaybe<Array<Scalars['String']>>;
   /** Does not match the specified pattern (case-sensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters. */
   notLike?: InputMaybe<Scalars['String']>;
   /** Does not match the specified pattern (case-insensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters. */
@@ -1938,6 +2044,45 @@ export enum SubscriptionPlanProviderConfigsOrderBy {
   SubscriptionPlanIdDesc = 'SUBSCRIPTION_PLAN_ID_DESC'
 }
 
+/** A connection to a list of `SubscriptionPlan` values. */
+export type SubscriptionPlansConnection = {
+  __typename?: 'SubscriptionPlansConnection';
+  /** A list of edges which contains the `SubscriptionPlan` and cursor to aid in pagination. */
+  edges: Array<SubscriptionPlansEdge>;
+  /** A list of `SubscriptionPlan` objects. */
+  nodes: Array<SubscriptionPlan>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `SubscriptionPlan` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `SubscriptionPlan` edge in the connection. */
+export type SubscriptionPlansEdge = {
+  __typename?: 'SubscriptionPlansEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `SubscriptionPlan` at the end of the edge. */
+  node: SubscriptionPlan;
+};
+
+/** Methods to use when ordering `SubscriptionPlan`. */
+export enum SubscriptionPlansOrderBy {
+  CoverImagePathAsc = 'COVER_IMAGE_PATH_ASC',
+  CoverImagePathDesc = 'COVER_IMAGE_PATH_DESC',
+  DescriptionAsc = 'DESCRIPTION_ASC',
+  DescriptionDesc = 'DESCRIPTION_DESC',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  IsActiveAsc = 'IS_ACTIVE_ASC',
+  IsActiveDesc = 'IS_ACTIVE_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  TitleAsc = 'TITLE_ASC',
+  TitleDesc = 'TITLE_DESC'
+}
+
 /** A filter to be used against many `PaymentPlan` object types. All fields are combined with a logical ‘and.’ */
 export type SubscriptionPlanToManyPaymentPlanFilter = {
   /** Every related `PaymentPlan` matches the filter criteria. All fields are combined with a logical ‘and.’ */
@@ -1977,45 +2122,6 @@ export type SubscriptionPlanToManySubscriptionTypeFilter = {
   /** Some related `SubscriptionType` matches the filter criteria. All fields are combined with a logical ‘and.’ */
   some?: InputMaybe<SubscriptionTypeFilter>;
 };
-
-/** A connection to a list of `SubscriptionPlan` values. */
-export type SubscriptionPlansConnection = {
-  __typename?: 'SubscriptionPlansConnection';
-  /** A list of edges which contains the `SubscriptionPlan` and cursor to aid in pagination. */
-  edges: Array<SubscriptionPlansEdge>;
-  /** A list of `SubscriptionPlan` objects. */
-  nodes: Array<SubscriptionPlan>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `SubscriptionPlan` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `SubscriptionPlan` edge in the connection. */
-export type SubscriptionPlansEdge = {
-  __typename?: 'SubscriptionPlansEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `SubscriptionPlan` at the end of the edge. */
-  node: SubscriptionPlan;
-};
-
-/** Methods to use when ordering `SubscriptionPlan`. */
-export enum SubscriptionPlansOrderBy {
-  CoverImagePathAsc = 'COVER_IMAGE_PATH_ASC',
-  CoverImagePathDesc = 'COVER_IMAGE_PATH_DESC',
-  DescriptionAsc = 'DESCRIPTION_ASC',
-  DescriptionDesc = 'DESCRIPTION_DESC',
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  IsActiveAsc = 'IS_ACTIVE_ASC',
-  IsActiveDesc = 'IS_ACTIVE_DESC',
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
-  TitleAsc = 'TITLE_ASC',
-  TitleDesc = 'TITLE_DESC'
-}
 
 export type SubscriptionStatusChange = {
   __typename?: 'SubscriptionStatusChange';
@@ -2391,26 +2497,6 @@ export type SubscriptionTypeFilter = {
   userId?: InputMaybe<UuidFilter>;
 };
 
-/** A filter to be used against many `SubscriptionStatusChange` object types. All fields are combined with a logical ‘and.’ */
-export type SubscriptionTypeToManySubscriptionStatusChangeFilter = {
-  /** Every related `SubscriptionStatusChange` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  every?: InputMaybe<SubscriptionStatusChangeFilter>;
-  /** No related `SubscriptionStatusChange` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  none?: InputMaybe<SubscriptionStatusChangeFilter>;
-  /** Some related `SubscriptionStatusChange` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  some?: InputMaybe<SubscriptionStatusChangeFilter>;
-};
-
-/** A filter to be used against many `SubscriptionTransaction` object types. All fields are combined with a logical ‘and.’ */
-export type SubscriptionTypeToManySubscriptionTransactionFilter = {
-  /** Every related `SubscriptionTransaction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  every?: InputMaybe<SubscriptionTransactionFilter>;
-  /** No related `SubscriptionTransaction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  none?: InputMaybe<SubscriptionTransactionFilter>;
-  /** Some related `SubscriptionTransaction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
-  some?: InputMaybe<SubscriptionTransactionFilter>;
-};
-
 /** A connection to a list of `SubscriptionType` values. */
 export type SubscriptionTypesConnection = {
   __typename?: 'SubscriptionTypesConnection';
@@ -2463,6 +2549,26 @@ export enum SubscriptionTypesOrderBy {
   UserIdAsc = 'USER_ID_ASC',
   UserIdDesc = 'USER_ID_DESC'
 }
+
+/** A filter to be used against many `SubscriptionStatusChange` object types. All fields are combined with a logical ‘and.’ */
+export type SubscriptionTypeToManySubscriptionStatusChangeFilter = {
+  /** Every related `SubscriptionStatusChange` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: InputMaybe<SubscriptionStatusChangeFilter>;
+  /** No related `SubscriptionStatusChange` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: InputMaybe<SubscriptionStatusChangeFilter>;
+  /** Some related `SubscriptionStatusChange` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: InputMaybe<SubscriptionStatusChangeFilter>;
+};
+
+/** A filter to be used against many `SubscriptionTransaction` object types. All fields are combined with a logical ‘and.’ */
+export type SubscriptionTypeToManySubscriptionTransactionFilter = {
+  /** Every related `SubscriptionTransaction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  every?: InputMaybe<SubscriptionTransactionFilter>;
+  /** No related `SubscriptionTransaction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  none?: InputMaybe<SubscriptionTransactionFilter>;
+  /** Some related `SubscriptionTransaction` matches the filter criteria. All fields are combined with a logical ‘and.’ */
+  some?: InputMaybe<SubscriptionTransactionFilter>;
+};
 
 export enum TransactionType {
   /** Payment */

--- a/services/entitlement/service/src/generated/graphql/catalog.ts
+++ b/services/entitlement/service/src/generated/graphql/catalog.ts
@@ -18,6 +18,161 @@ export type Scalars = {
   Datetime: any;
 };
 
+/** Definition of the channel publish format. */
+export type Channel = {
+  __typename?: 'Channel';
+  /** DASH stream URL of the channel. */
+  dashStreamUrl?: Maybe<Scalars['String']>;
+  /** Description of the channel. */
+  description?: Maybe<Scalars['String']>;
+  /** HLS stream URL of the channel. */
+  hlsStreamUrl?: Maybe<Scalars['String']>;
+  id: Scalars['String'];
+  /** Reads and enables pagination through a set of `ChannelImage`. */
+  images: ChannelImagesConnection;
+  /** Key identifier for DRM protected streams. */
+  keyId?: Maybe<Scalars['String']>;
+  /** Title of the channel. */
+  title: Scalars['String'];
+};
+
+
+/** Definition of the channel publish format. */
+export type ChannelImagesArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<ChannelImageCondition>;
+  filter?: InputMaybe<ChannelImageFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<ChannelImagesOrderBy>>;
+};
+
+/** A condition to be used against `Channel` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type ChannelCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: InputMaybe<Scalars['String']>;
+};
+
+/** A filter to be used against `Channel` object types. All fields are combined with a logical ‘and.’ */
+export type ChannelFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<ChannelFilter>>;
+  /** Filter by the object’s `id` field. */
+  id?: InputMaybe<StringFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<ChannelFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<ChannelFilter>>;
+};
+
+/** Asset image metadata. */
+export type ChannelImage = {
+  __typename?: 'ChannelImage';
+  /** Reads a single `Channel` that is related to this `ChannelImage`. */
+  channel?: Maybe<Channel>;
+  channelId?: Maybe<Scalars['String']>;
+  /** Height of the image in pixels. */
+  height?: Maybe<Scalars['Int']>;
+  id: Scalars['Int'];
+  /** URI to the image file. */
+  path?: Maybe<Scalars['String']>;
+  /** Type of the image. */
+  type?: Maybe<Scalars['String']>;
+  /** Width of the image in pixels. */
+  width?: Maybe<Scalars['Int']>;
+};
+
+/**
+ * A condition to be used against `ChannelImage` object types. All fields are
+ * tested for equality and combined with a logical ‘and.’
+ */
+export type ChannelImageCondition = {
+  /** Checks for equality with the object’s `channelId` field. */
+  channelId?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `id` field. */
+  id?: InputMaybe<Scalars['Int']>;
+};
+
+/** A filter to be used against `ChannelImage` object types. All fields are combined with a logical ‘and.’ */
+export type ChannelImageFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<ChannelImageFilter>>;
+  /** Filter by the object’s `channelId` field. */
+  channelId?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `id` field. */
+  id?: InputMaybe<IntFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<ChannelImageFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<ChannelImageFilter>>;
+};
+
+/** A connection to a list of `ChannelImage` values. */
+export type ChannelImagesConnection = {
+  __typename?: 'ChannelImagesConnection';
+  /** A list of edges which contains the `ChannelImage` and cursor to aid in pagination. */
+  edges: Array<ChannelImagesEdge>;
+  /** A list of `ChannelImage` objects. */
+  nodes: Array<ChannelImage>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `ChannelImage` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `ChannelImage` edge in the connection. */
+export type ChannelImagesEdge = {
+  __typename?: 'ChannelImagesEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `ChannelImage` at the end of the edge. */
+  node: ChannelImage;
+};
+
+/** Methods to use when ordering `ChannelImage`. */
+export enum ChannelImagesOrderBy {
+  ChannelIdAsc = 'CHANNEL_ID_ASC',
+  ChannelIdDesc = 'CHANNEL_ID_DESC',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
+/** A connection to a list of `Channel` values. */
+export type ChannelsConnection = {
+  __typename?: 'ChannelsConnection';
+  /** A list of edges which contains the `Channel` and cursor to aid in pagination. */
+  edges: Array<ChannelsEdge>;
+  /** A list of `Channel` objects. */
+  nodes: Array<Channel>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `Channel` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `Channel` edge in the connection. */
+export type ChannelsEdge = {
+  __typename?: 'ChannelsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `Channel` at the end of the edge. */
+  node: Channel;
+};
+
+/** Methods to use when ordering `Channel`. */
+export enum ChannelsOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
 /** Definition of the collection publish format. */
 export type Collection = {
   __typename?: 'Collection';
@@ -171,6 +326,7 @@ export type CollectionItemsRelation = {
   movie?: Maybe<Movie>;
   movieId?: Maybe<Scalars['String']>;
   orderNo: Scalars['Int'];
+  /** Type of the relation. */
   relationType?: Maybe<Scalars['String']>;
   /** Reads a single `Season` that is related to this `CollectionItemsRelation`. */
   season?: Maybe<Season>;
@@ -317,6 +473,7 @@ export type Episode = {
   licenses: EpisodeLicensesConnection;
   /** Original title of the episode. */
   originalTitle?: Maybe<Scalars['String']>;
+  /** Array of production countries */
   productionCountries?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Date of first release. */
   released?: Maybe<Scalars['Datetime']>;
@@ -639,6 +796,39 @@ export enum EpisodeLicensesOrderBy {
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
 
+/** A connection to a list of `Episode` values. */
+export type EpisodesConnection = {
+  __typename?: 'EpisodesConnection';
+  /** A list of edges which contains the `Episode` and cursor to aid in pagination. */
+  edges: Array<EpisodesEdge>;
+  /** A list of `Episode` objects. */
+  nodes: Array<Episode>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `Episode` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `Episode` edge in the connection. */
+export type EpisodesEdge = {
+  __typename?: 'EpisodesEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `Episode` at the end of the edge. */
+  node: Episode;
+};
+
+/** Methods to use when ordering `Episode`. */
+export enum EpisodesOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  SeasonIdAsc = 'SEASON_ID_ASC',
+  SeasonIdDesc = 'SEASON_ID_DESC'
+}
+
 /** Video stream metadata. */
 export type EpisodeVideo = {
   __typename?: 'EpisodeVideo';
@@ -646,6 +836,8 @@ export type EpisodeVideo = {
   audioLanguages?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Array of caption languages available in the stream. */
   captionLanguages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Reads and enables pagination through a set of `EpisodeVideoCuePoint`. */
+  cuePoints: EpisodeVideoCuePointsConnection;
   /** URI to a DASH manifest. */
   dashManifest?: Maybe<Scalars['String']>;
   /** Reads a single `Episode` that is related to this `EpisodeVideo`. */
@@ -668,6 +860,19 @@ export type EpisodeVideo = {
   type?: Maybe<Scalars['String']>;
   /** Reads and enables pagination through a set of `EpisodeVideoStream`. */
   videoStreams: EpisodeVideoStreamsConnection;
+};
+
+
+/** Video stream metadata. */
+export type EpisodeVideoCuePointsArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<EpisodeVideoCuePointCondition>;
+  filter?: InputMaybe<EpisodeVideoCuePointFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<EpisodeVideoCuePointsOrderBy>>;
 };
 
 
@@ -696,6 +901,79 @@ export type EpisodeVideoCondition = {
   type?: InputMaybe<Scalars['String']>;
 };
 
+/** Video cue point metadata */
+export type EpisodeVideoCuePoint = {
+  __typename?: 'EpisodeVideoCuePoint';
+  /** Type of the cue point */
+  cuePointTypeKey: Scalars['String'];
+  id: Scalars['Int'];
+  /** Time in seconds at which the cue point is set within the video */
+  timeInSeconds: Scalars['Float'];
+  /** Additional information associated with the cue point */
+  value?: Maybe<Scalars['String']>;
+  /** Reads a single `EpisodeVideo` that is related to this `EpisodeVideoCuePoint`. */
+  video?: Maybe<EpisodeVideo>;
+  videoId?: Maybe<Scalars['Int']>;
+};
+
+/**
+ * A condition to be used against `EpisodeVideoCuePoint` object types. All fields
+ * are tested for equality and combined with a logical ‘and.’
+ */
+export type EpisodeVideoCuePointCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: InputMaybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `videoId` field. */
+  videoId?: InputMaybe<Scalars['Int']>;
+};
+
+/** A filter to be used against `EpisodeVideoCuePoint` object types. All fields are combined with a logical ‘and.’ */
+export type EpisodeVideoCuePointFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<EpisodeVideoCuePointFilter>>;
+  /** Filter by the object’s `id` field. */
+  id?: InputMaybe<IntFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<EpisodeVideoCuePointFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<EpisodeVideoCuePointFilter>>;
+  /** Filter by the object’s `videoId` field. */
+  videoId?: InputMaybe<IntFilter>;
+};
+
+/** A connection to a list of `EpisodeVideoCuePoint` values. */
+export type EpisodeVideoCuePointsConnection = {
+  __typename?: 'EpisodeVideoCuePointsConnection';
+  /** A list of edges which contains the `EpisodeVideoCuePoint` and cursor to aid in pagination. */
+  edges: Array<EpisodeVideoCuePointsEdge>;
+  /** A list of `EpisodeVideoCuePoint` objects. */
+  nodes: Array<EpisodeVideoCuePoint>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `EpisodeVideoCuePoint` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `EpisodeVideoCuePoint` edge in the connection. */
+export type EpisodeVideoCuePointsEdge = {
+  __typename?: 'EpisodeVideoCuePointsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `EpisodeVideoCuePoint` at the end of the edge. */
+  node: EpisodeVideoCuePoint;
+};
+
+/** Methods to use when ordering `EpisodeVideoCuePoint`. */
+export enum EpisodeVideoCuePointsOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  VideoIdAsc = 'VIDEO_ID_ASC',
+  VideoIdDesc = 'VIDEO_ID_DESC'
+}
+
 /** A filter to be used against `EpisodeVideo` object types. All fields are combined with a logical ‘and.’ */
 export type EpisodeVideoFilter = {
   /** Checks for all expressions in this list. */
@@ -711,6 +989,41 @@ export type EpisodeVideoFilter = {
   /** Filter by the object’s `type` field. */
   type?: InputMaybe<StringFilter>;
 };
+
+/** A connection to a list of `EpisodeVideo` values. */
+export type EpisodeVideosConnection = {
+  __typename?: 'EpisodeVideosConnection';
+  /** A list of edges which contains the `EpisodeVideo` and cursor to aid in pagination. */
+  edges: Array<EpisodeVideosEdge>;
+  /** A list of `EpisodeVideo` objects. */
+  nodes: Array<EpisodeVideo>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `EpisodeVideo` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `EpisodeVideo` edge in the connection. */
+export type EpisodeVideosEdge = {
+  __typename?: 'EpisodeVideosEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `EpisodeVideo` at the end of the edge. */
+  node: EpisodeVideo;
+};
+
+/** Methods to use when ordering `EpisodeVideo`. */
+export enum EpisodeVideosOrderBy {
+  EpisodeIdAsc = 'EPISODE_ID_ASC',
+  EpisodeIdDesc = 'EPISODE_ID_DESC',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  TypeAsc = 'TYPE_ASC',
+  TypeDesc = 'TYPE_DESC'
+}
 
 /** Video stream DRM metadata */
 export type EpisodeVideoStream = {
@@ -819,74 +1132,6 @@ export enum EpisodeVideoStreamsOrderBy {
   VideoIdDesc = 'VIDEO_ID_DESC'
 }
 
-/** A connection to a list of `EpisodeVideo` values. */
-export type EpisodeVideosConnection = {
-  __typename?: 'EpisodeVideosConnection';
-  /** A list of edges which contains the `EpisodeVideo` and cursor to aid in pagination. */
-  edges: Array<EpisodeVideosEdge>;
-  /** A list of `EpisodeVideo` objects. */
-  nodes: Array<EpisodeVideo>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `EpisodeVideo` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `EpisodeVideo` edge in the connection. */
-export type EpisodeVideosEdge = {
-  __typename?: 'EpisodeVideosEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `EpisodeVideo` at the end of the edge. */
-  node: EpisodeVideo;
-};
-
-/** Methods to use when ordering `EpisodeVideo`. */
-export enum EpisodeVideosOrderBy {
-  EpisodeIdAsc = 'EPISODE_ID_ASC',
-  EpisodeIdDesc = 'EPISODE_ID_DESC',
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
-  TypeAsc = 'TYPE_ASC',
-  TypeDesc = 'TYPE_DESC'
-}
-
-/** A connection to a list of `Episode` values. */
-export type EpisodesConnection = {
-  __typename?: 'EpisodesConnection';
-  /** A list of edges which contains the `Episode` and cursor to aid in pagination. */
-  edges: Array<EpisodesEdge>;
-  /** A list of `Episode` objects. */
-  nodes: Array<Episode>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `Episode` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `Episode` edge in the connection. */
-export type EpisodesEdge = {
-  __typename?: 'EpisodesEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `Episode` at the end of the edge. */
-  node: Episode;
-};
-
-/** Methods to use when ordering `Episode`. */
-export enum EpisodesOrderBy {
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
-  SeasonIdAsc = 'SEASON_ID_ASC',
-  SeasonIdDesc = 'SEASON_ID_DESC'
-}
-
 /** Exposes all error codes and messages for errors that a service requests can throw. In some cases, messages that are actually thrown can be different, since they can include more details or a single code can used for different errors of the same type. */
 export enum ErrorCodesEnum {
   /** The assertion check for the identifier %s failed. */
@@ -907,7 +1152,7 @@ export enum ErrorCodesEnum {
   LicenseNotFound = 'LICENSE_NOT_FOUND',
   /** An application startup error has occurred. The actual message will have more information. */
   StartupError = 'STARTUP_ERROR',
-  /** An unhandled database-related has occurred. Please contact the service support. */
+  /** An unhandled database-related error has occurred. Please contact the service support. */
   UnhandledDatabaseError = 'UNHANDLED_DATABASE_ERROR',
   /** An unhandled error has occurred. Please contact the service support. */
   UnhandledError = 'UNHANDLED_ERROR'
@@ -1339,6 +1584,37 @@ export enum MovieLicensesOrderBy {
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
 
+/** A connection to a list of `Movie` values. */
+export type MoviesConnection = {
+  __typename?: 'MoviesConnection';
+  /** A list of edges which contains the `Movie` and cursor to aid in pagination. */
+  edges: Array<MoviesEdge>;
+  /** A list of `Movie` objects. */
+  nodes: Array<Movie>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `Movie` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `Movie` edge in the connection. */
+export type MoviesEdge = {
+  __typename?: 'MoviesEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `Movie` at the end of the edge. */
+  node: Movie;
+};
+
+/** Methods to use when ordering `Movie`. */
+export enum MoviesOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
 /** Video stream metadata. */
 export type MovieVideo = {
   __typename?: 'MovieVideo';
@@ -1346,6 +1622,8 @@ export type MovieVideo = {
   audioLanguages?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Array of caption languages available in the stream. */
   captionLanguages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Reads and enables pagination through a set of `MovieVideoCuePoint`. */
+  cuePoints: MovieVideoCuePointsConnection;
   /** URI to a DASH manifest. */
   dashManifest?: Maybe<Scalars['String']>;
   /** URI to an HLS manifest. */
@@ -1368,6 +1646,19 @@ export type MovieVideo = {
   type?: Maybe<Scalars['String']>;
   /** Reads and enables pagination through a set of `MovieVideoStream`. */
   videoStreams: MovieVideoStreamsConnection;
+};
+
+
+/** Video stream metadata. */
+export type MovieVideoCuePointsArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<MovieVideoCuePointCondition>;
+  filter?: InputMaybe<MovieVideoCuePointFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<MovieVideoCuePointsOrderBy>>;
 };
 
 
@@ -1396,6 +1687,79 @@ export type MovieVideoCondition = {
   type?: InputMaybe<Scalars['String']>;
 };
 
+/** Video cue point metadata */
+export type MovieVideoCuePoint = {
+  __typename?: 'MovieVideoCuePoint';
+  /** Type of the cue point */
+  cuePointTypeKey: Scalars['String'];
+  id: Scalars['Int'];
+  /** Time in seconds at which the cue point is set within the video */
+  timeInSeconds: Scalars['Float'];
+  /** Additional information associated with the cue point */
+  value?: Maybe<Scalars['String']>;
+  /** Reads a single `MovieVideo` that is related to this `MovieVideoCuePoint`. */
+  video?: Maybe<MovieVideo>;
+  videoId?: Maybe<Scalars['Int']>;
+};
+
+/**
+ * A condition to be used against `MovieVideoCuePoint` object types. All fields are
+ * tested for equality and combined with a logical ‘and.’
+ */
+export type MovieVideoCuePointCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: InputMaybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `videoId` field. */
+  videoId?: InputMaybe<Scalars['Int']>;
+};
+
+/** A filter to be used against `MovieVideoCuePoint` object types. All fields are combined with a logical ‘and.’ */
+export type MovieVideoCuePointFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<MovieVideoCuePointFilter>>;
+  /** Filter by the object’s `id` field. */
+  id?: InputMaybe<IntFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<MovieVideoCuePointFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<MovieVideoCuePointFilter>>;
+  /** Filter by the object’s `videoId` field. */
+  videoId?: InputMaybe<IntFilter>;
+};
+
+/** A connection to a list of `MovieVideoCuePoint` values. */
+export type MovieVideoCuePointsConnection = {
+  __typename?: 'MovieVideoCuePointsConnection';
+  /** A list of edges which contains the `MovieVideoCuePoint` and cursor to aid in pagination. */
+  edges: Array<MovieVideoCuePointsEdge>;
+  /** A list of `MovieVideoCuePoint` objects. */
+  nodes: Array<MovieVideoCuePoint>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `MovieVideoCuePoint` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `MovieVideoCuePoint` edge in the connection. */
+export type MovieVideoCuePointsEdge = {
+  __typename?: 'MovieVideoCuePointsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `MovieVideoCuePoint` at the end of the edge. */
+  node: MovieVideoCuePoint;
+};
+
+/** Methods to use when ordering `MovieVideoCuePoint`. */
+export enum MovieVideoCuePointsOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  VideoIdAsc = 'VIDEO_ID_ASC',
+  VideoIdDesc = 'VIDEO_ID_DESC'
+}
+
 /** A filter to be used against `MovieVideo` object types. All fields are combined with a logical ‘and.’ */
 export type MovieVideoFilter = {
   /** Checks for all expressions in this list. */
@@ -1411,6 +1775,41 @@ export type MovieVideoFilter = {
   /** Filter by the object’s `type` field. */
   type?: InputMaybe<StringFilter>;
 };
+
+/** A connection to a list of `MovieVideo` values. */
+export type MovieVideosConnection = {
+  __typename?: 'MovieVideosConnection';
+  /** A list of edges which contains the `MovieVideo` and cursor to aid in pagination. */
+  edges: Array<MovieVideosEdge>;
+  /** A list of `MovieVideo` objects. */
+  nodes: Array<MovieVideo>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `MovieVideo` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `MovieVideo` edge in the connection. */
+export type MovieVideosEdge = {
+  __typename?: 'MovieVideosEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `MovieVideo` at the end of the edge. */
+  node: MovieVideo;
+};
+
+/** Methods to use when ordering `MovieVideo`. */
+export enum MovieVideosOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  MovieIdAsc = 'MOVIE_ID_ASC',
+  MovieIdDesc = 'MOVIE_ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  TypeAsc = 'TYPE_ASC',
+  TypeDesc = 'TYPE_DESC'
+}
 
 /** Video stream DRM metadata */
 export type MovieVideoStream = {
@@ -1519,72 +1918,6 @@ export enum MovieVideoStreamsOrderBy {
   VideoIdDesc = 'VIDEO_ID_DESC'
 }
 
-/** A connection to a list of `MovieVideo` values. */
-export type MovieVideosConnection = {
-  __typename?: 'MovieVideosConnection';
-  /** A list of edges which contains the `MovieVideo` and cursor to aid in pagination. */
-  edges: Array<MovieVideosEdge>;
-  /** A list of `MovieVideo` objects. */
-  nodes: Array<MovieVideo>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `MovieVideo` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `MovieVideo` edge in the connection. */
-export type MovieVideosEdge = {
-  __typename?: 'MovieVideosEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `MovieVideo` at the end of the edge. */
-  node: MovieVideo;
-};
-
-/** Methods to use when ordering `MovieVideo`. */
-export enum MovieVideosOrderBy {
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  MovieIdAsc = 'MOVIE_ID_ASC',
-  MovieIdDesc = 'MOVIE_ID_DESC',
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
-  TypeAsc = 'TYPE_ASC',
-  TypeDesc = 'TYPE_DESC'
-}
-
-/** A connection to a list of `Movie` values. */
-export type MoviesConnection = {
-  __typename?: 'MoviesConnection';
-  /** A list of edges which contains the `Movie` and cursor to aid in pagination. */
-  edges: Array<MoviesEdge>;
-  /** A list of `Movie` objects. */
-  nodes: Array<Movie>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `Movie` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `Movie` edge in the connection. */
-export type MoviesEdge = {
-  __typename?: 'MoviesEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `Movie` at the end of the edge. */
-  node: Movie;
-};
-
-/** Methods to use when ordering `Movie`. */
-export enum MoviesOrderBy {
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
-}
-
 /** Information about pagination in a connection. */
 export type PageInfo = {
   __typename?: 'PageInfo';
@@ -1601,6 +1934,9 @@ export type PageInfo = {
 /** The root query type which gives access points into the data universe. */
 export type Query = {
   __typename?: 'Query';
+  channel?: Maybe<Channel>;
+  /** Reads and enables pagination through a set of `Channel`. */
+  channels?: Maybe<ChannelsConnection>;
   collection?: Maybe<Collection>;
   /** Reads and enables pagination through a set of `Collection`. */
   collections?: Maybe<CollectionsConnection>;
@@ -1627,6 +1963,25 @@ export type Query = {
   tvshowGenres?: Maybe<TvshowGenresConnection>;
   /** Reads and enables pagination through a set of `Tvshow`. */
   tvshows?: Maybe<TvshowsConnection>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryChannelArgs = {
+  id: Scalars['String'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryChannelsArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<ChannelCondition>;
+  filter?: InputMaybe<ChannelFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<ChannelsOrderBy>>;
 };
 
 
@@ -2116,6 +2471,39 @@ export enum SeasonLicensesOrderBy {
   SeasonIdDesc = 'SEASON_ID_DESC'
 }
 
+/** A connection to a list of `Season` values. */
+export type SeasonsConnection = {
+  __typename?: 'SeasonsConnection';
+  /** A list of edges which contains the `Season` and cursor to aid in pagination. */
+  edges: Array<SeasonsEdge>;
+  /** A list of `Season` objects. */
+  nodes: Array<Season>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `Season` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `Season` edge in the connection. */
+export type SeasonsEdge = {
+  __typename?: 'SeasonsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `Season` at the end of the edge. */
+  node: Season;
+};
+
+/** Methods to use when ordering `Season`. */
+export enum SeasonsOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  TvshowIdAsc = 'TVSHOW_ID_ASC',
+  TvshowIdDesc = 'TVSHOW_ID_DESC'
+}
+
 /** Video stream metadata. */
 export type SeasonVideo = {
   __typename?: 'SeasonVideo';
@@ -2123,6 +2511,8 @@ export type SeasonVideo = {
   audioLanguages?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Array of caption languages available in the stream. */
   captionLanguages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Reads and enables pagination through a set of `SeasonVideoCuePoint`. */
+  cuePoints: SeasonVideoCuePointsConnection;
   /** URI to a DASH manifest. */
   dashManifest?: Maybe<Scalars['String']>;
   /** URI to an HLS manifest. */
@@ -2149,6 +2539,19 @@ export type SeasonVideo = {
 
 
 /** Video stream metadata. */
+export type SeasonVideoCuePointsArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<SeasonVideoCuePointCondition>;
+  filter?: InputMaybe<SeasonVideoCuePointFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<SeasonVideoCuePointsOrderBy>>;
+};
+
+
+/** Video stream metadata. */
 export type SeasonVideoVideoStreamsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -2171,6 +2574,79 @@ export type SeasonVideoCondition = {
   seasonId?: InputMaybe<Scalars['String']>;
 };
 
+/** Video cue point metadata */
+export type SeasonVideoCuePoint = {
+  __typename?: 'SeasonVideoCuePoint';
+  /** Type of the cue point */
+  cuePointTypeKey: Scalars['String'];
+  id: Scalars['Int'];
+  /** Time in seconds at which the cue point is set within the video */
+  timeInSeconds: Scalars['Float'];
+  /** Additional information associated with the cue point */
+  value?: Maybe<Scalars['String']>;
+  /** Reads a single `SeasonVideo` that is related to this `SeasonVideoCuePoint`. */
+  video?: Maybe<SeasonVideo>;
+  videoId?: Maybe<Scalars['Int']>;
+};
+
+/**
+ * A condition to be used against `SeasonVideoCuePoint` object types. All fields
+ * are tested for equality and combined with a logical ‘and.’
+ */
+export type SeasonVideoCuePointCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: InputMaybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `videoId` field. */
+  videoId?: InputMaybe<Scalars['Int']>;
+};
+
+/** A filter to be used against `SeasonVideoCuePoint` object types. All fields are combined with a logical ‘and.’ */
+export type SeasonVideoCuePointFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<SeasonVideoCuePointFilter>>;
+  /** Filter by the object’s `id` field. */
+  id?: InputMaybe<IntFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<SeasonVideoCuePointFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<SeasonVideoCuePointFilter>>;
+  /** Filter by the object’s `videoId` field. */
+  videoId?: InputMaybe<IntFilter>;
+};
+
+/** A connection to a list of `SeasonVideoCuePoint` values. */
+export type SeasonVideoCuePointsConnection = {
+  __typename?: 'SeasonVideoCuePointsConnection';
+  /** A list of edges which contains the `SeasonVideoCuePoint` and cursor to aid in pagination. */
+  edges: Array<SeasonVideoCuePointsEdge>;
+  /** A list of `SeasonVideoCuePoint` objects. */
+  nodes: Array<SeasonVideoCuePoint>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `SeasonVideoCuePoint` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `SeasonVideoCuePoint` edge in the connection. */
+export type SeasonVideoCuePointsEdge = {
+  __typename?: 'SeasonVideoCuePointsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `SeasonVideoCuePoint` at the end of the edge. */
+  node: SeasonVideoCuePoint;
+};
+
+/** Methods to use when ordering `SeasonVideoCuePoint`. */
+export enum SeasonVideoCuePointsOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  VideoIdAsc = 'VIDEO_ID_ASC',
+  VideoIdDesc = 'VIDEO_ID_DESC'
+}
+
 /** A filter to be used against `SeasonVideo` object types. All fields are combined with a logical ‘and.’ */
 export type SeasonVideoFilter = {
   /** Checks for all expressions in this list. */
@@ -2184,6 +2660,39 @@ export type SeasonVideoFilter = {
   /** Filter by the object’s `seasonId` field. */
   seasonId?: InputMaybe<StringFilter>;
 };
+
+/** A connection to a list of `SeasonVideo` values. */
+export type SeasonVideosConnection = {
+  __typename?: 'SeasonVideosConnection';
+  /** A list of edges which contains the `SeasonVideo` and cursor to aid in pagination. */
+  edges: Array<SeasonVideosEdge>;
+  /** A list of `SeasonVideo` objects. */
+  nodes: Array<SeasonVideo>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `SeasonVideo` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `SeasonVideo` edge in the connection. */
+export type SeasonVideosEdge = {
+  __typename?: 'SeasonVideosEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `SeasonVideo` at the end of the edge. */
+  node: SeasonVideo;
+};
+
+/** Methods to use when ordering `SeasonVideo`. */
+export enum SeasonVideosOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  SeasonIdAsc = 'SEASON_ID_ASC',
+  SeasonIdDesc = 'SEASON_ID_DESC'
+}
 
 /** Video stream DRM metadata */
 export type SeasonVideoStream = {
@@ -2292,72 +2801,6 @@ export enum SeasonVideoStreamsOrderBy {
   VideoIdDesc = 'VIDEO_ID_DESC'
 }
 
-/** A connection to a list of `SeasonVideo` values. */
-export type SeasonVideosConnection = {
-  __typename?: 'SeasonVideosConnection';
-  /** A list of edges which contains the `SeasonVideo` and cursor to aid in pagination. */
-  edges: Array<SeasonVideosEdge>;
-  /** A list of `SeasonVideo` objects. */
-  nodes: Array<SeasonVideo>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `SeasonVideo` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `SeasonVideo` edge in the connection. */
-export type SeasonVideosEdge = {
-  __typename?: 'SeasonVideosEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `SeasonVideo` at the end of the edge. */
-  node: SeasonVideo;
-};
-
-/** Methods to use when ordering `SeasonVideo`. */
-export enum SeasonVideosOrderBy {
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
-  SeasonIdAsc = 'SEASON_ID_ASC',
-  SeasonIdDesc = 'SEASON_ID_DESC'
-}
-
-/** A connection to a list of `Season` values. */
-export type SeasonsConnection = {
-  __typename?: 'SeasonsConnection';
-  /** A list of edges which contains the `Season` and cursor to aid in pagination. */
-  edges: Array<SeasonsEdge>;
-  /** A list of `Season` objects. */
-  nodes: Array<Season>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `Season` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `Season` edge in the connection. */
-export type SeasonsEdge = {
-  __typename?: 'SeasonsEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `Season` at the end of the edge. */
-  node: Season;
-};
-
-/** Methods to use when ordering `Season`. */
-export enum SeasonsOrderBy {
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
-  TvshowIdAsc = 'TVSHOW_ID_ASC',
-  TvshowIdDesc = 'TVSHOW_ID_DESC'
-}
-
 /** A filter to be used against String fields. All fields are combined with a logical ‘and.’ */
 export type StringFilter = {
   /** Not equal to the specified value, treating null like an ordinary value. */
@@ -2382,12 +2825,12 @@ export type StringFilter = {
   greaterThanOrEqualToInsensitive?: InputMaybe<Scalars['String']>;
   /** Included in the specified list. */
   in?: InputMaybe<Array<Scalars['String']>>;
-  /** Included in the specified list (case-insensitive). */
-  inInsensitive?: InputMaybe<Array<Scalars['String']>>;
   /** Contains the specified string (case-sensitive). */
   includes?: InputMaybe<Scalars['String']>;
   /** Contains the specified string (case-insensitive). */
   includesInsensitive?: InputMaybe<Scalars['String']>;
+  /** Included in the specified list (case-insensitive). */
+  inInsensitive?: InputMaybe<Array<Scalars['String']>>;
   /** Is null (if `true` is specified) or is not null (if `false` is specified). */
   isNull?: InputMaybe<Scalars['Boolean']>;
   /** Less than the specified value. */
@@ -2416,12 +2859,12 @@ export type StringFilter = {
   notEqualToInsensitive?: InputMaybe<Scalars['String']>;
   /** Not included in the specified list. */
   notIn?: InputMaybe<Array<Scalars['String']>>;
-  /** Not included in the specified list (case-insensitive). */
-  notInInsensitive?: InputMaybe<Array<Scalars['String']>>;
   /** Does not contain the specified string (case-sensitive). */
   notIncludes?: InputMaybe<Scalars['String']>;
   /** Does not contain the specified string (case-insensitive). */
   notIncludesInsensitive?: InputMaybe<Scalars['String']>;
+  /** Not included in the specified list (case-insensitive). */
+  notInInsensitive?: InputMaybe<Array<Scalars['String']>>;
   /** Does not match the specified pattern (case-sensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters. */
   notLike?: InputMaybe<Scalars['String']>;
   /** Does not match the specified pattern (case-insensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters. */
@@ -2851,6 +3294,37 @@ export enum TvshowLicensesOrderBy {
   TvshowIdDesc = 'TVSHOW_ID_DESC'
 }
 
+/** A connection to a list of `Tvshow` values. */
+export type TvshowsConnection = {
+  __typename?: 'TvshowsConnection';
+  /** A list of edges which contains the `Tvshow` and cursor to aid in pagination. */
+  edges: Array<TvshowsEdge>;
+  /** A list of `Tvshow` objects. */
+  nodes: Array<Tvshow>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `Tvshow` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `Tvshow` edge in the connection. */
+export type TvshowsEdge = {
+  __typename?: 'TvshowsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `Tvshow` at the end of the edge. */
+  node: Tvshow;
+};
+
+/** Methods to use when ordering `Tvshow`. */
+export enum TvshowsOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
+}
+
 /** Video stream metadata. */
 export type TvshowVideo = {
   __typename?: 'TvshowVideo';
@@ -2858,6 +3332,8 @@ export type TvshowVideo = {
   audioLanguages?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Array of caption languages available in the stream. */
   captionLanguages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Reads and enables pagination through a set of `TvshowVideoCuePoint`. */
+  cuePoints: TvshowVideoCuePointsConnection;
   /** URI to a DASH manifest. */
   dashManifest?: Maybe<Scalars['String']>;
   /** URI to an HLS manifest. */
@@ -2884,6 +3360,19 @@ export type TvshowVideo = {
 
 
 /** Video stream metadata. */
+export type TvshowVideoCuePointsArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<TvshowVideoCuePointCondition>;
+  filter?: InputMaybe<TvshowVideoCuePointFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<TvshowVideoCuePointsOrderBy>>;
+};
+
+
+/** Video stream metadata. */
 export type TvshowVideoVideoStreamsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
   before?: InputMaybe<Scalars['Cursor']>;
@@ -2906,6 +3395,79 @@ export type TvshowVideoCondition = {
   tvshowId?: InputMaybe<Scalars['String']>;
 };
 
+/** Video cue point metadata */
+export type TvshowVideoCuePoint = {
+  __typename?: 'TvshowVideoCuePoint';
+  /** Type of the cue point */
+  cuePointTypeKey: Scalars['String'];
+  id: Scalars['Int'];
+  /** Time in seconds at which the cue point is set within the video */
+  timeInSeconds: Scalars['Float'];
+  /** Additional information associated with the cue point */
+  value?: Maybe<Scalars['String']>;
+  /** Reads a single `TvshowVideo` that is related to this `TvshowVideoCuePoint`. */
+  video?: Maybe<TvshowVideo>;
+  videoId?: Maybe<Scalars['Int']>;
+};
+
+/**
+ * A condition to be used against `TvshowVideoCuePoint` object types. All fields
+ * are tested for equality and combined with a logical ‘and.’
+ */
+export type TvshowVideoCuePointCondition = {
+  /** Checks for equality with the object’s `id` field. */
+  id?: InputMaybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `videoId` field. */
+  videoId?: InputMaybe<Scalars['Int']>;
+};
+
+/** A filter to be used against `TvshowVideoCuePoint` object types. All fields are combined with a logical ‘and.’ */
+export type TvshowVideoCuePointFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<TvshowVideoCuePointFilter>>;
+  /** Filter by the object’s `id` field. */
+  id?: InputMaybe<IntFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<TvshowVideoCuePointFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<TvshowVideoCuePointFilter>>;
+  /** Filter by the object’s `videoId` field. */
+  videoId?: InputMaybe<IntFilter>;
+};
+
+/** A connection to a list of `TvshowVideoCuePoint` values. */
+export type TvshowVideoCuePointsConnection = {
+  __typename?: 'TvshowVideoCuePointsConnection';
+  /** A list of edges which contains the `TvshowVideoCuePoint` and cursor to aid in pagination. */
+  edges: Array<TvshowVideoCuePointsEdge>;
+  /** A list of `TvshowVideoCuePoint` objects. */
+  nodes: Array<TvshowVideoCuePoint>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `TvshowVideoCuePoint` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `TvshowVideoCuePoint` edge in the connection. */
+export type TvshowVideoCuePointsEdge = {
+  __typename?: 'TvshowVideoCuePointsEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `TvshowVideoCuePoint` at the end of the edge. */
+  node: TvshowVideoCuePoint;
+};
+
+/** Methods to use when ordering `TvshowVideoCuePoint`. */
+export enum TvshowVideoCuePointsOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  VideoIdAsc = 'VIDEO_ID_ASC',
+  VideoIdDesc = 'VIDEO_ID_DESC'
+}
+
 /** A filter to be used against `TvshowVideo` object types. All fields are combined with a logical ‘and.’ */
 export type TvshowVideoFilter = {
   /** Checks for all expressions in this list. */
@@ -2919,6 +3481,39 @@ export type TvshowVideoFilter = {
   /** Filter by the object’s `tvshowId` field. */
   tvshowId?: InputMaybe<StringFilter>;
 };
+
+/** A connection to a list of `TvshowVideo` values. */
+export type TvshowVideosConnection = {
+  __typename?: 'TvshowVideosConnection';
+  /** A list of edges which contains the `TvshowVideo` and cursor to aid in pagination. */
+  edges: Array<TvshowVideosEdge>;
+  /** A list of `TvshowVideo` objects. */
+  nodes: Array<TvshowVideo>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `TvshowVideo` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `TvshowVideo` edge in the connection. */
+export type TvshowVideosEdge = {
+  __typename?: 'TvshowVideosEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `TvshowVideo` at the end of the edge. */
+  node: TvshowVideo;
+};
+
+/** Methods to use when ordering `TvshowVideo`. */
+export enum TvshowVideosOrderBy {
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  TvshowIdAsc = 'TVSHOW_ID_ASC',
+  TvshowIdDesc = 'TVSHOW_ID_DESC'
+}
 
 /** Video stream DRM metadata */
 export type TvshowVideoStream = {
@@ -3027,70 +3622,6 @@ export enum TvshowVideoStreamsOrderBy {
   VideoIdDesc = 'VIDEO_ID_DESC'
 }
 
-/** A connection to a list of `TvshowVideo` values. */
-export type TvshowVideosConnection = {
-  __typename?: 'TvshowVideosConnection';
-  /** A list of edges which contains the `TvshowVideo` and cursor to aid in pagination. */
-  edges: Array<TvshowVideosEdge>;
-  /** A list of `TvshowVideo` objects. */
-  nodes: Array<TvshowVideo>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `TvshowVideo` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `TvshowVideo` edge in the connection. */
-export type TvshowVideosEdge = {
-  __typename?: 'TvshowVideosEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `TvshowVideo` at the end of the edge. */
-  node: TvshowVideo;
-};
-
-/** Methods to use when ordering `TvshowVideo`. */
-export enum TvshowVideosOrderBy {
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
-  TvshowIdAsc = 'TVSHOW_ID_ASC',
-  TvshowIdDesc = 'TVSHOW_ID_DESC'
-}
-
-/** A connection to a list of `Tvshow` values. */
-export type TvshowsConnection = {
-  __typename?: 'TvshowsConnection';
-  /** A list of edges which contains the `Tvshow` and cursor to aid in pagination. */
-  edges: Array<TvshowsEdge>;
-  /** A list of `Tvshow` objects. */
-  nodes: Array<Tvshow>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `Tvshow` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `Tvshow` edge in the connection. */
-export type TvshowsEdge = {
-  __typename?: 'TvshowsEdge';
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `Tvshow` at the end of the edge. */
-  node: Tvshow;
-};
-
-/** Methods to use when ordering `Tvshow`. */
-export enum TvshowsOrderBy {
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
-}
-
 export enum VideoStreamType {
   /** Audio */
   Audio = 'AUDIO',
@@ -3128,6 +3659,13 @@ export type VideoStreamTypeFilter = {
   notIn?: InputMaybe<Array<VideoStreamType>>;
 };
 
+export type GetChannelVideoQueryVariables = Exact<{
+  id: Scalars['String'];
+}>;
+
+
+export type GetChannelVideoQuery = { __typename?: 'Query', channel?: { __typename?: 'Channel', dashStreamUrl?: string | null, hlsStreamUrl?: string | null, keyId?: string | null } | null };
+
 export type GetEpisodeMainVideoQueryVariables = Exact<{
   id: Scalars['String'];
   countryCode?: InputMaybe<Scalars['String']>;
@@ -3145,6 +3683,15 @@ export type GetMovieMainVideoQueryVariables = Exact<{
 export type GetMovieMainVideoQuery = { __typename?: 'Query', movie?: { __typename?: 'Movie', videos: { __typename?: 'MovieVideosConnection', nodes: Array<{ __typename?: 'MovieVideo', id: number, isProtected?: boolean | null, videoStreams: { __typename?: 'MovieVideoStreamsConnection', nodes: Array<{ __typename?: 'MovieVideoStream', keyId?: string | null }> } }> } } | null };
 
 
+export const GetChannelVideoDocument = gql`
+    query GetChannelVideo($id: String!) {
+  channel(id: $id) {
+    dashStreamUrl
+    hlsStreamUrl
+    keyId
+  }
+}
+    `;
 export const GetEpisodeMainVideoDocument = gql`
     query GetEpisodeMainVideo($id: String!, $countryCode: String) {
   episode(id: $id, countryCode: $countryCode) {
@@ -3184,10 +3731,14 @@ export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, str
 
 
 const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType) => action();
+const GetChannelVideoDocumentString = print(GetChannelVideoDocument);
 const GetEpisodeMainVideoDocumentString = print(GetEpisodeMainVideoDocument);
 const GetMovieMainVideoDocumentString = print(GetMovieMainVideoDocument);
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
+    GetChannelVideo(variables: GetChannelVideoQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: GetChannelVideoQuery; extensions?: any; headers: Dom.Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GetChannelVideoQuery>(GetChannelVideoDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetChannelVideo', 'query');
+    },
     GetEpisodeMainVideo(variables: GetEpisodeMainVideoQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: GetEpisodeMainVideoQuery; extensions?: any; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<GetEpisodeMainVideoQuery>(GetEpisodeMainVideoDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetEpisodeMainVideo', 'query');
     },

--- a/services/entitlement/service/src/generated/graphql/schema.graphql
+++ b/services/entitlement/service/src/generated/graphql/schema.graphql
@@ -231,7 +231,7 @@ enum ErrorCodesEnum {
   EMPTY_ENTITY_ID
 
   """
-  The provided entity ID '%s' is invalid. It must start with 'movie-' or 'episode-' followed by a number.
+  The provided entity ID '%s' is invalid. It must be either a UUID, or start with 'movie-' or 'episode-' followed by a number.
   """
   INVALID_ENTITY_ID
 
@@ -244,6 +244,11 @@ enum ErrorCodesEnum {
   The requested video for the %s is not protected. An entitlement message to receive a DRM license is therefore not required.
   """
   VIDEO_NOT_PROTECTED
+
+  """
+  The requested data for the %s does not have the required stream URLs. It is possible that the channel is still being processed.
+  """
+  CHANNEL_STREAM_UNAVAILABLE
 
   """
   The user either does not have an active subscription, or subscription does not allow the playback of specific video.

--- a/services/entitlement/service/src/graphql/documents/catalog-get-channel-video.graphql
+++ b/services/entitlement/service/src/graphql/documents/catalog-get-channel-video.graphql
@@ -1,0 +1,7 @@
+query GetChannelVideo($id: String!) {
+  channel(id: $id) {
+    dashStreamUrl
+    hlsStreamUrl
+    keyId
+  }
+}

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.db.spec.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.db.spec.ts
@@ -1055,12 +1055,13 @@ describe('EntitlementEndpointPlugin', () => {
         // Act
         const resp = await ctx.runGqlQuery(
           ENTITLEMENT_REQUEST,
-          { input: { entityId: 'movie-1' } },
+          { input: { entityId: `${type}-1` } },
           {
             ip: '89.219.153.70', // EE
             authContext: {
               subject: createTestEndUser(),
             },
+            token: 'mock_token',
           },
         );
 
@@ -1104,6 +1105,7 @@ describe('EntitlementEndpointPlugin', () => {
             authContext: {
               subject: createTestEndUser(),
             },
+            token: 'mock_token',
           },
         );
 

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.db.spec.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.db.spec.ts
@@ -10,9 +10,14 @@ import {
 import gql from 'graphql-tag';
 import { stub } from 'jest-auto-stub';
 import 'jest-extended';
+import { v4 as uuid } from 'uuid';
 import { insert } from 'zapatos/db';
 import { CommonErrors } from '../../common';
-import { ENTITY_TYPE_MOVIES } from '../../domains';
+import {
+  ENTITY_TYPE_CHANNELS,
+  ENTITY_TYPE_EPISODES,
+  ENTITY_TYPE_MOVIES,
+} from '../../domains';
 import {
   getSdk as getBillingSdk,
   Sdk as BillingSdk,
@@ -35,6 +40,7 @@ jest.mock('../../generated/graphql/catalog');
 const catalogStub = stub<CatalogSdk>({
   GetEpisodeMainVideo: () => catalogCall(),
   GetMovieMainVideo: () => catalogCall(),
+  GetChannelVideo: () => catalogCall(),
 });
 const catalogMock = getCatalogSdk as jest.MockedFunction<typeof getCatalogSdk>;
 catalogMock.mockReturnValue(catalogStub);
@@ -70,7 +76,7 @@ describe('EntitlementEndpointPlugin', () => {
   let errorOverride: jest.SpyInstance;
   let warnOverride: jest.SpyInstance;
   let debugOverride: jest.SpyInstance;
-  let expectedJwtPayload: (persistence: boolean) => unknown;
+  let expectedJwtPayload: (persistence: boolean, keyIds?: string[]) => unknown;
   const jwtRegex =
     /([A-Za-z0-9]{36,})\.([A-Za-z0-9]{100,})\.([A-Za-z0-9-_]{40,})/gi;
   let defaultRequestContext: TestRequestContext;
@@ -126,6 +132,7 @@ describe('EntitlementEndpointPlugin', () => {
       },
     ],
   };
+  const channelId = uuid();
 
   beforeAll(async () => {
     ctx = await createTestContext({
@@ -145,7 +152,7 @@ describe('EntitlementEndpointPlugin', () => {
     };
 
     const policy = getPolicy('DEFAULT');
-    expectedJwtPayload = (persistence: boolean) => ({
+    expectedJwtPayload = (persistence: boolean, keyIds = [keyId1, keyId2]) => ({
       version: 1,
       com_key_id: ctx.config.drmLicenseCommunicationKeyId,
       message: {
@@ -155,16 +162,10 @@ describe('EntitlementEndpointPlugin', () => {
           allow_persistence: persistence,
         },
         content_keys_source: {
-          inline: [
-            {
-              id: keyId1,
-              usage_policy: 'Policy A',
-            },
-            {
-              id: keyId2,
-              usage_policy: 'Policy A',
-            },
-          ],
+          inline: keyIds.map((keyId) => ({
+            id: keyId,
+            usage_policy: 'Policy A',
+          })),
         },
         content_key_usage_policies: [
           {
@@ -183,13 +184,13 @@ describe('EntitlementEndpointPlugin', () => {
   });
 
   beforeEach(async () => {
-    errorOverride = await jest
+    errorOverride = jest
       .spyOn(console, 'error')
       .mockImplementation((obj) => JSON.parse(obj));
-    warnOverride = await jest
+    warnOverride = jest
       .spyOn(console, 'warn')
       .mockImplementation((obj) => JSON.parse(obj));
-    debugOverride = await jest
+    debugOverride = jest
       .spyOn(console, 'debug')
       .mockImplementation((obj) => JSON.parse(obj));
     catalogCall = () => undefined;
@@ -199,7 +200,7 @@ describe('EntitlementEndpointPlugin', () => {
     await insert('claim_sets', {
       key: 'TEST',
       title: 'test',
-      claims: [ENTITY_TYPE_MOVIES],
+      claims: [ENTITY_TYPE_MOVIES, ENTITY_TYPE_CHANNELS, ENTITY_TYPE_EPISODES],
     }).run(ctx.ownerPool);
   });
 
@@ -244,8 +245,14 @@ describe('EntitlementEndpointPlugin', () => {
       },
     );
 
-    // Maximum numeric value is 2147483647, from SQL int4 type, which is 10 digits long. Checking 11 digits here as well.
-    it.each(['season-1', 'movie-', 'episode-', '-234', 'movie-21474836470'])(
+    it.each([
+      'season-1',
+      'movie-',
+      'episode-',
+      '-234',
+      'movie-21474836470', // Maximum numeric value is 2147483647, from SQL int4 type, which is 10 digits long. Checking 11 digits here.
+      '68945fc1-237-4685-8dac-31cb808dc74d', // invalid uuid
+    ])(
       'Request with invalid id -> error thrown and logged as WARN',
       async (entityId) => {
         // Act
@@ -259,7 +266,7 @@ describe('EntitlementEndpointPlugin', () => {
         expect(resp.data?.entitlement).toBeFalsy();
         expect(resp.errors).toMatchObject([
           {
-            message: `The provided entity ID '${entityId}' is invalid. It must start with 'movie-' or 'episode-' followed by a number.`,
+            message: `The provided entity ID '${entityId}' is invalid. It must be either a UUID, or start with 'movie-' or 'episode-' followed by a number.`,
             code: CommonErrors.InvalidEntityId.code,
             path: ['entitlement'],
             details: undefined,
@@ -268,7 +275,7 @@ describe('EntitlementEndpointPlugin', () => {
 
         const loggedObject = getFirstMockResult<any>(warnOverride);
         expect(loggedObject).toMatchObject({
-          message: `The provided entity ID '${entityId}' is invalid. It must start with 'movie-' or 'episode-' followed by a number.`,
+          message: `The provided entity ID '${entityId}' is invalid. It must be either a UUID, or start with 'movie-' or 'episode-' followed by a number.`,
           loglevel: 'WARN',
         });
       },
@@ -420,6 +427,37 @@ describe('EntitlementEndpointPlugin', () => {
       });
     });
 
+    it('Response with null channel -> error thrown and logged as WARN', async () => {
+      // Arrange
+      catalogCall = () => ({
+        data: { channel: null },
+      });
+
+      // Act
+      const resp = await ctx.runGqlQuery(
+        ENTITLEMENT_REQUEST,
+        { input: { entityId: channelId } },
+        defaultRequestContext,
+      );
+
+      // Assert
+      expect(resp.data?.entitlement).toBeFalsy();
+      expect(resp.errors).toMatchObject([
+        {
+          message: `The channel with ID '${channelId}' cannot be retrieved. Please make sure that the channel is successfully published.`,
+          code: CommonErrors.EntityNotFound.code,
+          path: ['entitlement'],
+          details: undefined,
+        },
+      ]);
+
+      const loggedObject = getFirstMockResult<any>(warnOverride);
+      expect(loggedObject).toMatchObject({
+        message: `The channel with ID '${channelId}' cannot be retrieved. Please make sure that the channel is successfully published.`,
+        loglevel: 'WARN',
+      });
+    });
+
     it('Response with movie without videos -> error thrown and logged as ERROR', async () => {
       // Arrange
       catalogCall = () => ({
@@ -452,6 +490,79 @@ describe('EntitlementEndpointPlugin', () => {
         loglevel: 'ERROR',
       });
     });
+
+    it.each([{}, { keyId: null }])(
+      'Response with channel with missing keyId -> error thrown and logged as WARN',
+      async (channel) => {
+        // Arrange
+        catalogCall = () => ({
+          data: { channel },
+        });
+
+        // Act
+        const resp = await ctx.runGqlQuery(
+          ENTITLEMENT_REQUEST,
+          { input: { entityId: channelId } },
+          defaultRequestContext,
+        );
+
+        // Assert
+        expect(resp.data?.entitlement).toBeFalsy();
+        expect(resp.errors).toMatchObject([
+          {
+            message: `The requested video for the channel with ID '${channelId}' is not protected. An entitlement message to receive a DRM license is therefore not required.`,
+            code: CommonErrors.VideoNotProtected.code,
+            path: ['entitlement'],
+            details: undefined,
+          },
+        ]);
+
+        const loggedObject = getFirstMockResult<any>(warnOverride);
+        expect(loggedObject).toMatchObject({
+          message: `The requested video for the channel with ID '${channelId}' is not protected. An entitlement message to receive a DRM license is therefore not required.`,
+          loglevel: 'WARN',
+        });
+      },
+    );
+
+    it.each([
+      { keyId: 'test-value' },
+      { keyId: 'test-value', dashStreamUrl: 'test-value' },
+      { keyId: 'test-value', hlsStreamUrl: 'test-value' },
+      { keyId: 'test-value', dashStreamUrl: 'test-value', hlsStreamUrl: null },
+    ])(
+      'Response with channel with missing stream urls -> error thrown and logged as WARN',
+      async (channel) => {
+        // Arrange
+        catalogCall = () => ({
+          data: { channel },
+        });
+
+        // Act
+        const resp = await ctx.runGqlQuery(
+          ENTITLEMENT_REQUEST,
+          { input: { entityId: channelId } },
+          defaultRequestContext,
+        );
+
+        // Assert
+        expect(resp.data?.entitlement).toBeFalsy();
+        expect(resp.errors).toMatchObject([
+          {
+            message: `The requested data for the channel with ID '${channelId}' does not have the required stream URLs. It is possible that the channel is still being processed.`,
+            code: CommonErrors.ChannelStreamUnavailable.code,
+            path: ['entitlement'],
+            details: undefined,
+          },
+        ]);
+
+        const loggedObject = getFirstMockResult<any>(warnOverride);
+        expect(loggedObject).toMatchObject({
+          message: `The requested data for the channel with ID '${channelId}' does not have the required stream URLs. It is possible that the channel is still being processed.`,
+          loglevel: 'WARN',
+        });
+      },
+    );
 
     it('Response with no billing subscriptions -> error thrown and logged as ERROR', async () => {
       // Arrange
@@ -926,45 +1037,92 @@ describe('EntitlementEndpointPlugin', () => {
   });
 
   describe('Success cases', () => {
-    it('valid response received from catalog in prod mode - no error, expected jwt returned', async () => {
-      // Arrange
-      catalogCall = () => ({
-        data: {
-          movie: {
-            videos: {
-              nodes: [{ isProtected: true, videoStreams }],
+    it.each(['movie', 'episode'])(
+      'valid response received from catalog in prod mode for %p - no error, expected jwt returned',
+      async (type) => {
+        // Arrange
+        catalogCall = () => ({
+          data: {
+            [type]: {
+              videos: {
+                nodes: [{ isProtected: true, videoStreams }],
+              },
             },
           },
-        },
-      });
-      countryCode = 'EE';
+        });
+        countryCode = 'EE';
 
-      // Act
-      const resp = await ctx.runGqlQuery(
-        ENTITLEMENT_REQUEST,
-        { input: { entityId: 'movie-1' } },
-        {
-          ip: '89.219.153.70', // EE
-          authContext: {
-            subject: createTestEndUser(),
+        // Act
+        const resp = await ctx.runGqlQuery(
+          ENTITLEMENT_REQUEST,
+          { input: { entityId: 'movie-1' } },
+          {
+            ip: '89.219.153.70', // EE
+            authContext: {
+              subject: createTestEndUser(),
+            },
           },
-          token: 'mock_token',
-        },
-      );
+        );
 
-      // Assert
-      expect(resp.errors).toBeFalsy();
+        // Assert
+        expect(resp.errors).toBeFalsy();
 
-      expect(resp?.data?.entitlement.entitlementMessageJwt).toMatch(jwtRegex);
-      const jwtParts = resp?.data?.entitlement.entitlementMessageJwt
-        .split('.')
-        .map((part: string) => Buffer.from(part, 'base64').toString());
-      expect(JSON.parse(jwtParts[0])).toEqual({
-        alg: 'HS256',
-        typ: 'JWT',
-      });
-      expect(JSON.parse(jwtParts[1])).toEqual(expectedJwtPayload(false));
-    });
+        expect(resp?.data?.entitlement.entitlementMessageJwt).toMatch(jwtRegex);
+        const jwtParts = resp?.data?.entitlement.entitlementMessageJwt
+          .split('.')
+          .map((part: string) => Buffer.from(part, 'base64').toString());
+        expect(JSON.parse(jwtParts[0])).toEqual({
+          alg: 'HS256',
+          typ: 'JWT',
+        });
+        expect(JSON.parse(jwtParts[1])).toEqual(expectedJwtPayload(false));
+      },
+    );
+
+    it.each([true, false])(
+      'valid response received from catalog in prod mode for channel - no error, expected jwt returned',
+      async (allowPersistence) => {
+        // Arrange
+        catalogCall = () => ({
+          data: {
+            channel: {
+              keyId: keyId1,
+              dashStreamUrl: 'test-value',
+              hlsStreamUrl: 'test-value',
+            },
+          },
+        });
+        countryCode = 'EE';
+
+        // Act
+        const resp = await ctx.runGqlQuery(
+          ENTITLEMENT_REQUEST,
+          // allowPersistance is ignored for channels
+          { input: { entityId: channelId, allowPersistence } },
+          {
+            ip: '89.219.153.70', // EE
+            authContext: {
+              subject: createTestEndUser(),
+            },
+          },
+        );
+
+        // Assert
+        expect(resp.errors).toBeFalsy();
+
+        expect(resp?.data?.entitlement.entitlementMessageJwt).toMatch(jwtRegex);
+        const jwtParts = resp?.data?.entitlement.entitlementMessageJwt
+          .split('.')
+          .map((part: string) => Buffer.from(part, 'base64').toString());
+        expect(JSON.parse(jwtParts[0])).toEqual({
+          alg: 'HS256',
+          typ: 'JWT',
+        });
+        expect(JSON.parse(jwtParts[1])).toEqual(
+          expectedJwtPayload(false, [keyId1]),
+        );
+      },
+    );
 
     it('valid response received from catalog in prod mode - with duplicate drm key ids, no error, expected jwt returned with de-duplicated drm key ids', async () => {
       // Arrange

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.ts
@@ -10,7 +10,7 @@ import {
   generateEntitlementMessageJwt,
   getEntityType,
   getSubscriptionPlanId,
-  getVideo,
+  getVideoKeyIds,
   validateUserClaims,
 } from './entitlement-endpoint';
 import { getValidatedExtendedContext } from './extended-graphql-context';
@@ -59,7 +59,7 @@ export const EntitlementEndpointPlugin = makeExtendSchemaPlugin(() => {
             }
 
             const type = getEntityType(args.input.entityId);
-            const video = await getVideo(
+            const keyIds = await getVideoKeyIds(
               type,
               args.input.entityId,
               config.catalogServiceBaseUrl,
@@ -77,7 +77,7 @@ export const EntitlementEndpointPlugin = makeExtendSchemaPlugin(() => {
               ownerPool,
             );
             const entitlementMessageJwt = generateEntitlementMessageJwt(
-              video.videoStreams?.nodes?.map((stream) => stream.keyId),
+              keyIds,
               claims,
               config,
               config.isDev ? 'DEV' : 'DEFAULT',

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/catalog-service-communication.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/catalog-service-communication.ts
@@ -2,18 +2,20 @@ import {
   isNullOrWhitespace,
   MosaicError,
   mosaicErrorMappingFactory,
+  UnreachableCaseError,
 } from '@axinom/mosaic-service-common';
 import { GraphQLClient } from 'graphql-request';
 import { ClientError, GraphQLError } from 'graphql-request/dist/types';
 import urljoin from 'url-join';
-import { CommonErrors } from '../../../common';
+import { CommonErrors, sanitizeStringArray } from '../../../common';
 import {
+  GetChannelVideoQuery,
   GetEpisodeMainVideoQuery,
   GetMovieMainVideoQuery,
   getSdk,
 } from '../../../generated/graphql/catalog';
 
-export type EntityWithVideoType = 'movie' | 'episode';
+export type EntityWithVideoType = 'movie' | 'episode' | 'channel';
 
 type MovieVideo = NonNullable<
   GetMovieMainVideoQuery['movie']
@@ -21,6 +23,7 @@ type MovieVideo = NonNullable<
 type EpisodeVideo = NonNullable<
   GetEpisodeMainVideoQuery['episode']
 >['videos']['nodes'][0];
+type ChannelVideo = NonNullable<GetChannelVideoQuery['channel']>;
 
 const getCatalogMappedError = mosaicErrorMappingFactory<{
   type: EntityWithVideoType;
@@ -58,11 +61,11 @@ const getCatalogMappedError = mosaicErrorMappingFactory<{
   return undefined;
 });
 
-const getCatalogResponseVideo = (
+const getValidatedKeyIds = (
   type: EntityWithVideoType,
   id: string,
-  videos: MovieVideo[] | EpisodeVideo[] | undefined,
-): MovieVideo | EpisodeVideo => {
+  videos: MovieVideo[] | EpisodeVideo[] | ChannelVideo | null | undefined,
+): string[] => {
   const identifier = `${type} with ID '${id}'`;
 
   if (!videos) {
@@ -70,6 +73,25 @@ const getCatalogResponseVideo = (
       ...CommonErrors.EntityNotFound,
       messageParams: [identifier, type],
     });
+  }
+
+  if (!Array.isArray(videos)) {
+    if (isNullOrWhitespace(videos.keyId)) {
+      throw new MosaicError({
+        ...CommonErrors.VideoNotProtected,
+        messageParams: [identifier],
+      });
+    }
+    if (
+      isNullOrWhitespace(videos.dashStreamUrl) ||
+      isNullOrWhitespace(videos.hlsStreamUrl)
+    ) {
+      throw new MosaicError({
+        ...CommonErrors.ChannelStreamUnavailable,
+        messageParams: [identifier],
+      });
+    }
+    return [videos.keyId];
   }
 
   if (videos.length === 0) {
@@ -87,25 +109,30 @@ const getCatalogResponseVideo = (
   }
 
   const [video] = videos;
-  if (
-    !video.isProtected ||
-    !video.videoStreams?.nodes?.length ||
-    video.videoStreams.nodes // A protected video will always have at least one stream with non-empty Key ID
-      .map((videoStream) => videoStream.keyId)
-      .filter((keyId) => !isNullOrWhitespace(keyId)).length === 0
-  ) {
+  const keyIds = sanitizeStringArray(
+    video?.videoStreams?.nodes?.map((videoStream) => videoStream.keyId),
+  );
+
+  // A protected video will always have at least one stream with non-empty Key ID
+  if (!video.isProtected || keyIds.length === 0) {
     throw new MosaicError({
       ...CommonErrors.VideoNotProtected,
       messageParams: [identifier],
     });
   }
 
-  return video;
+  return keyIds;
 };
 
 export const getEntityType = (id: string): EntityWithVideoType => {
   if (isNullOrWhitespace(id)) {
     throw new MosaicError(CommonErrors.EmptyEntityId);
+  }
+
+  const uuidRegex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (uuidRegex.test(id)) {
+    return 'channel';
   }
 
   if (!id.match(/^(movie-|episode-)\d{1,10}$/)) {
@@ -122,29 +149,31 @@ export const getEntityType = (id: string): EntityWithVideoType => {
   }
 };
 
-export const getVideo = async (
+export const getVideoKeyIds = async (
   type: EntityWithVideoType,
   id: string,
   catalogUrl: string,
   countryCode?: string,
-): Promise<MovieVideo | EpisodeVideo> => {
+): Promise<string[]> => {
   try {
     const client = new GraphQLClient(urljoin(catalogUrl, 'graphql'));
-    const { GetMovieMainVideo, GetEpisodeMainVideo } = getSdk(client);
-    if (type === 'movie') {
-      const result = await GetMovieMainVideo({ id, countryCode });
-      return getCatalogResponseVideo(
-        type,
-        id,
-        result.data?.movie?.videos.nodes,
-      );
-    } else {
-      const result = await GetEpisodeMainVideo({ id, countryCode });
-      return getCatalogResponseVideo(
-        type,
-        id,
-        result.data?.episode?.videos.nodes,
-      );
+    const { GetMovieMainVideo, GetEpisodeMainVideo, GetChannelVideo } =
+      getSdk(client);
+    switch (type) {
+      case 'movie': {
+        const result = await GetMovieMainVideo({ id, countryCode });
+        return getValidatedKeyIds(type, id, result.data?.movie?.videos.nodes);
+      }
+      case 'episode': {
+        const result = await GetEpisodeMainVideo({ id, countryCode });
+        return getValidatedKeyIds(type, id, result.data?.episode?.videos.nodes);
+      }
+      case 'channel': {
+        const result = await GetChannelVideo({ id });
+        return getValidatedKeyIds(type, id, result.data.channel);
+      }
+      default:
+        throw new UnreachableCaseError(type);
     }
   } catch (error) {
     throw getCatalogMappedError(error, { id, type });

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/entitlement-message-generation.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/entitlement-message-generation.ts
@@ -2,10 +2,6 @@ import { Dict, UnreachableCaseError } from '@axinom/mosaic-service-common';
 import jwt from 'jsonwebtoken';
 import { Config } from '../../../common';
 import { ENABLE_VIDEOS_DOWNLOAD } from '../../../domains';
-import {
-  EpisodeVideoStream,
-  MovieVideoStream,
-} from '../../../generated/graphql/catalog';
 
 type PolicyMode = 'DEFAULT' | 'DEV' | 'STRICT';
 
@@ -68,7 +64,7 @@ export const getPolicy = (mode: PolicyMode): Dict<unknown> => {
 };
 
 export const generateEntitlementMessageJwt = (
-  keyIds: (MovieVideoStream | EpisodeVideoStream)['keyId'][] | undefined,
+  keyIds: string[],
   claims: string[],
   config: Config,
   policyMode: PolicyMode,
@@ -84,7 +80,7 @@ export const generateEntitlementMessageJwt = (
         allow_persistence: claims.includes(ENABLE_VIDEOS_DOWNLOAD), // Allows to specify whether the license can be persisted on the playback device.
       },
       content_keys_source: {
-        inline: [...new Set(keyIds?.filter(Boolean) ?? [])].map((id) => ({
+        inline: keyIds.map((id) => ({
           id,
           usage_policy: 'Policy A',
         })),


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

You can now pass a channel ID as an entityId to the `entitlement` endpoint and get an entitlement token to playback protected live streams produced by the VOD-to-Live service
