### PR TITLE
[AB#40272] chore: register `transformNavigationTree` to adjust nav item order

### DIFF
--- a/services/media/workflows/src/Stations/Episodes/registrations.tsx
+++ b/services/media/workflows/src/Stations/Episodes/registrations.tsx
@@ -17,6 +17,7 @@ import { EpisodeVideoManagement } from './EpisodeVideoManagement/EpisodeVideoMan
 
 export function register(app: PiletApi, extensions: Extensions): void {
   const episodesNav = {
+    name: 'episodes',
     path: '/episodes',
     label: 'Episodes',
     icon: <MediaIcons icon={MediaIconName.Episodes} />,

--- a/services/media/workflows/src/Stations/Ingest/registrations.tsx
+++ b/services/media/workflows/src/Stations/Ingest/registrations.tsx
@@ -12,6 +12,7 @@ import { IngestDocumentUpload } from './IngestDocumentUpload/IngestDocumentUploa
 
 export function register(app: PiletApi, extensions: Extensions): void {
   const ingestNav = {
+    name: 'ingest',
     path: '/ingest',
     label: 'Ingest',
     icon: <MediaIcons icon={MediaIconName.Ingest} />,

--- a/services/media/workflows/src/Stations/Movies/registrations.tsx
+++ b/services/media/workflows/src/Stations/Movies/registrations.tsx
@@ -25,6 +25,7 @@ import { MovieVideoManagement } from './MovieVideoManagement/MovieVideoManagemen
 
 export function register(app: PiletApi, extensions: Extensions): void {
   const moviesNav = {
+    name: 'movies',
     path: '/movies',
     label: 'Movies',
     icon: <MediaIcons icon={MediaIconName.Movie} />,
@@ -126,6 +127,7 @@ export function register(app: PiletApi, extensions: Extensions): void {
   );
 
   const movieSettingsNav = {
+    name: 'movie-genres',
     path: '/settings/media/moviegenres',
     label: 'Movie Genres',
     icon: <MediaIcons icon={MediaIconName.MovieGenres} />,

--- a/services/media/workflows/src/Stations/Publishing/registrations.tsx
+++ b/services/media/workflows/src/Stations/Publishing/registrations.tsx
@@ -7,6 +7,7 @@ import { SnapshotRegistry } from './SnapshotRegistryExplorer/SnapshotRegistry';
 
 export function register(app: PiletApi, _extensions: Extensions): void {
   const snapshotsNav = {
+    name: 'snapshots',
     path: '/snapshots',
     label: 'Snapshot Registry',
     icon: <MediaIcons icon={MediaIconName.Snapshots} />,

--- a/services/media/workflows/src/Stations/Seasons/registrations.tsx
+++ b/services/media/workflows/src/Stations/Seasons/registrations.tsx
@@ -18,6 +18,7 @@ import { SeasonVideoManagement } from './SeasonVideoManagement/SeasonVideoManage
 
 export function register(app: PiletApi, extensions: Extensions): void {
   const seasonsNav = {
+    name: 'seasons',
     path: '/seasons',
     label: 'Seasons',
     icon: <MediaIcons icon={MediaIconName.Seasons} />,

--- a/services/media/workflows/src/Stations/TvShows/registrations.tsx
+++ b/services/media/workflows/src/Stations/TvShows/registrations.tsx
@@ -26,6 +26,7 @@ import { TvShowVideoManagement } from './TvShowVideoManagement/TvShowVideoManage
 
 export function register(app: PiletApi, extensions: Extensions): void {
   const tvshowNav = {
+    name: 'tvshows',
     path: '/tvshows',
     label: 'TV Shows',
     icon: <MediaIcons icon={MediaIconName.TV} />,
@@ -133,6 +134,7 @@ export function register(app: PiletApi, extensions: Extensions): void {
   });
 
   const tvshowSettingsNav = {
+    name: 'tvshow-genres',
     path: '/settings/media/tvshowgenres',
     label: 'TV Show Genres',
     icon: <MediaIcons icon={MediaIconName.TvShowGenres} />,

--- a/services/media/workflows/src/index.tsx
+++ b/services/media/workflows/src/index.tsx
@@ -15,7 +15,10 @@ import { register as registerMovies } from './Stations/Movies/registrations';
 import { register as registerSnapshotRegistry } from './Stations/Publishing/registrations';
 import { register as registerSeasons } from './Stations/Seasons/registrations';
 import { register as registerTvShows } from './Stations/TvShows/registrations';
-import { transformNavigationItems } from './transformNavigation/transformNavigation';
+import {
+  transformNavigationItems,
+  transformNavigationTree,
+} from './transformNavigation/transformNavigation';
 
 export const settingsGroupName = 'Media Management';
 export const mediaManagementParentName = 'media-management';
@@ -39,6 +42,8 @@ export function setup(app: PiletApi): void {
   app.setHomeTileSorter(sortTiles);
 
   app.setNavigationItemsTransformer(transformNavigationItems);
+
+  app.setNavigationTreeTransformer(transformNavigationTree);
 
   app.registerNavigationItem({
     icon: <MediaIcons icon={MediaIconName.Movie} />,

--- a/services/media/workflows/src/transformNavigation/transformNavigation.ts
+++ b/services/media/workflows/src/transformNavigation/transformNavigation.ts
@@ -1,4 +1,4 @@
-import { NavigationItem } from '@axinom/mosaic-portal';
+import { NavigationItem, NavigationPanelCategory } from '@axinom/mosaic-portal';
 
 const processingCategoryItemName = 'videos';
 const contentCategoryItemName = 'images';
@@ -12,6 +12,9 @@ const curationCategoryItemNames = [
 export const transformNavigationItems = (
   items: NavigationItem[],
 ): NavigationItem[] => {
+  // move managed solution navigation items
+  // that are in "Workflows" category
+  // to their own categories (content, processing or curation)
   items.forEach((item) => {
     if (item.name === contentCategoryItemName) {
       item.categoryName = 'Content';
@@ -22,4 +25,78 @@ export const transformNavigationItems = (
     }
   });
   return items;
+};
+
+export const transformNavigationTree = (
+  tree: NavigationPanelCategory[],
+): NavigationPanelCategory[] => {
+  const sortedTree = [...tree].sort(alphabeticalObjectSorter('categoryName'));
+
+  const settingsIndex = sortedTree.findIndex(
+    ({ categoryName }) => categoryName === 'Settings',
+  );
+
+  // move Settings to the end of the list
+  const transformedTree = [
+    ...sortedTree.slice(0, settingsIndex),
+    ...sortedTree.slice(settingsIndex + 1),
+    sortedTree[settingsIndex],
+  ];
+
+  // sort items in each category
+  transformedTree.forEach(categoryItemSorter);
+
+  return transformedTree;
+};
+
+const CategoryItemOrder = {
+  Content: ['movies', 'tvshows', 'seasons', 'episodes', 'images'],
+  Curation: ['collections', 'channels', 'monetization'],
+  Processing: ['ingest', 'videos', 'snapshots'],
+};
+
+const categoryItemSorter = (
+  category: NavigationPanelCategory,
+): NavigationPanelCategory => {
+  const predefinedOrder = CategoryItemOrder[category.categoryName] || [];
+  return {
+    ...category,
+    items: predefinedOrderSorter(predefinedOrder, category.items, 'name'),
+  };
+};
+
+/**
+ * Sorts objects alphabetically by property
+ * @param propName - property to sort by
+ * @returns sort function
+ */
+const alphabeticalObjectSorter =
+  <T>(propName: keyof T) =>
+  (a: T, b: T): number =>
+    String(a[propName]).localeCompare(String(b[propName]));
+
+/**
+ * Sorts items by predefined order, then alphabetically
+ * @param predefinedOrder - predefined order of items
+ * @param items - items to sort
+ * @param sortProperty - property to sort by
+ * @returns sorted items
+ */
+const predefinedOrderSorter = <T>(
+  predefinedOrder: T[keyof T][] = [],
+  items: T[] = [],
+  sortProperty: keyof T,
+): T[] => {
+  return items.sort((a, b) => {
+    const aIndex = predefinedOrder.indexOf(a[sortProperty]);
+    const bIndex = predefinedOrder.indexOf(b[sortProperty]);
+
+    return aIndex === -1 && bIndex === -1
+      ? 0 // neither a nor b are in the predefined order, sort alphabetically
+      : aIndex === -1
+      ? 1 // a is not in the predefined order, b is, b comes first
+      : bIndex === -1
+      ? -1 // b is not in the predefined order, a is, a comes first
+      : aIndex - bIndex; // both a and b are in the predefined order, sort by index
+  });
 };


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

Registers `transformNavigationTree` function to achieve following navigation panel item order:
```
Content
  Movies
  TV Shows
  Seasons
  Episodes
  Images

Curation
  Collections
  Channels
  Monetization

Processing
  Ingest
  Videos
  Snapshot Registry

Settings
  ...

```