### PR TITLE
[AB#40475] exclude jest config from tsconfig

### DIFF
--- a/services/catalog/service/tsconfig.build.json
+++ b/services/catalog/service/tsconfig.build.json
@@ -4,5 +4,12 @@
   "compilerOptions": {
     "noEmit": false
   },
-  "exclude": ["node_modules", "dist", "scripts", "**/tests", "**/*spec.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "scripts",
+    "**/tests",
+    "**/*spec.ts",
+    "jest.*"
+  ]
 }

--- a/services/entitlement/service/tsconfig.build.json
+++ b/services/entitlement/service/tsconfig.build.json
@@ -4,5 +4,12 @@
   "compilerOptions": {
     "noEmit": false
   },
-  "exclude": ["node_modules", "dist", "scripts", "**/tests", "**/*spec.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "scripts",
+    "**/tests",
+    "**/*spec.ts",
+    "jest.*"
+  ]
 }


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

Previous PR #99 adjusted jest config files to be `.ts` instead of `.js` to make sure that root `test` script would run catalog and entitlement tests as well. But this made `build` script also build that file, changing the `dist` folder structure. This PR fixes this by excluding jest config file from being built.
