### PR TITLE
[AB#40100] feat: build and run container as their native non-root users

### DIFF
--- a/.adops/backend-service-build.yml
+++ b/.adops/backend-service-build.yml
@@ -70,9 +70,7 @@ stages:
                   Dockerfile: $(dockerfilePath)
                   buildContext: '.'
                   tags: '$(tag)'
-                  arguments:
-                    '--build-arg PACKAGE_ROOT=$(packageRoot) --build-arg
-                  PACKAGE_BUILD_COMMAND=$(packageBuildCommand)'
+                  arguments: '--build-arg PACKAGE_ROOT=$(packageRoot) --build-arg PACKAGE_BUILD_COMMAND=$(packageBuildCommand)'
 
               - task: Docker@2
                 displayName: Push Docker Image to Axinom Container Registry

--- a/.adops/package-update.yml
+++ b/.adops/package-update.yml
@@ -8,7 +8,7 @@ pool:
 resources:
   pipelines:
     - pipeline: packageRelease
-      source: 'Package release'
+      source: 'release-managed-libraries'
       trigger:
         branches:
           include:

--- a/.adops/workflow-build.yml
+++ b/.adops/workflow-build.yml
@@ -12,9 +12,8 @@ variables:
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
   continueBuild: true
   tag: '$(Build.BuildNumber)'
-  ? ${{ if and(eq(variables['Build.SourceBranch'], 'refs/heads/dev'),
-    eq(variables['Build.Reason'], 'Schedule')) }}
-  : additionalBuildNameSuffix: 'cb-'
+  ${{ if and(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), eq(variables['Build.Reason'], 'Schedule')) }}:
+    additionalBuildNameSuffix: 'cb-'
   ${{ else }}:
     additionalBuildNameSuffix: ''
 
@@ -35,9 +34,8 @@ stages:
           # If not, skip the rest of the steps.
           # By default, the value of `continueBuild` will be true, this allowing all the steps in the pipeline to run from
           # non-dev branches.
-          - ? ${{ if and(eq(variables['Build.SourceBranch'], 'refs/heads/dev'),
-              eq(variables['Build.Reason'], 'Schedule')) }}
-            : - task: AzureCLI@2
+          - ${{ if and(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), eq(variables['Build.Reason'], 'Schedule')) }}:
+              - task: AzureCLI@2
                 displayName: Generate Changelist
                 env:
                   AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
@@ -48,14 +46,14 @@ stages:
                   inlineScript: |
                     echo "Skip Change List Check: $(skipChangeList)"
                     [[ "$(skipChangeList)" == "true" ]] && exit 0
-
+                    
                     echo "Variable cbContinuousDeploymentEnabled is set to $(cbContinuousDeploymentEnabled)"
                     previousSuccessfulCommitId=$(az pipelines build list --definition-ids $(System.DefinitionId) --result succeeded --reason schedule --top 1 --organization $(System.CollectionUri) --project $(System.TeamProject) --query "[0].sourceVersion" --output tsv)
-
+                    
                     echo "Current Commit ID                 : $(Build.SourceVersion)"
                     echo "Previous Scheduled Build Commit ID: $previousSuccessfulCommitId"
                     echo "Generating file delta between $(Build.SourceVersion) and $previousSuccessfulCommitId"
-
+                    
                     DIFFS="$(git diff $(Build.SourceVersion) $previousSuccessfulCommitId --name-only)"
                     echo "Changed File List: $DIFFS"
                     [[ "$(cbContinuousDeploymentEnabled)" == "true" && "${DIFFS[@]}" =~ "$(packageRoot)" ]] || echo "##vso[task.setvariable variable=continueBuild;]false"
@@ -63,7 +61,7 @@ stages:
           - ${{ if eq(variables['continueBuild'], 'true') }}:
               - task: NodeTool@0
                 inputs:
-                  versionSpec: '18.x'
+                  versionSpec: '14.x'
                 displayName: 'Install Node.js'
 
               - task: Cache@2
@@ -78,12 +76,12 @@ stages:
               - script: |
                   ORIGINAL_PKG_VER=`npx -q json -f "$(packageRoot)/package.json" version`
                   NEW_PKG_VER="${ORIGINAL_PKG_VER}-$(tag)"
-
+                  
                   echo "Current package.json version is: [${ORIGINAL_PKG_VER}]"
                   echo "Updating package.json version to: [${NEW_PKG_VER}]"
-
+                  
                   npx -q json -I -f "$(packageRoot)/package.json" -e "this.version = '${NEW_PKG_VER}'"
-
+                  
                   echo "Updated package.json version is: [`npx -q json -f \"$(packageRoot)/package.json\" version`]"
                 displayName:
                   'Updating package.json version to reflect the build number'
@@ -110,7 +108,7 @@ stages:
                 inputs:
                   targetType: 'inline'
                   script: |
-                    $buildType = if ("$(Build.SourceBranch)" -like "refs/heads/release*") { "stable" } else { "prerelease" }
+                    $buildType = if ("$(Build.SourceBranch)" -like "*refs/heads/release*" ) { "stable" } else { "prerelease" }
                     Write-Host "##vso[build.addbuildtag]$buildType"
                     Write-Host "##vso[build.addbuildtag]complete-build"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,7 @@ COPY --from=build ["/checkout/$PACKAGE_ROOT/node_modules", "./node_modules/"]
 COPY --from=build ["/checkout/$PACKAGE_ROOT/dist", "./dist/"]
 COPY --from=build ["/checkout/$PACKAGE_ROOT/migrations", "./migrations/"]
 
+RUN chown -R node:node /app
+USER node
+
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

<!-- describe your changes here -->
- Backend Service Containers (node):
   - ownership of `/app` directory is given to `node` user that is built into the standard `node:18-alpine` image and has `1000` as the `uid` and `gid`. This change was not needed for most of the services but if the app itself or a library tries to download something like geolite data, there will be a permission issue so now the ownership is given to `node` user universally
   - container is run as user `node(1000)` and group `node(1000)` with no privilege escalations