### PR TITLE
[AB#40568] channel id changed in catalog service to match other entities

### DIFF
--- a/services/catalog/service/migrations/committed/000010-channel-id-values-updated.sql
+++ b/services/catalog/service/migrations/committed/000010-channel-id-values-updated.sql
@@ -1,0 +1,30 @@
+--! Previous: sha1:66a3704e0515a63889b50a53166b99fc6e10e458
+--! Hash: sha1:c9457b917399b9a43ac0fc04d0e130cf728bfcb7
+--! Message: channel-id-values-updated
+
+DO $$ BEGIN
+  IF EXISTS(SELECT constraint_name FROM information_schema.constraint_column_usage 
+    WHERE table_schema='app_public' AND table_name='channel' AND constraint_name ='channel_images_channel_id_fkey')
+  THEN
+    ALTER TABLE app_public.channel_images DROP CONSTRAINT channel_images_channel_id_fkey;
+  END IF;
+END $$;
+
+UPDATE app_public.channel 
+  SET id = 'channel-' || id 
+  WHERE id NOT ILIKE 'channel-%';
+
+UPDATE app_public.channel_images
+  SET channel_id = 'channel-' || channel_id 
+  WHERE channel_id NOT ILIKE 'channel-%';
+
+DO $$ BEGIN
+  IF NOT EXISTS(SELECT constraint_name FROM information_schema.constraint_column_usage 
+    WHERE table_schema='app_public' AND table_name='channel' AND constraint_name ='channel_images_channel_id_fkey')
+  THEN
+    ALTER TABLE app_public.channel_images 
+      ADD CONSTRAINT channel_images_channel_id_fkey 
+      FOREIGN KEY (channel_id) REFERENCES app_public.channel(id) 
+      ON DELETE CASCADE;
+  END IF;
+END $$;

--- a/services/catalog/service/package.json
+++ b/services/catalog/service/package.json
@@ -75,6 +75,7 @@
     "ts-jest": "^29",
     "ts-node": "^10.9.1",
     "tsc-watch": "^4.6.2",
-    "typescript": "^4.8.4"
+    "typescript": "^4.8.4",
+    "uuid": "^8.3.2"
   }
 }

--- a/services/catalog/service/src/domains/channels/common/constants.ts
+++ b/services/catalog/service/src/domains/channels/common/constants.ts
@@ -1,0 +1,7 @@
+export const CHANNEL_ID_PREFIX = 'channel-';
+
+/**
+ * Adds a `channel-` prefix to the original UUID ID of the channel to match the
+ * convention, similar to movies, episodes, etc...
+ */
+export const getChannelId = (id: string): string => `${CHANNEL_ID_PREFIX}${id}`;

--- a/services/catalog/service/src/domains/channels/common/index.ts
+++ b/services/catalog/service/src/domains/channels/common/index.ts
@@ -1,0 +1,1 @@
+export * from './constants';

--- a/services/catalog/service/src/domains/channels/handlers/channel-unpublished-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/channels/handlers/channel-unpublished-event-handler.db.spec.ts
@@ -4,6 +4,7 @@ import { stub } from 'jest-auto-stub';
 import { v4 as uuid } from 'uuid';
 import { insert, selectOne } from 'zapatos/db';
 import { createTestContext, ITestContext } from '../../../tests/test-utils';
+import { getChannelId } from '../common';
 import { ChannelUnpublishedEventHandler } from './channel-unpublished-event-handler';
 
 describe('ChannelPublishEventHandler', () => {
@@ -27,7 +28,8 @@ describe('ChannelPublishEventHandler', () => {
   describe('onMessage', () => {
     test('An existing channel is unpublished', async () => {
       // Arrange
-      const channelId = uuid();
+      const originalId = uuid();
+      const channelId = getChannelId(originalId);
       const insertedChannel = await insert('channel', {
         id: channelId,
         title: 'Some title',
@@ -42,7 +44,7 @@ describe('ChannelPublishEventHandler', () => {
       }).run(ctx.ownerPool);
 
       const message: ChannelUnpublishedEvent = {
-        id: channelId,
+        id: originalId,
       };
       const messageInfo = stub<MessageInfo<ChannelUnpublishedEvent>>({
         envelope: {
@@ -56,12 +58,12 @@ describe('ChannelPublishEventHandler', () => {
 
       // Assert
       const channel = await selectOne('channel', {
-        id: message.id,
+        id: channelId,
       }).run(ctx.ownerPool);
 
       expect(channel).toBeUndefined();
       const channelImage = await selectOne('channel_images', {
-        channel_id: message.id,
+        channel_id: channelId,
       }).run(ctx.ownerPool);
 
       expect(channelImage).toBeUndefined();

--- a/services/catalog/service/src/domains/channels/handlers/channel-unpublished-event-handler.ts
+++ b/services/catalog/service/src/domains/channels/handlers/channel-unpublished-event-handler.ts
@@ -6,6 +6,7 @@ import {
 } from '@axinom/mosaic-messages';
 import * as db from 'zapatos/db';
 import { Config } from '../../../common';
+import { getChannelId } from '../common';
 import { AuthenticatedMessageHandler } from './authenticated-message-handler';
 
 export class ChannelUnpublishedEventHandler extends AuthenticatedMessageHandler<ChannelUnpublishedEvent> {
@@ -23,12 +24,13 @@ export class ChannelUnpublishedEventHandler extends AuthenticatedMessageHandler<
     payload: ChannelUnpublishedEvent,
     _message: MessageInfo<ChannelUnpublishedEvent>,
   ): Promise<void> {
+    const channelId = getChannelId(payload.id);
     await transactionWithContext(
       this.loginPool,
       db.IsolationLevel.Serializable,
       { role: this.config.dbGqlRole },
       async (txnClient) => {
-        await db.deletes('channel', { id: payload.id }).run(txnClient);
+        await db.deletes('channel', { id: channelId }).run(txnClient);
       },
     );
   }

--- a/services/catalog/service/src/domains/channels/handlers/check-channel-job-status-succeeded-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/channels/handlers/check-channel-job-status-succeeded-event-handler.db.spec.ts
@@ -3,6 +3,7 @@ import { CheckChannelJobStatusSucceededEvent } from 'media-messages';
 import { v4 as uuid } from 'uuid';
 import { insert, selectOne } from 'zapatos/db';
 import { createTestContext, ITestContext } from '../../../tests/test-utils';
+import { getChannelId } from '../common';
 import { CheckChannelJobStatusSucceededEventHandler } from './check-channel-job-status-succeeded-event-handler';
 
 describe('CheckChannelJobStatusSucceededEventHandler', () => {
@@ -11,7 +12,10 @@ describe('CheckChannelJobStatusSucceededEventHandler', () => {
 
   beforeAll(async () => {
     ctx = await createTestContext();
-    handler = new CheckChannelJobStatusSucceededEventHandler(ctx.loginPool, ctx.config);
+    handler = new CheckChannelJobStatusSucceededEventHandler(
+      ctx.loginPool,
+      ctx.config,
+    );
   });
 
   afterEach(async () => {
@@ -26,8 +30,10 @@ describe('CheckChannelJobStatusSucceededEventHandler', () => {
   describe('onMessage', () => {
     test('live stream is ready, but the channel is not yet registered in catalog -> error is thrown & channel is not created', async () => {
       // Arrange
+      const originalId = uuid();
+      const channelId = getChannelId(originalId);
       const message: CheckChannelJobStatusSucceededEvent = {
-        channel_id: uuid(),
+        channel_id: originalId,
         dash_stream_url: 'https://axinom-test-origin.com/channel.isml/.mpd',
         hls_stream_url: 'https://axinom-test-origin.com/channel.isml/.m3u8',
       };
@@ -37,25 +43,27 @@ describe('CheckChannelJobStatusSucceededEventHandler', () => {
 
       // Assert
       expect(error).toMatchObject({
-        message: `Channel with id ${message.channel_id} not found! Failed to add links to channel's live stream.`,
+        message: `Channel with id ${channelId} not found! Failed to add links to channel's live stream.`,
         code: 'CHANNEL_NOT_FOUND',
       });
       const channel = await selectOne('channel', {
-        id: message.channel_id,
+        id: channelId,
       }).run(ctx.ownerPool);
       expect(channel).toBeUndefined();
     });
 
     test('live stream is ready and channel is registered in catalog -> channel is updated', async () => {
       // Arrange
+      const originalId = uuid();
+      const channelId = getChannelId(originalId);
       await insert('channel', {
-        id: 'channel-1',
+        id: channelId,
         title: 'Old title',
         dash_stream_url: 'https://axinom-test-origin.com/channel-1.isml/.mpd',
         hls_stream_url: 'https://axinom-test-origin.com/channel-1.isml/.m3u8',
       }).run(ctx.ownerPool);
       const message: CheckChannelJobStatusSucceededEvent = {
-        channel_id: 'channel-1',
+        channel_id: originalId,
         dash_stream_url: 'https://axinom-test-origin.com/channel.isml/.mpd',
         hls_stream_url: 'https://axinom-test-origin.com/channel.isml/.m3u8',
       };
@@ -65,7 +73,7 @@ describe('CheckChannelJobStatusSucceededEventHandler', () => {
 
       // Assert
       const channel = await selectOne('channel', {
-        id: message.channel_id,
+        id: channelId,
       }).run(ctx.ownerPool);
 
       expect(channel?.dash_stream_url).toEqual(message.dash_stream_url);

--- a/services/catalog/service/src/domains/channels/handlers/check-channel-job-status-succeeded-event-handler.ts
+++ b/services/catalog/service/src/domains/channels/handlers/check-channel-job-status-succeeded-event-handler.ts
@@ -6,6 +6,7 @@ import {
 } from 'media-messages';
 import { IsolationLevel, selectOne, update } from 'zapatos/db';
 import { Config } from '../../../common';
+import { getChannelId } from '../common';
 import { AuthenticatedMessageHandler } from './authenticated-message-handler';
 
 export class CheckChannelJobStatusSucceededEventHandler extends AuthenticatedMessageHandler<CheckChannelJobStatusSucceededEvent> {
@@ -21,17 +22,18 @@ export class CheckChannelJobStatusSucceededEventHandler extends AuthenticatedMes
   }
 
   async onMessage(payload: CheckChannelJobStatusSucceededEvent): Promise<void> {
+    const channelId = getChannelId(payload.channel_id);
     await transactionWithContext(
       this.loginPool,
       IsolationLevel.Serializable,
       { role: this.config.dbGqlRole },
       async (txnClient) => {
         const dbChannel = await selectOne('channel', {
-          id: payload.channel_id,
+          id: channelId,
         }).run(txnClient);
         if (!dbChannel) {
           throw new MosaicError({
-            message: `Channel with id ${payload.channel_id} not found! Failed to add links to channel's live stream.`,
+            message: `Channel with id ${channelId} not found! Failed to add links to channel's live stream.`,
             code: 'CHANNEL_NOT_FOUND',
           });
         }
@@ -41,7 +43,7 @@ export class CheckChannelJobStatusSucceededEventHandler extends AuthenticatedMes
             dash_stream_url: payload.dash_stream_url,
             hls_stream_url: payload.hls_stream_url,
           },
-          { id: payload.channel_id },
+          { id: channelId },
         ).run(txnClient);
       },
     );

--- a/services/catalog/service/src/domains/channels/handlers/live-stream-protection-key-created-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/channels/handlers/live-stream-protection-key-created-event-handler.db.spec.ts
@@ -3,6 +3,7 @@ import { LiveStreamProtectionKeyCreatedEvent } from 'media-messages';
 import { v4 as uuid } from 'uuid';
 import { insert, selectOne } from 'zapatos/db';
 import { createTestContext, ITestContext } from '../../../tests/test-utils';
+import { getChannelId } from '../common';
 import { LiveStreamProtectionKeyCreatedEventHandler } from './live-stream-protection-key-created-event-handler';
 
 describe('LiveStreamProtectionKeyCreatedEventHandler', () => {
@@ -29,8 +30,10 @@ describe('LiveStreamProtectionKeyCreatedEventHandler', () => {
   describe('onMessage', () => {
     test('live stream protection key is sent, but the channel is not yet registered in catalog -> error is thrown & channel is not created', async () => {
       // Arrange
+      const originalId = uuid();
+      const channelId = getChannelId(originalId);
       const message: LiveStreamProtectionKeyCreatedEvent = {
-        channel_id: uuid(),
+        channel_id: originalId,
         key_id: uuid(),
       };
 
@@ -39,25 +42,27 @@ describe('LiveStreamProtectionKeyCreatedEventHandler', () => {
 
       // Assert
       expect(error).toMatchObject({
-        message: `Channel with id ${message.channel_id} not found! Failed to add channel's DRM key id.`,
+        message: `Channel with id ${channelId} not found! Failed to add channel's DRM key id.`,
         code: 'CHANNEL_NOT_FOUND',
       });
       const channel = await selectOne('channel', {
-        id: message.channel_id,
+        id: channelId,
       }).run(ctx.ownerPool);
       expect(channel).toBeUndefined();
     });
 
     test('live stream protection key is sent and channel is registered in catalog -> channel is updated', async () => {
       // Arrange
+      const originalId = uuid();
+      const channelId = getChannelId(originalId);
       await insert('channel', {
-        id: 'channel-1',
+        id: channelId,
         title: 'Old title',
         dash_stream_url: 'https://axinom-test-origin.com/channel-1.isml/.mpd',
         hls_stream_url: 'https://axinom-test-origin.com/channel-1.isml/.m3u8',
       }).run(ctx.ownerPool);
       const message: LiveStreamProtectionKeyCreatedEvent = {
-        channel_id: 'channel-1',
+        channel_id: originalId,
         key_id: uuid(),
       };
 
@@ -66,7 +71,7 @@ describe('LiveStreamProtectionKeyCreatedEventHandler', () => {
 
       // Assert
       const channel = await selectOne('channel', {
-        id: message.channel_id,
+        id: channelId,
       }).run(ctx.ownerPool);
 
       expect(channel?.key_id).toEqual(message.key_id);

--- a/services/entitlement/service/src/common/errors/common-errors.ts
+++ b/services/entitlement/service/src/common/errors/common-errors.ts
@@ -63,7 +63,7 @@ export const CommonErrors = {
   },
   InvalidEntityId: {
     message:
-      "The provided entity ID '%s' is invalid. It must be either a UUID, or start with 'movie-' or 'episode-' followed by a number.",
+      "The provided entity ID '%s' is invalid. It must start with 'movie-' or 'episode-' followed by a number, or start with 'channel-' followed by UUID.",
     code: 'INVALID_ENTITY_ID',
   },
   EntityNotFound: {

--- a/services/entitlement/service/src/domains/encoding/video-playback-middlewares.ts
+++ b/services/entitlement/service/src/domains/encoding/video-playback-middlewares.ts
@@ -121,7 +121,12 @@ export const setupEntitlementWebhookEndpoint = (
             (s) => s.key_id,
           ),
         );
-        const jwt = generateEntitlementMessageJwt(keyIds, [], config, 'STRICT');
+        const jwt = generateEntitlementMessageJwt(
+          keyIds,
+          [],
+          config,
+          config.isDev ? 'DEV' : 'STRICT',
+        );
         const response =
           generateWebhookResponse<EntitlementWebhookResponsePayload>({
             payload: {

--- a/services/entitlement/service/src/generated/graphql/schema.graphql
+++ b/services/entitlement/service/src/generated/graphql/schema.graphql
@@ -231,7 +231,7 @@ enum ErrorCodesEnum {
   EMPTY_ENTITY_ID
 
   """
-  The provided entity ID '%s' is invalid. It must be either a UUID, or start with 'movie-' or 'episode-' followed by a number.
+  The provided entity ID '%s' is invalid. It must start with 'movie-' or 'episode-' followed by a number, or start with 'channel-' followed by UUID.
   """
   INVALID_ENTITY_ID
 

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.db.spec.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint-plugin.db.spec.ts
@@ -132,7 +132,7 @@ describe('EntitlementEndpointPlugin', () => {
       },
     ],
   };
-  const channelId = uuid();
+  const channelId = `channel-${uuid()}`;
 
   beforeAll(async () => {
     ctx = await createTestContext({
@@ -249,9 +249,10 @@ describe('EntitlementEndpointPlugin', () => {
       'season-1',
       'movie-',
       'episode-',
+      'channel-',
       '-234',
       'movie-21474836470', // Maximum numeric value is 2147483647, from SQL int4 type, which is 10 digits long. Checking 11 digits here.
-      '68945fc1-237-4685-8dac-31cb808dc74d', // invalid uuid
+      '92b27f89-ac27-4e50-8fe7-e4cd75a5855e', // uuid without channel- prefix
     ])(
       'Request with invalid id -> error thrown and logged as WARN',
       async (entityId) => {
@@ -266,7 +267,7 @@ describe('EntitlementEndpointPlugin', () => {
         expect(resp.data?.entitlement).toBeFalsy();
         expect(resp.errors).toMatchObject([
           {
-            message: `The provided entity ID '${entityId}' is invalid. It must be either a UUID, or start with 'movie-' or 'episode-' followed by a number.`,
+            message: `The provided entity ID '${entityId}' is invalid. It must start with 'movie-' or 'episode-' followed by a number, or start with 'channel-' followed by UUID.`,
             code: CommonErrors.InvalidEntityId.code,
             path: ['entitlement'],
             details: undefined,
@@ -275,7 +276,7 @@ describe('EntitlementEndpointPlugin', () => {
 
         const loggedObject = getFirstMockResult<any>(warnOverride);
         expect(loggedObject).toMatchObject({
-          message: `The provided entity ID '${entityId}' is invalid. It must be either a UUID, or start with 'movie-' or 'episode-' followed by a number.`,
+          message: `The provided entity ID '${entityId}' is invalid. It must start with 'movie-' or 'episode-' followed by a number, or start with 'channel-' followed by UUID.`,
           loglevel: 'WARN',
         });
       },

--- a/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/catalog-service-communication.ts
+++ b/services/entitlement/service/src/graphql/plugins/entitlement-endpoint/catalog-service-communication.ts
@@ -141,9 +141,9 @@ export const getEntityType = (id: string): EntityWithVideoType => {
     throw new MosaicError(CommonErrors.EmptyEntityId);
   }
 
-  const uuidRegex =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-  if (uuidRegex.test(id)) {
+  const channelUuidRegex =
+    /^channel-[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (channelUuidRegex.test(id)) {
     return 'channel';
   }
 


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

To match other entities, channel ID is now explicitly adjusted in catalog service, adding a `channel-` prefix to the original UUID value. Corresponding changes are made in the entitlement service to support this. And explicit database migration is added to update possible existing channel entries in the channel service database.

## Testing Notes

Publish a channel, make sure that catalog API would return a valid id value (e.g. `channel-92b27f89-ac27-4e50-8fe7-e4cd75a5855e`) when querying channels and channel images. IF VOD-to-live service is configured to enable DRM protection - make sure that passing the updated channel id to the `entitlement` endpoint would return the entitlement token.
