### PR TITLE
[AB#40442] feat: set remote fspg instance creds in env file

### DIFF
--- a/.adops/pull-request.yml
+++ b/.adops/pull-request.yml
@@ -42,6 +42,11 @@ steps:
       sed -i 's/^\(RABBITMQ_PASSWORD=\)$/\1fake/' .env
       sed -i 's/^\(DEV_SERVICE_ACCOUNT_CLIENT_ID=\)$/\1fake/' .env
       sed -i 's/^\(DEV_SERVICE_ACCOUNT_CLIENT_SECRET=\)$/\1fake/' .env
+      sed -i '/POSTGRESQL_HOST/d' .env
+      sed -i '/POSTGRESQL_ROOT/d' .env
+      echo -e "\nPOSTGRESQL_HOST=$(DATABASE_HOST)" >> .env
+      echo "POSTGRESQL_ROOT=$(DATABASE_USERNAME)" >> .env
+      echo "POSTGRESQL_ROOT_PASSWORD=$(DATABASE_PASSWORD)" >> .env
     displayName: Add fake values to .env to keep config loader happy
 
   - script: cat .env

--- a/scripts/helpers/db-command-helpers.ts
+++ b/scripts/helpers/db-command-helpers.ts
@@ -87,6 +87,7 @@ export const runResetQueries = async (
   dbOwnerPassword: string,
   dbEnvOwner?: string,
   dbEnvOwnerPassword?: string,
+  pgRoot?: string,
 ): Promise<void> => {
   const client = await pgPool.connect();
   try {
@@ -126,6 +127,11 @@ export const runResetQueries = async (
       // When owner is superuser - this is not needed, but in deployed environments and for test databases owner is a regular user and also needs such grant.
       `GRANT ${dbGqlRole} TO ${dbOwner};`,
       createEnvOwner ? `GRANT ${dbGqlRole} TO ${dbEnvOwner};` : '',
+
+      // Trying to create a database with a different owner than the user/role that is running the create db query will,
+      // fail in Flexible Servers for Postgres servers in Azure. Therefore we grant the `dbOwner` role to the user that runs,
+      // the query first.
+      pgRoot ? `GRANT ${dbOwner} TO ${pgRoot}` : '',
     ];
 
     for await (const command of commands) {

--- a/scripts/helpers/db-test-helpers.ts
+++ b/scripts/helpers/db-test-helpers.ts
@@ -65,6 +65,9 @@ export async function recreateTestDbTemplate(
     dbConfig.dbLoginPassword,
     dbConfig.dbOwner,
     dbConfig.dbOwnerPassword,
+    undefined,
+    undefined,
+    dbConfig.pgRoot,
   );
 
   await rootPgPool.end();

--- a/scripts/helpers/db-test-helpers.ts
+++ b/scripts/helpers/db-test-helpers.ts
@@ -65,8 +65,6 @@ export async function recreateTestDbTemplate(
     dbConfig.dbLoginPassword,
     dbConfig.dbOwner,
     dbConfig.dbOwnerPassword,
-    undefined,
-    undefined,
     dbConfig.pgRoot,
   );
 


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

<!-- describe your changes here -->
- Running lengthy tests that involve Postgres databases consume a lot of memory and sometimes Microsoft build agents are not able to accommodate all the memory requests. This leads to builds crashing.
- Utilize existing non-production FSPG instance as the database source so that we can skip running tests against a Postgres container inside the built agent, completely skipping the memory penalty.