### PR TITLE
[AB#40685] fix: better pilet upgrade command

### DIFF
--- a/scripts/package-version-check.ts
+++ b/scripts/package-version-check.ts
@@ -15,7 +15,7 @@ const packageJsonGlob = process.argv[4] || '**/workflows/package.json';
 
 const message = chalk.red(`A newer version %s of ${packageName} is available!
 Your current version is: %s
-Please run "pilet upgrade" in "%s" to update.`);
+Please run "yarn pilet upgrade" in "%s" to update.`);
 
 /**
  * Compares latest version of package from npm registry with package.json files.


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

<!-- describe your changes here -->
When running `pilet upgrade` from a global piral-cli command the command will fail under some circumstances, as the `yarn workspaces info` command the piral-cli runs does prefix the JSON with the Yarn version number.
Running the command through `yarn pilet upgrade` makes it on the one hand use the piral-cli version of the repo but on the other hand also prevent `yarn workspaces info` to print invalid JSON, making the command more robust.

This PR updates the message we print from our script, when asking the user to upgrade the pilet to use `yarn pilet upgrade`.
