### PR TITLE
[AB#40296] Add deployment manifests and setup:hosting script

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -14,6 +14,11 @@ RABBITMQ_PASSWORD=
 DEV_SERVICE_ACCOUNT_CLIENT_ID=
 DEV_SERVICE_ACCOUNT_CLIENT_SECRET=
 
+# Only for Deployments through Mosaic Hosting Service
+# Can set by running `yarn setup:hosting` script from root.
+MOSAIC_HOSTING_CLIENT_ID=
+MOSAIC_HOSTING_CLIENT_SECRET=
+
 
 ########################################################
 ### Advanced options below - change at your own risk ###
@@ -22,6 +27,7 @@ DEV_SERVICE_ACCOUNT_CLIENT_SECRET=
 # Managed Service Endpoint URLs
 MICRO_FRONTEND_SERVICE_BASE_URL=https://frontends.service.eu.axinom.net
 ID_SERVICE_AUTH_BASE_URL=https://id.service.eu.axinom.net
+HOSTING_SERVICE_BASE_URL=https://hosting.service.eu.axinom.net
 
 # Local Proxy Ports
 ID_SERVICE_LOCAL_PROXY_PORT=10505

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build:entitlement-service:prod": "yarn && wsrun -trm -p entitlement-service -c build && yarn install --prod",
     "build:vod-to-live-service:prod": "yarn && wsrun -trm -p vod-to-live-service -c build && yarn install --prod",
     "build:media-workflows:prod": "yarn && wsrun -trm -p media-workflows -c build && pilet pack services/media/workflows",
+    "setup:hosting": "yarn util:load-vars ts-node ./scripts/setup-hosting.ts",
     "yarn:de-dupe": "npx yarn-deduplicate yarn.lock"
   },
   "devDependencies": {

--- a/scripts/setup-hosting.ts
+++ b/scripts/setup-hosting.ts
@@ -54,6 +54,7 @@ async function main(): Promise<void> {
           'SERVICE_DEFINITIONS_VIEW',
           'SERVICE_PILET_ARTIFACTS_EDIT',
           'SERVICE_DEPLOYMENT_CONFIG_EDIT',
+          'SERVICE_DEPLOYMENTS_EDIT',
         ],
       },
       {

--- a/scripts/setup-hosting.ts
+++ b/scripts/setup-hosting.ts
@@ -52,6 +52,7 @@ async function main(): Promise<void> {
         serviceId: 'ax-hosting-service',
         permissions: [
           'SERVICE_DEFINITIONS_VIEW',
+          'CONTAINER_REGISTRY_CONNECTIONS_VIEW',
           'SERVICE_PILET_ARTIFACTS_EDIT',
           'SERVICE_DEPLOYMENT_CONFIG_EDIT',
           'SERVICE_DEPLOYMENTS_EDIT',

--- a/scripts/setup-hosting.ts
+++ b/scripts/setup-hosting.ts
@@ -1,0 +1,126 @@
+/* eslint-disable no-console */
+import {
+  devSetupServiceAccountWithPermissions,
+  getServiceAccountToken,
+} from '@axinom/mosaic-id-link-be';
+import { PermissionStructure } from '@axinom/mosaic-id-utils';
+import {
+  getBasicCustomizableConfigDefinitions,
+  getValidatedConfig,
+  isNullOrWhitespace,
+  pick,
+} from '@axinom/mosaic-service-common';
+import { from } from 'env-var';
+import { promises as fs } from 'fs';
+import { join, resolve } from 'path';
+
+async function main(): Promise<void> {
+  const env = from(process.env);
+
+  const config = getValidatedConfig(
+    pick(
+      getBasicCustomizableConfigDefinitions(),
+      'idServiceAuthBaseUrl',
+      'tenantId',
+      'environmentId',
+    ),
+  );
+
+  const devServiceAccountClientId = env
+    .get('DEV_SERVICE_ACCOUNT_CLIENT_ID')
+    .asString();
+
+  const devServiceAccountClientSecret = env
+    .get('DEV_SERVICE_ACCOUNT_CLIENT_SECRET')
+    .asString();
+
+  if (
+    isNullOrWhitespace(devServiceAccountClientId) ||
+    isNullOrWhitespace(devServiceAccountClientSecret)
+  ) {
+    throw new Error(
+      'Please ensure the root environment variables [DEV_SERVICE_ACCOUNT_CLIENT_ID] & [DEV_SERVICE_ACCOUNT_CLIENT_SECRET] have been configured.',
+    );
+  }
+
+  await serviceAccountSetup(
+    config.idServiceAuthBaseUrl,
+    devServiceAccountClientId,
+    devServiceAccountClientSecret,
+    [
+      {
+        serviceId: 'ax-hosting-service',
+        permissions: [
+          'SERVICE_DEFINITIONS_VIEW',
+          'SERVICE_PILET_ARTIFACTS_EDIT',
+          'SERVICE_DEPLOYMENT_CONFIG_EDIT',
+        ],
+      },
+      {
+        serviceId: 'ax-micro-frontend-service',
+        permissions: ['PILETS_REGISTER'],
+      },
+    ],
+  );
+}
+
+const serviceAccountSetup = async (
+  idServiceAuthBaseUrl: string,
+  devServiceAccountClientId: string,
+  devServiceAccountClientSecret: string,
+  permissions: PermissionStructure[],
+): Promise<void> => {
+  const tokenResult = await getServiceAccountToken(
+    idServiceAuthBaseUrl,
+    devServiceAccountClientId,
+    devServiceAccountClientSecret,
+  );
+
+  const serviceAccountName = `hosting-service-account`;
+  const serviceAccount = await devSetupServiceAccountWithPermissions(
+    idServiceAuthBaseUrl,
+    tokenResult.accessToken,
+    serviceAccountName,
+    permissions,
+  );
+
+  await updateEnvFile(serviceAccount.clientId, serviceAccount.clientSecret);
+
+  console.log({
+    message: `Service account "${serviceAccountName}" successfully created and its credentials added to the .env file.`,
+    ...serviceAccount,
+  });
+};
+
+async function updateEnvFile(
+  clientId: string,
+  clientSecret: string,
+): Promise<void> {
+  const envVarPath = resolve(join(process.cwd(), '.env'));
+  let envFileContent = await fs.readFile(envVarPath, { encoding: 'utf8' });
+
+  const clientIdRegex = /^MOSAIC_HOSTING_CLIENT_ID=.*$/gm;
+  const clientSecretRegex = /^MOSAIC_HOSTING_CLIENT_SECRET=.*$/gm;
+
+  const clientIdEnv = 'MOSAIC_HOSTING_CLIENT_ID=' + clientId;
+  const clientSecretEnv = 'MOSAIC_HOSTING_CLIENT_SECRET=' + clientSecret;
+
+  if (envFileContent.match(clientIdRegex) !== null) {
+    envFileContent = envFileContent.replace(clientIdRegex, clientIdEnv);
+  } else {
+    envFileContent += '\n' + clientIdEnv;
+  }
+
+  if (envFileContent.match(clientSecretRegex) !== null) {
+    envFileContent = envFileContent.replace(clientSecretRegex, clientSecretEnv);
+  } else {
+    envFileContent += '\n' + clientSecretEnv;
+  }
+
+  await fs.writeFile(envVarPath, envFileContent, 'utf8');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});

--- a/scripts/setup-hosting.ts
+++ b/scripts/setup-hosting.ts
@@ -78,7 +78,7 @@ const serviceAccountSetup = async (
     devServiceAccountClientSecret,
   );
 
-  const serviceAccountName = `hosting-service-account`;
+  const serviceAccountName = `hosting-CLI-service-account`;
   const serviceAccount = await devSetupServiceAccountWithPermissions(
     idServiceAuthBaseUrl,
     tokenResult.accessToken,

--- a/services/catalog/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/catalog/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,43 +1,65 @@
-# This YAML contains the Deployment Configuration template
-# for Catalog Service.
-# This configuration file is required when deploying the service via
-# Mosaic Hosting Service.
-# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
-# mosaic hosting manifest upload
+# This YAML contains the Deployment Manifest for the Catalog Service.
+# It is required when deploying the service via the Mosaic Hosting Service.
+# Refer to the README.md file for instructions on how to use this.
 
 version: '1.0'
-serviceId: 'ax-catalog-service'
-dnsMappedPorts:
-  - name: 'api'
-    port: 10300
-pilets: []
-serviceAccounts: []
-secureVariables:
-  PGSSLMODE: 'prefer'
-  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
-  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
-  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
-  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
-  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
-  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
-  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+serviceId: 'catalog-service'
+
+regularVariables:
+  # Service General Variables
+  SERVICE_ID: 'catalog-service'
+  NODE_ENV: 'production'
+  LOG_LEVEL: 'DEBUG'
+  GRAPHQL_GUI_ENABLED: true
+  PORT: '${__ax_hosted__.port.api}'
+
+  # Mosaic Environment Info
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+
+  # Database Server Variables
+  PGSSLMODE: '${__ax_hosted__.pg.sslmode}'
   POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
   POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
+  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
+
+  # Database Variables
+  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
   DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
-  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+
+  # RabbitMQ Variables
   RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
+  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
+  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
+  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
   RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
   RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
-  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
-  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
-  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
-  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
-regularVariables:
-  PORT: '${__ax_hosted__.port.api}'
-  NODE_ENV: 'test'
-  LOG_LEVEL: 'DEBUG'
-  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
-  SERVICE_ID: 'catalog-service'
-  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
-  GRAPHQL_GUI_ENABLED: true
+  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
+  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+
+  # Managed Service URLs
   ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
+
+secureVariables:
+  # Use this section to store any custom environment variables which contain sensitive data.
+  # i.e.
+  # YOUR_KEY: 'SENSITIVE_DATA'
+  {}
+
+serviceAccounts:
+  # Defines the service accounts that will be provisioned for this service.
+  []
+
+pilets:
+  # Defines the pilets (i.e. micro-frontends) associated with the service, and the required key-value pairs to run the pilet.
+  []
+
+dnsMappedPorts:
+  # Defines the DNS subdomains that will provisioned and be mapped to the ports exposed by the service
+  - name: 'api'
+    port: 10300

--- a/services/catalog/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/catalog/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,0 +1,43 @@
+# This YAML contains the Deployment Configuration template
+# for Catalog Service.
+# This configuration file is required when deploying the service via
+# Mosaic Hosting Service.
+# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
+# mosaic hosting manifest upload
+
+version: '1.0'
+serviceId: 'ax-catalog-service'
+dnsMappedPorts:
+  - name: 'api'
+    port: 10300
+pilets: []
+serviceAccounts: []
+secureVariables:
+  PGSSLMODE: 'prefer'
+  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
+  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
+  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+  POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
+  POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
+  DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
+  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+  RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
+  RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
+  RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
+  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
+  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+regularVariables:
+  PORT: '${__ax_hosted__.port.api}'
+  NODE_ENV: 'test'
+  LOG_LEVEL: 'DEBUG'
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  SERVICE_ID: 'catalog-service'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+  GRAPHQL_GUI_ENABLED: true
+  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'

--- a/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,0 +1,58 @@
+# This YAML contains the Deployment Configuration template
+# for Entitlement Service.
+# This configuration file is required when deploying the service via
+# Mosaic Hosting Service.
+# Make sure to replace the license key values for DRM and Geo Lite.
+# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
+# mosaic hosting manifest upload
+
+pilets: []
+version: '1.0'
+serviceId: 'entitlement-service'
+dnsMappedPorts:
+  - name: 'api'
+    port: 11600
+secureVariables:
+  PGSSLMODE: 'prefer'
+  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
+  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
+  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+  POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
+  POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
+  DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
+  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+  RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
+  RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
+  RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
+  GEOLITE2_LICENSE_KEY: [REPLACE_WITH_VALID_LICENSE_KEY]
+  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
+  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  SERVICE_ACCOUNT_CLIENT_ID: '${__ax_hosted__.sa.client_id.primary}'
+  DRM_LICENSE_COMMUNICATION_KEY: [REPLACE_WITH_VALID_LICENSE_KEY]
+  SERVICE_ACCOUNT_CLIENT_SECRET: '${__ax_hosted__.sa.client_secret.primary}'
+  DRM_LICENSE_COMMUNICATION_KEY_ID: [REPLACE_WITH_VALID_COMMUNICATION_KEY]
+serviceAccounts:
+  - name: 'primary'
+    permissionStructure:
+      - serviceId: 'ax-monetization-grants-service'
+        permissions:
+          - 'CLAIM_DEFINITIONS_SYNCHRONIZE'
+regularVariables:
+  PORT: '${__ax_hosted__.port.api}'
+  NODE_ENV: 'production'
+  DEMO_MODE: true
+  LOG_LEVEL: 'DEBUG'
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  SERVICE_ID: 'entitlement-service'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+  GRAPHQL_GUI_ENABLED: true
+  BILLING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-billing-service.end_user_base_url}'
+  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.catalog-service.api}'
+  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
+  USER_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-user-service.auth_base_url}'

--- a/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
@@ -56,7 +56,7 @@ regularVariables:
   USER_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-user-service.auth_base_url}'
 
   # Custom Service URLs
-  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.catalog-service.api}'
+  CATALOG_SERVICE_BASE_URL: 'https://${__ax_hosted__.dns.catalog-service.api}'
 
 secureVariables:
   # Use this section to store any custom environment variables which contain sensitive data.

--- a/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,58 +1,88 @@
-# This YAML contains the Deployment Configuration template
-# for Entitlement Service.
-# This configuration file is required when deploying the service via
-# Mosaic Hosting Service.
-# Make sure to replace the license key values for DRM and Geo Lite.
-# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
-# mosaic hosting manifest upload
+# This YAML contains the Deployment Manifest for the Entitlement Service.
+# It is required when deploying the service via the Mosaic Hosting Service.
+# Refer to the README.md file for instructions on how to use this.
 
-pilets: []
+# NOTE:
+# The following environment variables need to be replaced with your own values.
+#
+# GEOLITE2_LICENSE_KEY
+# DRM_LICENSE_COMMUNICATION_KEY
+# DRM_LICENSE_COMMUNICATION_KEY_ID
+
 version: '1.0'
 serviceId: 'entitlement-service'
-dnsMappedPorts:
-  - name: 'api'
-    port: 11600
-secureVariables:
-  PGSSLMODE: 'prefer'
-  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
-  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
-  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
-  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
-  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
-  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
-  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+
+regularVariables:
+  # Service General Variables
+  SERVICE_ID: 'entitlement-service'
+  NODE_ENV: 'production'
+  LOG_LEVEL: 'DEBUG'
+  GRAPHQL_GUI_ENABLED: true
+  DEMO_MODE: true
+  PORT: '${__ax_hosted__.port.api}'
+
+  # Mosaic Environment Info
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+
+  # Database Server Variables
+  PGSSLMODE: '${__ax_hosted__.pg.sslmode}'
   POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
   POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
+  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
+
+  # Database Variables
+  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
   DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
-  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+
+  # RabbitMQ Variables
   RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
+  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
+  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
+  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
   RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
   RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
-  GEOLITE2_LICENSE_KEY: [REPLACE_WITH_VALID_LICENSE_KEY]
-  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
-  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
-  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
-  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
+  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+
+  # Managed Service URLs
+  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
+  BILLING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-billing-service.end_user_base_url}'
+  USER_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-user-service.auth_base_url}'
+
+  # Custom Service URLs
+  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.catalog-service.api}'
+
+secureVariables:
+  # Use this section to store any custom environment variables which contain sensitive data.
+
+  # Service Account Variables
   SERVICE_ACCOUNT_CLIENT_ID: '${__ax_hosted__.sa.client_id.primary}'
-  DRM_LICENSE_COMMUNICATION_KEY: [REPLACE_WITH_VALID_LICENSE_KEY]
   SERVICE_ACCOUNT_CLIENT_SECRET: '${__ax_hosted__.sa.client_secret.primary}'
-  DRM_LICENSE_COMMUNICATION_KEY_ID: [REPLACE_WITH_VALID_COMMUNICATION_KEY]
+
+  # GeoLite License Key
+  GEOLITE2_LICENSE_KEY: 'REPLACE_WITH_VALID_GEOLITE2_LICENSE_KEY'
+
+  # DRM License Communication Key and ID
+  DRM_LICENSE_COMMUNICATION_KEY: 'REPLACE_WITH_VALID_DRM_LICENSE_COMMUNICATION_KEY'
+  DRM_LICENSE_COMMUNICATION_KEY_ID: 'REPLACE_WITH_VALID_DRM_LICENSE_COMMUNICATION_KEY_ID'
+
 serviceAccounts:
   - name: 'primary'
     permissionStructure:
       - serviceId: 'ax-monetization-grants-service'
         permissions:
           - 'CLAIM_DEFINITIONS_SYNCHRONIZE'
-regularVariables:
-  PORT: '${__ax_hosted__.port.api}'
-  NODE_ENV: 'production'
-  DEMO_MODE: true
-  LOG_LEVEL: 'DEBUG'
-  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
-  SERVICE_ID: 'entitlement-service'
-  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
-  GRAPHQL_GUI_ENABLED: true
-  BILLING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-billing-service.end_user_base_url}'
-  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.catalog-service.api}'
-  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
-  USER_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-user-service.auth_base_url}'
+
+pilets:
+  # Defines the pilets (i.e. micro-frontends) associated with the service, and the required key-value pairs to run the pilet.
+  []
+
+dnsMappedPorts:
+  - name: 'api'
+    port: 11600

--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,35 +1,37 @@
-# This YAML contains the Deployment Configuration template
-# for Media Service.
-# This configuration file is required when deploying the service via
-# Mosaic Hosting Service.
-# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
-# mosaic hosting manifest upload
+# This YAML contains the Deployment Manifest for the Media Service.
+# It is required when deploying the service via the Mosaic Hosting Service.
+# Refer to the README.md file for instructions on how to use this.
 
 version: '1.0'
 serviceId: 'media-service'
-dnsMappedPorts:
-  - name: 'api'
-    port: 10200
-pilets:
-  - name: 'media_workflows'
-    args:
-      MEDIA_SERVICE_BASE_URL: 'https://${__ax_hosted__.dns.self.api}'
-serviceAccounts:
-  - name: 'primary'
-    permissionStructure:
-      - serviceId: 'ax-id-service'
-        permissions:
-          - 'PERMISSIONS_SYNCHRONIZE'
-          - 'ACCESS_TOKENS_GENERATE_LONG_LIVED_TOKEN'
-      - serviceId: 'ax-image-service'
-        permissions:
-          - 'IMAGE_TYPES_DECLARE'
+
 regularVariables:
+  # Service General Variables
+  SERVICE_ID: 'media-service'
+  NODE_ENV: 'production'
+  LOG_LEVEL: 'DEBUG'
+  GRAPHQL_GUI_ENABLED: true
+  PORT: '${__ax_hosted__.port.api}'
+
+  # Mosaic Environment Info
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+
+  # Database Server Variables
+  PGSSLMODE: '${__ax_hosted__.pg.sslmode}'
   POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
   POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
   POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
-  PGSSLMODE: '${__ax_hosted__.pg.sslmode}'
+
+  # Database Variables
   DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
+  DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
+
+  # RabbitMQ Variables
   RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
   RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
   RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
@@ -37,23 +39,41 @@ regularVariables:
   RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
   RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
   RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
-  NODE_ENV: 'production'
-  SERVICE_ID: 'media-service'
-  LOG_LEVEL: 'DEBUG'
-  GRAPHQL_GUI_ENABLED: true
-  PORT: '${__ax_hosted__.port.api}'
-  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
-  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
-  IMAGE_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-image-service.management_base_url}'
-  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
-  ENCODING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-encoding-service.management_base_url}'
-secureVariables:
   RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
   RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
-  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
-  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
-  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
-  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
-  DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
+
+  # Managed Service URLs
+  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
+  IMAGE_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-image-service.management_base_url}'
+  ENCODING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-encoding-service.management_base_url}'
+
+secureVariables:
+  # Use this section to store any custom environment variables which contain sensitive data.
+
+  # Service Account Variables
   SERVICE_ACCOUNT_CLIENT_ID: '${__ax_hosted__.sa.client_id.primary}'
   SERVICE_ACCOUNT_CLIENT_SECRET: '${__ax_hosted__.sa.client_secret.primary}'
+
+serviceAccounts:
+  # Defines the service accounts that will be provisioned for this service.
+  - name: 'primary'
+    permissionStructure:
+      - serviceId: 'ax-id-service'
+        permissions:
+          - 'PERMISSIONS_SYNCHRONIZE'
+          - 'ACCESS_TOKENS_GENERATE_LONG_LIVED_TOKEN'
+
+      - serviceId: 'ax-image-service'
+        permissions:
+          - 'IMAGE_TYPES_DECLARE'
+
+pilets:
+  # Defines the pilets (i.e. micro-frontends) associated with the service, and the required key-value pairs to run the pilet.
+  - name: 'media_workflows'
+    args:
+      MEDIA_SERVICE_BASE_URL: 'https://${__ax_hosted__.dns.self.api}'
+
+dnsMappedPorts:
+  # Defines the DNS subdomains that will provisioned and be mapped to the ports exposed by the service
+  - name: 'api'
+    port: 10200

--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -45,7 +45,6 @@ regularVariables:
   TENANT_ID: '${__ax_hosted__.env.tenant_id}'
   ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
   IMAGE_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-image-service.management_base_url}'
-  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.ax-catalog-service.api}'
   ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
   ENCODING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-encoding-service.management_base_url}'
 secureVariables:

--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,0 +1,60 @@
+# This YAML contains the Deployment Configuration template
+# for Media Service.
+# This configuration file is required when deploying the service via
+# Mosaic Hosting Service.
+# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
+# mosaic hosting manifest upload
+
+version: '1.0'
+serviceId: 'media-service'
+dnsMappedPorts:
+  - name: 'api'
+    port: 10200
+pilets:
+  - name: 'media_workflows'
+    args:
+      MEDIA_SERVICE_BASE_URL: 'https://${__ax_hosted__.dns.self.api}'
+serviceAccounts:
+  - name: 'primary'
+    permissionStructure:
+      - serviceId: 'ax-id-service'
+        permissions:
+          - 'PERMISSIONS_SYNCHRONIZE'
+          - 'ACCESS_TOKENS_GENERATE_LONG_LIVED_TOKEN'
+      - serviceId: 'ax-image-service'
+        permissions:
+          - 'IMAGE_TYPES_DECLARE'
+regularVariables:
+  POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
+  POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
+  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
+  PGSSLMODE: '${__ax_hosted__.pg.sslmode}'
+  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
+  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
+  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
+  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
+  RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
+  RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
+  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+  NODE_ENV: 'production'
+  SERVICE_ID: 'media-service'
+  LOG_LEVEL: 'DEBUG'
+  GRAPHQL_GUI_ENABLED: true
+  PORT: '${__ax_hosted__.port.api}'
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+  IMAGE_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-image-service.management_base_url}'
+  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.ax-catalog-service.api}'
+  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
+  ENCODING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-encoding-service.management_base_url}'
+secureVariables:
+  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
+  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
+  DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
+  SERVICE_ACCOUNT_CLIENT_ID: '${__ax_hosted__.sa.client_id.primary}'
+  SERVICE_ACCOUNT_CLIENT_SECRET: '${__ax_hosted__.sa.client_secret.primary}'


### PR DESCRIPTION
- Add `mosaic-hosting-deployment-manifest.yaml` files to media, catalog and entitlement services.
- Add new script `setup:hosting` in root `package.json`.
- Update `.env.template` to reflect new Hosting related env vars.