### PR TITLE
[AB#39236] Change Isolation Level to RepeatableRead when publishing entities

### DIFF
--- a/services/media/service/src/publishing/handlers/publish-entity-command-handler.ts
+++ b/services/media/service/src/publishing/handlers/publish-entity-command-handler.ts
@@ -52,7 +52,7 @@ export class PublishEntityCommandHandler extends MediaGuardedMessageHandler<Publ
   ): Promise<void> {
     await transactionWithContext(
       this.loginPool,
-      IsolationLevel.Serializable,
+      IsolationLevel.RepeatableRead,
       await this.getPgSettings(messageInfo),
       async (tnxClient) => {
         const payloadTable = payload.table_name as Table;


### PR DESCRIPTION
The Isolation Level for the transaction when publishing entities was changed from Serializable to RepeatableRead. 

Test Notes:
Before, the serialize errors came up even when publishing 6 items in bulk. Tested with publishing 100 movie entities in bulk and the error was not re-created.