### PR TITLE
[AB#41127] Update video-service base URL reference of hosting-service YAML

### DIFF
--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -45,7 +45,7 @@ regularVariables:
   # Managed Service URLs
   ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
   IMAGE_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-image-service.management_base_url}'
-  ENCODING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-encoding-service.management_base_url}'
+  VIDEO_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-video-service.management_base_url}'
 
 secureVariables:
   # Use this section to store any custom environment variables which contain sensitive data.


### PR DESCRIPTION
- the deployment manifest YAML file of media-service is updated to have correct placeholder values of video-service

For Testers:
- verify by deploying media-service via hosting-service
  - build the updated media-service and push to docker registry
  - upload the new deployment manifest for media-service
  - deploying the service using latest docker image & deployment manifest
  - ensure no errors occur