### PR TITLE
[AB#41155] Update media deployment manifest

### DIFF
--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -69,9 +69,11 @@ serviceAccounts:
 
 pilets:
   # Defines the pilets (i.e. micro-frontends) associated with the service, and the required key-value pairs to run the pilet.
-  - name: 'media_workflows'
+  # Use the pilet's package name as the 'name', and any ENV arguments required by the pilet under 'args'.
+  - name: 'media-workflows'
     args:
-      MEDIA_SERVICE_BASE_URL: 'https://${__ax_hosted__.dns.self.api}'
+      MEDIA_MANAGEMENT_HOST: '${__ax_hosted__.dns.self.api}'
+      MEDIA_MANAGEMENT_HTTP_PROTOCOL: 'https'
 
 dnsMappedPorts:
   # Defines the DNS subdomains that will provisioned and be mapped to the ports exposed by the service


### PR DESCRIPTION
- Updated the deployment manifest of media-service to contain the correct values for the pilets section

Testing Notes:
- Ensure deploying the media-service via hosting-service works as expected, and the workflows are able to connect with the media-service backend (i.e. when visiting the "Movies" station there shall not be any exceptions)