### PR TITLE
[AB#40831] added a workaround to jest memory leak issue for CI PR builds

### DIFF
--- a/.adops/pull-request.yml
+++ b/.adops/pull-request.yml
@@ -2,6 +2,7 @@ trigger: none
 pr:
   - main
   - dev
+  - feature/localization #TODO: Remove when it is time to merge this branch into dev
 pool:
   vmImage: 'ubuntu-latest'
   demands: project_navy

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,7 +2,6 @@ import type { JestConfigWithTsJest } from 'ts-jest';
 
 const jestConfig: JestConfigWithTsJest = {
   preset: 'ts-jest',
-  testTimeout: 60000,
   modulePathIgnorePatterns: ['./dist/'],
   setupFilesAfterEnv: ['jest-expect-message', 'jest-extended/all'],
   projects: [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev:workflows": "yarn util:portal-version-check && yarn util:load-vars cross-env-shell pilet debug 'services/**/workflows/src/index.tsx' --feed '\\$MICRO_FRONTEND_SERVICE_BASE_URL/v1/pilets/\\$TENANT_ID/\\$ENVIRONMENT_ID' --port 10053",
     "dev:workflows:local": "pilet debug 'services/**/workflows/src/index.tsx' --port 10053",
     "test": "yarn util:load-vars jest --silent",
-    "test:ci": "jest --silent --reporters=default --reporters=jest-junit --coverage --coverageReporters=cobertura",
+    "test:ci": "jest --silent --reporters=default --reporters=jest-junit --coverage --coverageReporters=cobertura --maxWorkers=2",
     "test:reset:dbs": "wsrun -sm test:reset:dbs",
     "test:create:dbs": "wsrun -sm test:create:dbs",
     "db:reset": "wsrun -sm db:reset",

--- a/scripts/jest.config.ts
+++ b/scripts/jest.config.ts
@@ -9,7 +9,7 @@ const jestConfig: JestConfigWithTsJest = {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
-        esModuleInterop: true,
+        diagnostics: { ignoreCodes: ['TS151001'] },
       },
     ],
   },

--- a/services/catalog/service/jest.config.ts
+++ b/services/catalog/service/jest.config.ts
@@ -3,9 +3,13 @@ import type { JestConfigWithTsJest } from 'ts-jest';
 const jestConfig: JestConfigWithTsJest = {
   preset: 'ts-jest',
   modulePathIgnorePatterns: ['./dist/', './legacy/'],
-  setupFilesAfterEnv: ['jest-expect-message', 'jest-extended/all'],
+  setupFilesAfterEnv: [
+    'jest-expect-message',
+    'jest-extended/all',
+    '<rootDir>/jest.setup.ts',
+  ],
   displayName: 'catalog-service',
-  testTimeout: 60000,
+  workerIdleMemoryLimit: '1GB',
 };
 
 export default jestConfig;

--- a/services/catalog/service/jest.setup.ts
+++ b/services/catalog/service/jest.setup.ts
@@ -1,0 +1,9 @@
+import { url as debugUrl } from 'inspector';
+
+//TODO: Move this to jest.config.js as `testTimeout` property when this issue is
+//resolved: https://github.com/facebook/jest/issues/9696
+if (debugUrl() !== undefined) {
+  jest.setTimeout(60000); // wait for longer when debugging a test
+} else {
+  jest.setTimeout(30000);
+}

--- a/services/catalog/service/jest.setup.ts
+++ b/services/catalog/service/jest.setup.ts
@@ -3,7 +3,7 @@ import { url as debugUrl } from 'inspector';
 //TODO: Move this to jest.config.js as `testTimeout` property when this issue is
 //resolved: https://github.com/facebook/jest/issues/9696
 if (debugUrl() !== undefined) {
-  jest.setTimeout(60000); // wait for longer when debugging a test
+  jest.setTimeout(900_000); // wait for longer when debugging a test
 } else {
-  jest.setTimeout(30000);
+  jest.setTimeout(30_000);
 }

--- a/services/entitlement/service/jest.config.ts
+++ b/services/entitlement/service/jest.config.ts
@@ -3,9 +3,13 @@ import type { JestConfigWithTsJest } from 'ts-jest';
 const jestConfig: JestConfigWithTsJest = {
   preset: 'ts-jest',
   modulePathIgnorePatterns: ['./dist/', './legacy/'],
-  setupFilesAfterEnv: ['jest-expect-message', 'jest-extended/all'],
+  setupFilesAfterEnv: [
+    'jest-expect-message',
+    'jest-extended/all',
+    '<rootDir>/jest.setup.ts',
+  ],
   displayName: 'entitlement-service',
-  testTimeout: 60000,
+  workerIdleMemoryLimit: '1GB',
 };
 
 export default jestConfig;

--- a/services/entitlement/service/jest.setup.ts
+++ b/services/entitlement/service/jest.setup.ts
@@ -1,0 +1,9 @@
+import { url as debugUrl } from 'inspector';
+
+//TODO: Move this to jest.config.js as `testTimeout` property when this issue is
+//resolved: https://github.com/facebook/jest/issues/9696
+if (debugUrl() !== undefined) {
+  jest.setTimeout(60000); // wait for longer when debugging a test
+} else {
+  jest.setTimeout(30000);
+}

--- a/services/entitlement/service/jest.setup.ts
+++ b/services/entitlement/service/jest.setup.ts
@@ -3,7 +3,7 @@ import { url as debugUrl } from 'inspector';
 //TODO: Move this to jest.config.js as `testTimeout` property when this issue is
 //resolved: https://github.com/facebook/jest/issues/9696
 if (debugUrl() !== undefined) {
-  jest.setTimeout(60000); // wait for longer when debugging a test
+  jest.setTimeout(900_000); // wait for longer when debugging a test
 } else {
-  jest.setTimeout(30000);
+  jest.setTimeout(30_000);
 }

--- a/services/media/service/jest.config.ts
+++ b/services/media/service/jest.config.ts
@@ -3,9 +3,13 @@ import type { JestConfigWithTsJest } from 'ts-jest';
 const jestConfig: JestConfigWithTsJest = {
   preset: 'ts-jest',
   modulePathIgnorePatterns: ['./dist/', './legacy/'],
-  setupFilesAfterEnv: ['jest-expect-message', 'jest-extended/all'],
+  setupFilesAfterEnv: [
+    'jest-expect-message',
+    'jest-extended/all',
+    '<rootDir>/jest.setup.ts',
+  ],
   displayName: 'media-service',
-  testTimeout: 60000,
+  workerIdleMemoryLimit: '1GB',
 };
 
 export default jestConfig;

--- a/services/media/service/jest.setup.ts
+++ b/services/media/service/jest.setup.ts
@@ -1,0 +1,4 @@
+//TODO: Move this to jest.config.js as `testTimeout` property when this issue is
+//resolved: https://github.com/facebook/jest/issues/9696
+//media service has some long-running tests compared to other services
+jest.setTimeout(60000);

--- a/services/media/service/jest.setup.ts
+++ b/services/media/service/jest.setup.ts
@@ -1,4 +1,9 @@
+import { url as debugUrl } from 'inspector';
+
 //TODO: Move this to jest.config.js as `testTimeout` property when this issue is
 //resolved: https://github.com/facebook/jest/issues/9696
-//media service has some long-running tests compared to other services
-jest.setTimeout(60000);
+if (debugUrl() !== undefined) {
+  jest.setTimeout(900_000); // wait for longer when debugging a test
+} else {
+  jest.setTimeout(60_000); // media service has some long-running tests compared to other services
+}

--- a/services/vod-to-live/service/jest.config.ts
+++ b/services/vod-to-live/service/jest.config.ts
@@ -3,9 +3,9 @@ import type { JestConfigWithTsJest } from 'ts-jest';
 const jestConfig: JestConfigWithTsJest = {
   preset: 'ts-jest',
   modulePathIgnorePatterns: ['./dist/', './legacy/'],
-  setupFilesAfterEnv: ['jest-expect-message'],
+  setupFilesAfterEnv: ['jest-expect-message', '<rootDir>/jest.setup.ts'],
   displayName: 'vod-to-live-service',
-  testTimeout: 60000,
+  workerIdleMemoryLimit: '1GB',
 };
 
 export default jestConfig;

--- a/services/vod-to-live/service/jest.setup.ts
+++ b/services/vod-to-live/service/jest.setup.ts
@@ -1,0 +1,9 @@
+import { url as debugUrl } from 'inspector';
+
+//TODO: Move this to jest.config.js as `testTimeout` property when this issue is
+//resolved: https://github.com/facebook/jest/issues/9696
+if (debugUrl() !== undefined) {
+  jest.setTimeout(60000); // wait for longer when debugging a test
+} else {
+  jest.setTimeout(30000);
+}

--- a/services/vod-to-live/service/jest.setup.ts
+++ b/services/vod-to-live/service/jest.setup.ts
@@ -3,7 +3,7 @@ import { url as debugUrl } from 'inspector';
 //TODO: Move this to jest.config.js as `testTimeout` property when this issue is
 //resolved: https://github.com/facebook/jest/issues/9696
 if (debugUrl() !== undefined) {
-  jest.setTimeout(60000); // wait for longer when debugging a test
+  jest.setTimeout(900_000); // wait for longer when debugging a test
 } else {
-  jest.setTimeout(30000);
+  jest.setTimeout(30_000);
 }


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

- Starting with Node 16.11 - Jest has a memory leak issue. 
- There is no good fix, just workarounds.
- There is an extensive Github issue with a lot of info. 2 handy summary posts from it:
   - https://github.com/jestjs/jest/issues/11956#issuecomment-1373844452
   - https://github.com/jestjs/jest/issues/11956#issuecomment-1428306364
- There is a relatively recent Node draft PR with a potential fix:
   - https://github.com/nodejs/node/pull/48510
- Applied workaround:
   - Set `workerIdleMemoryLimit: '1GB',` for jest configs of services
   - Set `--maxWorkers=2` for `test:ci` script
- Also adjusted jest config to cleanup some jest warnings furing execution of tests.