### PR TITLE
[AB#40224] Cleanup RabbitMQ queues and bindings for the Video Service renaming

### DIFF
--- a/services/media/service/package.json
+++ b/services/media/service/package.json
@@ -33,6 +33,7 @@
     "db:update-schema": "yarn util:load-vars ts-node --files scripts/db-reset-shadow.ts && yarn util:pg-dump",
     "setup": "yarn util:load-vars ts-node --files scripts/setup.ts",
     "codegen": "graphql-codegen -r dotenv/config --config codegen.yml",
+    "migrate:rmq-video": "yarn util:load-vars ts-node --files scripts/migrate-rabbitmq-for-video-service.ts",
     " -- internal scripts, do not change -- ": "",
     "internal:zapatos": "yarn util:load-vars ts-node --files scripts/codegen-zapatos.ts current",
     "internal:zapatos:committed": "yarn util:load-vars ts-node --files scripts/codegen-zapatos.ts",

--- a/services/media/service/scripts/migrate-rabbitmq-for-video-service.ts
+++ b/services/media/service/scripts/migrate-rabbitmq-for-video-service.ts
@@ -1,0 +1,72 @@
+/* eslint-disable no-console */
+import { getValidatedConfig, pick } from '@axinom/mosaic-service-common';
+import { connect } from 'amqplib';
+import { getConfigDefinitions } from '../src/common';
+
+async function main(): Promise<void> {
+  const configDefinitions = pick(
+    getConfigDefinitions(),
+    'rmqProtocol',
+    'rmqHost',
+    'rmqPort',
+    'rmqUser',
+    'rmqPassword',
+    'rmqVHost',
+    'serviceId',
+  );
+  const config = getValidatedConfig(configDefinitions);
+  const amqp = await connect(
+    {
+      protocol: config.rmqProtocol,
+      hostname: config.rmqHost,
+      port: config.rmqPort,
+      username: config.rmqUser,
+      password: config.rmqPassword,
+      vhost: config.rmqVHost,
+    },
+    {
+      connection_name: 'migrate-rabbitmq-for-video-service-renaming',
+    },
+  );
+  const channel = await amqp.createChannel();
+
+  // delete obsolete queues
+  await channel.deleteQueue('ax-encoding-service:cue_point_types:declare');
+  await channel.deleteQueue('ax-encoding-service:video:ensure_exists');
+
+  // remove obsolete bindings
+  await channel.unbindQueue(
+    'media-service:video:ensure_exists_already_existed',
+    'event',
+    'ax-encoding-service.*.*.video.ensure_exists_already_existed',
+  );
+  await channel.unbindQueue(
+    'media-service:video:ensure_exists_creation_started',
+    'event',
+    'ax-encoding-service.*.*.video.ensure_exists_creation_started',
+  );
+  await channel.unbindQueue(
+    'media-service:video:ensure_exists_failed',
+    'event',
+    'ax-encoding-service.*.*.video.ensure_exists_failed',
+  );
+  await channel.unbindQueue(
+    'media-service:cue_point_types:declared',
+    'event',
+    'ax-encoding-service.*.*.cue_point_types.declared',
+  );
+  await channel.unbindQueue(
+    'media-service:cue_point_types:declare_failed',
+    'event',
+    'ax-encoding-service.*.*.cue_point_types.declare_failed',
+  );
+
+  channel.close();
+  amqp.close();
+  console.log('Migration finished.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [X] My code follows the coding conventions
- [X] All tests pass

## Description

The Mosaic Encoding Service was renamed to Mosaic Video Service. This is done in a backward compatible way so events are sent both with the new and old message types. This requires a cleanup of the queue bindings for not receiving a message twice in the Media Service.

## Release Notes

The Mosaic Encoding Service was renamed to Mosaic Video Service. This means you should upgrade the mosaic libraries to the latest version which provides you with all the adjustments. The adjustment also affected the RabbitMQ queues that were used for video encodings. Those obsolete queues need to be removed now. Please stop your Media Service instance, deploy the latest version, run yarn migrate:rmq-video, and then start the Media Service normally.