### PR TITLE
[AB#41002] channel pre-publishing webhook validation message is now more detailed

### DIFF
--- a/services/vod-to-live/service/src/common/errors/validation-errors.ts
+++ b/services/vod-to-live/service/src/common/errors/validation-errors.ts
@@ -30,8 +30,9 @@ export const ValidationErrors = {
     message: 'The playlist cannot begin and end with an "AD_POD".',
     code: 'PLAYLIST_CANNOT_START_AND_END_WITH_AD_POD',
   },
-  PlaylistVideosHaveNoMutualStreams: {
-    message: 'The videos in the playlist do not share a common stream format.',
+  PlaceholderAndPlaylistVideosHaveNoMutualStreams: {
+    message:
+      'The placeholder video and playlist video(s) must each have at least one stream with the same resolution, frame rate, and bitrate.',
     code: 'PLAYLIST_VIDEOS_HAVE_NO_MUTUAL_STREAMS',
   },
   PlaylistPlaceholderVideoWasNotFound: {

--- a/services/vod-to-live/service/src/domains/validation/playlist-published-validation-handler.spec.ts
+++ b/services/vod-to-live/service/src/domains/validation/playlist-published-validation-handler.spec.ts
@@ -972,7 +972,7 @@ describe('PlaylistPublishedValidationWebhookHandler', () => {
       expect(validationResult.warnings).toHaveLength(0);
       expect(validationResult.errors).toHaveLength(1);
       expect(validationResult.errors).toMatchObject([
-        ValidationErrors.PlaylistVideosHaveNoMutualStreams,
+        ValidationErrors.PlaceholderAndPlaylistVideosHaveNoMutualStreams,
       ]);
     });
 

--- a/services/vod-to-live/service/src/domains/validation/playlist-published-validation-handler.ts
+++ b/services/vod-to-live/service/src/domains/validation/playlist-published-validation-handler.ts
@@ -155,7 +155,7 @@ export class PlaylistPublishedValidationWebhookHandler
         ]);
         if (mutualStreams.length < 1) {
           validationResult.errors.push(
-            ValidationErrors.PlaylistVideosHaveNoMutualStreams,
+            ValidationErrors.PlaceholderAndPlaylistVideosHaveNoMutualStreams,
           );
         }
       } else {


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Testing notes

- Have an environment with enabled channel service and a configured webhook pointing to the VOD-to-live service
- Create a channel with a placeholder video and publish it (should pass)
- Create a playlist with a single program item with assigned movie that has main video, which has no common streams with channel placeholder video (different width, height, framerate, and bitrate in all streams)
- Try publishing the playlist
- Publish validation should have a message: `The placeholder video and playlist video(s) must each have at least one stream with the same resolution, frame rate, and bitrate.` (the previous message was less descriptive)


