### PR TITLE
Fix setup:hosting script

### DIFF
--- a/scripts/setup-hosting.ts
+++ b/scripts/setup-hosting.ts
@@ -51,6 +51,7 @@ async function main(): Promise<void> {
       {
         serviceId: 'ax-hosting-service',
         permissions: [
+          'CONFIGURATIONS_VIEW',
           'SERVICE_DEFINITIONS_VIEW',
           'CONTAINER_REGISTRY_CONNECTIONS_VIEW',
           'SERVICE_PILET_ARTIFACTS_EDIT',


### PR DESCRIPTION
- the hosting-cli needs to have `CONFIGURATIONS_VIEW` permission, and is now added to the `yarn setup:hosting` script

Testing Notes:
- When deploying media-service via the CLI, there should not be any errors for missing permission `CONFIGURATIONS_VIEW`