### PR TITLE
[AB#36747] Use ID service availability check on customizable services

### DIFF
--- a/services/entitlement/service/src/index.ts
+++ b/services/entitlement/service/src/index.ts
@@ -17,6 +17,7 @@ import {
 import {
   closeHttpServer,
   handleGlobalErrors,
+  isServiceAvailable,
   Logger,
   MosaicErrors,
   setupGlobalConsoleOverride,
@@ -24,6 +25,7 @@ import {
   setupGlobalSkipMaskMiddleware,
   setupLivenessAndReadiness,
   setupMonitoring,
+  setupServiceHealthEndpoint,
   setupShutdownActions,
   tenantEnvironmentIdsLogMiddleware,
   trimErrorsSkipMaskMiddleware,
@@ -55,6 +57,16 @@ async function bootstrap(): Promise<void> {
   updateGeoDatabase(config);
 
   const { readiness } = setupLivenessAndReadiness(config);
+
+  // Check ID service is available
+  if (!(await isServiceAvailable(config.idServiceAuthBaseUrl))) {
+    throw new Error(
+      'The Mosaic Identity Service is required to run this service, but it was not available.',
+    );
+  }
+
+  // Register service health endpoint
+  setupServiceHealthEndpoint(app, config.port);
 
   await applyMigrations(config);
 


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

For Release Notes:

- A new method setupServiceHealthEndpoint is introduced to the @axinom/mosaic-service-common library. It exposes a /health route on the service API URL, that can be used to check for a HTTP 200 OK response to determine if a service is available for use. Optionally, the response body may also contain an arbitrary JSON document specified by the service that describes the health of individual components of the service. See https://github.com/Axinom/mosaic-media-template/pull/158 for more details on its usage.
- A new method isServiceAvailable is introduced to the @axinom/mosaic-service-common library. This method will query the route configured via the setupServiceHealthEndpoint method to check if the target service is available for use. If the response contains a HTTP 200 response code, it will return true, else will return false. The method will retry the availability check for a default 15 attempts with an exponential back-off strategy before returning false. See https://github.com/Axinom/mosaic-media-template/pull/158 for more details on its usage.
