### PR TITLE
[AB#41576] add missing video service permission to the hosting manifest

### DIFF
--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -67,6 +67,10 @@ serviceAccounts:
         permissions:
           - 'IMAGE_TYPES_DECLARE'
 
+      - serviceId: 'ax-video-service'
+        permissions:
+          - 'CUE_POINT_TYPES_DECLARE'
+
 pilets:
   # Defines the pilets (i.e. micro-frontends) associated with the service, and the required key-value pairs to run the pilet.
   # Use the pilet's package name as the 'name', and any ENV arguments required by the pilet under 'args'.


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

Previously omitted permission to declare cue points in video service added to the hosting manifest.
