### PR TITLE
[AB#36747] Use ID service availability check on customizable services

### DIFF
--- a/services/catalog/service/package.json
+++ b/services/catalog/service/package.json
@@ -44,7 +44,7 @@
     "@axinom/mosaic-db-common": "0.25.3",
     "@axinom/mosaic-message-bus": "0.15.0",
     "@axinom/mosaic-message-bus-abstractions": "0.5.8",
-    "@axinom/mosaic-service-common": "0.36.0",
+    "@axinom/mosaic-service-common": "0.37.0-rc.17",
     "@axinom/mosaic-graphql-common": "0.1.0",
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "add": "^2.0.6",

--- a/services/catalog/service/src/index.ts
+++ b/services/catalog/service/src/index.ts
@@ -51,7 +51,7 @@ async function bootstrap(): Promise<void> {
   }
 
   // Register service health endpoint
-  setupServiceHealthEndpoint(app, config.port);
+  setupServiceHealthEndpoint(app);
 
   await applyMigrations(config);
   const shutdownActions = setupShutdownActions(app, logger);

--- a/services/entitlement/service/package.json
+++ b/services/entitlement/service/package.json
@@ -51,7 +51,7 @@
     "@axinom/mosaic-id-utils": "0.15.5",
     "@axinom/mosaic-message-bus": "0.15.0",
     "@axinom/mosaic-messages": "0.31.0",
-    "@axinom/mosaic-service-common": "0.36.0",
+    "@axinom/mosaic-service-common": "0.37.0-rc.17",
     "@axinom/mosaic-graphql-common": "0.1.0",
     "ajv": "^7.2.4",
     "ajv-formats": "^1.6.1",

--- a/services/entitlement/service/src/index.ts
+++ b/services/entitlement/service/src/index.ts
@@ -66,7 +66,7 @@ async function bootstrap(): Promise<void> {
   }
 
   // Register service health endpoint
-  setupServiceHealthEndpoint(app, config.port);
+  setupServiceHealthEndpoint(app);
 
   await applyMigrations(config);
 

--- a/services/entitlement/service/src/index.ts
+++ b/services/entitlement/service/src/index.ts
@@ -17,6 +17,7 @@ import {
 import {
   closeHttpServer,
   handleGlobalErrors,
+  isServiceAvailable,
   Logger,
   MosaicErrors,
   setupGlobalConsoleOverride,
@@ -24,6 +25,7 @@ import {
   setupGlobalSkipMaskMiddleware,
   setupLivenessAndReadiness,
   setupMonitoring,
+  setupServiceHealthEndpoint,
   setupShutdownActions,
   tenantEnvironmentIdsLogMiddleware,
   trimErrorsSkipMaskMiddleware,
@@ -55,6 +57,16 @@ async function bootstrap(): Promise<void> {
   updateGeoDatabase(config);
 
   const { readiness } = setupLivenessAndReadiness(config);
+
+  // Check ID service is available
+  if (!(await isServiceAvailable(config.idServiceAuthBaseUrl))) {
+    throw new Error(
+      'The Mosaic Identity Service is required to run this service, but it was not available.',
+    );
+  }
+
+  // Register service health endpoint
+  setupServiceHealthEndpoint(app, config.port);
 
   await applyMigrations(config);
 

--- a/services/media/service/package.json
+++ b/services/media/service/package.json
@@ -52,7 +52,7 @@
     "@axinom/mosaic-message-bus": "0.15.0",
     "@axinom/mosaic-message-bus-abstractions": "0.5.8",
     "@axinom/mosaic-messages": "0.31.0",
-    "@axinom/mosaic-service-common": "0.36.0",
+    "@axinom/mosaic-service-common": "0.37.0-rc.17",
     "@axinom/mosaic-graphql-common": "0.1.0",
     "@faker-js/faker": "^7.5.0",
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",

--- a/services/media/service/src/index.ts
+++ b/services/media/service/src/index.ts
@@ -80,7 +80,7 @@ async function bootstrap(): Promise<void> {
   }
 
   // Register service health endpoint
-  setupServiceHealthEndpoint(app, config.port);
+  setupServiceHealthEndpoint(app);
 
   // Enable multipart request support for GQL to support file upload.
   app.use(graphqlUploadExpress());

--- a/services/vod-to-live/service/package.json
+++ b/services/vod-to-live/service/package.json
@@ -31,7 +31,7 @@
     "@axinom/mosaic-id-guard": "0.20.7",
     "@axinom/mosaic-message-bus": "0.15.0",
     "@axinom/mosaic-messages": "0.31.0",
-    "@axinom/mosaic-service-common": "0.36.0",
+    "@axinom/mosaic-service-common": "0.37.0-rc.17",
     "@azure/storage-blob": "^12.12.0",
     "amqplib": "^0.6.0",
     "axios": "^0.24.0",

--- a/services/vod-to-live/service/src/index.ts
+++ b/services/vod-to-live/service/src/index.ts
@@ -51,7 +51,7 @@ async function bootstrap(): Promise<void> {
   }
 
   // Register service health endpoint
-  setupServiceHealthEndpoint(app, config.port);
+  setupServiceHealthEndpoint(app);
 
   const shutdownActions = setupShutdownActions(app, logger);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,7 +333,33 @@
   resolved "https://registry.yarnpkg.com/@axinom/mosaic-portal/-/mosaic-portal-0.19.0.tgz#b489bdf472d52acd4c6084379b7a4e6dca953097"
   integrity sha512-ncZirnRgNE3Msb8nW43OCa3BD7orJlydXphN9hAqY3xRgoTBhOD8Pm6O3GKMjjfNVhUECPyDlkSjHN8uU/DZDQ==
 
-"@axinom/mosaic-service-common@0.36.0", "@axinom/mosaic-service-common@^0.36.0":
+"@axinom/mosaic-service-common@0.37.0-rc.17":
+  version "0.37.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@axinom/mosaic-service-common/-/mosaic-service-common-0.37.0-rc.17.tgz#2550b053bf7f49d77e53f7933796aa38eaf4b65f"
+  integrity sha512-u6I4e2jM/VSQqXq1SB1yWWlgGSzYAg+lLmFZRHY5piIfHBPYmMfH+OcQrVBmK5M7hYJZKylC36BPurbqk/Q7Ug==
+  dependencies:
+    ajv "^7.0.3"
+    ajv-formats "^2.1.1"
+    axios "^0.19.2"
+    cockatiel "^3.1.1"
+    endent "^2.1.0"
+    env-var "^6.3.0"
+    express "^4.17.1"
+    express-basic-auth "^1.2.1"
+    fast-stable-stringify "^1.0.0"
+    inflection "^1.12.0"
+    jest "^29"
+    jest-expect-message "^1.1.3"
+    moment "^2.29.1"
+    pg "^8.5.1"
+    prom-client "^13.2.0"
+    serialize-error "^7.0.1"
+    short-hash "^1.0.0"
+    uuid "^8.3.2"
+    uuid-encoder "^1.2.0"
+    verror "^1.10.1"
+
+"@axinom/mosaic-service-common@^0.36.0":
   version "0.36.0"
   resolved "https://registry.yarnpkg.com/@axinom/mosaic-service-common/-/mosaic-service-common-0.36.0.tgz#4519e6dd59cab07f23311a722c1e2fa7632bca2b"
   integrity sha512-qQ4Avs/mt/1oeuNJlj18iXyjUx8XegpCK0zJmKnzh+mHpI4WjWTvnazuqlixKmy47x+JcG5nTon3mY6QesexvQ==
@@ -4997,6 +5023,11 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
+
+cockatiel@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/cockatiel/-/cockatiel-3.1.1.tgz#82c95dcad673649c43c0a35c424c5d2ad59d4e6b"
+  integrity sha512-zHMqBGvkZLfMKkBMD+0U8X1nW8zYwMtymgJ8CTknWOmTDpvjEwygtFN4QR9A1iFQDwCbg8g8+B/zVBoxvj1feQ==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description
- `setupServiceHealthEndpoint` is used to register a health endpoint in each customizable-service.
- `isServiceAvailable` is used to ensure Mosaic ID Service is available on service bootstrap.

## For Release Notes:
- A new method `setupServiceHealthEndpoint` is introduced to the `@axinom/mosaic-service-common` library. It exposes a `/health` route on the service API URL, that can be used to check for a HTTP 200 OK response to determine if a service is available for use. Optionally, the response body may also contain an arbitrary JSON document specified by the service that describes the health of individual components of the service. See [this PR](https://github.com/Axinom/mosaic-media-template/pull/158) for more details on its usage.
- A new method `isServiceAvailable` is introduced to the `@axinom/mosaic-service-common` library. This method will query the route configured via the `setupServiceHealthEndpoint` method to check if the target service is available for use. If the response contains a HTTP 200 response code, it will return `true`, else will return `false`. The method will retry the availability check for a default 15 attempts with an exponential back-off strategy before returning `false`. See [this PR](https://github.com/Axinom/mosaic-media-template/pull/158) for more details on its usage.

## For Testing Notes:
- You can send request to /health end point and can check that endpoint is working. Can check for any manage service, not only for id-service. 
- This is for id-service,
Ex: https://id.service.test.axinom.net/health
- Should return empty json object with 200 ok response code.