### PR TITLE
[AB#24206] text search gin indexes are now being triggered

### DIFF
--- a/services/catalog/service/migrations/after-reset/install-extensions.sql
+++ b/services/catalog/service/migrations/after-reset/install-extensions.sql
@@ -7,6 +7,6 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public; -- used for gener
 
 -- This ensures that ILIKE gin indexes from pg_trgm extension are triggered
 -- when used together with RLS.
--- e.g. `SELECT ax_utils.define_like_index('title', 'entities', 'app_public');`
+-- e.g. `SELECT ax_define.define_like_index('title', 'entities', 'app_public');`
 -- More context: https://www.postgresql.org/message-id/CAGrP7a3PwDYJhPe53yE6pBPPNxk2Ve4n%2BdPQMS1HcBU6swXYfA%40mail.gmail.com
 ALTER FUNCTION pg_catalog.texticlike LEAKPROOF;

--- a/services/catalog/service/migrations/after-reset/install-extensions.sql
+++ b/services/catalog/service/migrations/after-reset/install-extensions.sql
@@ -4,3 +4,9 @@
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public; -- used for generation of short unique string values, e.g. salt in extenal_id
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public; -- used for gin indexes which optimize requests that use LIKE/ILIKE operators, e.g. filter by title
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public; -- used for generating UUID values for PK fields
+
+-- This ensures that ILIKE gin indexes from pg_trgm extension are triggered
+-- when used together with RLS.
+-- e.g. `SELECT ax_utils.define_like_index('title', 'entities', 'app_public');`
+-- More context: https://www.postgresql.org/message-id/CAGrP7a3PwDYJhPe53yE6pBPPNxk2Ve4n%2BdPQMS1HcBU6swXYfA%40mail.gmail.com
+ALTER FUNCTION pg_catalog.texticlike LEAKPROOF;

--- a/services/entitlement/service/migrations/after-reset/install-extensions.sql
+++ b/services/entitlement/service/migrations/after-reset/install-extensions.sql
@@ -7,6 +7,6 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public; -- used for gener
 
 -- This ensures that ILIKE gin indexes from pg_trgm extension are triggered
 -- when used together with RLS.
--- e.g. `SELECT ax_utils.define_like_index('title', 'entities', 'app_public');`
+-- e.g. `SELECT ax_define.define_like_index('title', 'entities', 'app_public');`
 -- More context: https://www.postgresql.org/message-id/CAGrP7a3PwDYJhPe53yE6pBPPNxk2Ve4n%2BdPQMS1HcBU6swXYfA%40mail.gmail.com
 ALTER FUNCTION pg_catalog.texticlike LEAKPROOF;

--- a/services/entitlement/service/migrations/after-reset/install-extensions.sql
+++ b/services/entitlement/service/migrations/after-reset/install-extensions.sql
@@ -4,3 +4,9 @@
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public; -- used for generation of short unique string values, e.g. salt in extenal_id
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public; -- used for gin indexes which optimize requests that use LIKE/ILIKE operators, e.g. filter by title
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public; -- used for generating UUID values for PK fields
+
+-- This ensures that ILIKE gin indexes from pg_trgm extension are triggered
+-- when used together with RLS.
+-- e.g. `SELECT ax_utils.define_like_index('title', 'entities', 'app_public');`
+-- More context: https://www.postgresql.org/message-id/CAGrP7a3PwDYJhPe53yE6pBPPNxk2Ve4n%2BdPQMS1HcBU6swXYfA%40mail.gmail.com
+ALTER FUNCTION pg_catalog.texticlike LEAKPROOF;

--- a/services/media/service/migrations/after-reset/install-extensions.sql
+++ b/services/media/service/migrations/after-reset/install-extensions.sql
@@ -7,6 +7,6 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public; -- used for gener
 
 -- This ensures that ILIKE gin indexes from pg_trgm extension are triggered
 -- when used together with RLS.
--- e.g. `SELECT ax_utils.define_like_index('title', 'entities', 'app_public');`
+-- e.g. `SELECT ax_define.define_like_index('title', 'entities', 'app_public');`
 -- More context: https://www.postgresql.org/message-id/CAGrP7a3PwDYJhPe53yE6pBPPNxk2Ve4n%2BdPQMS1HcBU6swXYfA%40mail.gmail.com
 ALTER FUNCTION pg_catalog.texticlike LEAKPROOF;

--- a/services/media/service/migrations/after-reset/install-extensions.sql
+++ b/services/media/service/migrations/after-reset/install-extensions.sql
@@ -4,3 +4,9 @@
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public; -- used for generation of short unique string values, e.g. salt in extenal_id
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public; -- used for gin indexes which optimize requests that use LIKE/ILIKE operators, e.g. filter by title
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public; -- used for generating UUID values for PK fields
+
+-- This ensures that ILIKE gin indexes from pg_trgm extension are triggered
+-- when used together with RLS.
+-- e.g. `SELECT ax_utils.define_like_index('title', 'entities', 'app_public');`
+-- More context: https://www.postgresql.org/message-id/CAGrP7a3PwDYJhPe53yE6pBPPNxk2Ve4n%2BdPQMS1HcBU6swXYfA%40mail.gmail.com
+ALTER FUNCTION pg_catalog.texticlike LEAKPROOF;


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

Previously some gin indexes were not being triggered because the underlying `pg_catalog.texticlike` function is not marked as LEAKPROOF in combination with using RLS. By marking it as LEAKPROOF with superuser credentials - text search indexes will start being triggered for queries that involve RLS checks, greatly increasing the performance of operations like "Find all movies where title contains 'something'". 

`pg_catalog.texticlike` function could leak error information, so marking it as LEAKPROOF is not technically correct. But in our system, we do not expose errors via GraphQL and with the mask middleware we also will not log sensitive data, so this is deemed acceptable.

More context: 
- https://stackoverflow.com/questions/63008838/postgresql-ignores-pg-trgm-gin-indexes-when-row-level-security-is-enabled-and-no
- https://www.postgresql.org/message-id/CAGrP7a3PwDYJhPe53yE6pBPPNxk2Ve4n%2BdPQMS1HcBU6swXYfA%40mail.gmail.com

## Testing notes:

Try filtering various entities on explorer stations by Title. It should work as before.
