### PR TITLE
[AB#39532] genre view permissions adjusted to include parent view permission

### DIFF
--- a/services/media/service/migrations/committed/000019-genre-view-permissions-updated.sql
+++ b/services/media/service/migrations/committed/000019-genre-view-permissions-updated.sql
@@ -1,0 +1,6 @@
+--! Previous: sha1:1bfd2d3842c32fb8018288da0a25da394a4b5f2d
+--! Hash: sha1:035a2ed9bc2b4421de935f14596c3a8f50bf2743
+--! Message: genre-view-permissions-updated
+
+SELECT ax_define.define_authentication('MOVIES_VIEW,SETTINGS_VIEW,SETTINGS_EDIT,ADMIN', 'SETTINGS_EDIT,ADMIN', 'movie_genres', 'app_public');
+SELECT ax_define.define_authentication('TVSHOWS_VIEW,SETTINGS_VIEW,SETTINGS_EDIT,ADMIN', 'SETTINGS_EDIT,ADMIN', 'tvshow_genres', 'app_public');

--- a/services/media/service/src/domains/movies/operation-groups.ts
+++ b/services/media/service/src/domains/movies/operation-groups.ts
@@ -64,6 +64,7 @@ export const MoviesReadOperations = [
   Sub.moviesSnapshots,
   Sub.snapshotValidationResults,
   S.movieMutated,
+  R.movieGenres,
 ];
 
 export const MoviesMutateOperations = [

--- a/services/media/service/src/domains/tvshows/operation-groups.ts
+++ b/services/media/service/src/domains/tvshows/operation-groups.ts
@@ -72,6 +72,7 @@ export const TvShowsReadOperations = [
   S.tvshowMutated,
   Sub.tvshowsSnapshots,
   Sub.snapshotValidationResults,
+  R.tvshowGenres,
 ];
 
 export const TvShowsMutateOperations = [

--- a/services/media/service/src/generated/db/schema.sql
+++ b/services/media/service/src/generated/db/schema.sql
@@ -2924,7 +2924,7 @@ $$;
 CREATE FUNCTION ax_utils.current_environment_id() RETURNS uuid
     LANGUAGE sql STABLE
     AS $$
-  SELECT coalesce(nullif(current_setting('mosaic.environment_id', TRUE), ''), uuid_nil()::TEXT)::UUID;
+  SELECT coalesce(nullif(current_setting('mosaic.environment_id', TRUE), ''), 'ffffffff-ffff-ffff-ffff-ffffffffffff')::UUID;
 $$;
 
 
@@ -2935,7 +2935,7 @@ $$;
 CREATE FUNCTION ax_utils.current_tenant_id() RETURNS uuid
     LANGUAGE sql STABLE
     AS $$
-  SELECT coalesce(nullif(current_setting('mosaic.tenant_id', TRUE), ''), uuid_nil()::TEXT)::UUID;
+  SELECT coalesce(nullif(current_setting('mosaic.tenant_id', TRUE), ''), 'ffffffff-ffff-ffff-ffff-ffffffffffff')::UUID;
 $$;
 
 
@@ -9554,7 +9554,7 @@ ALTER TABLE app_public.movie_genres ENABLE ROW LEVEL SECURITY;
 -- Name: movie_genres movie_genres_authorization; Type: POLICY; Schema: app_public; Owner: -
 --
 
-CREATE POLICY movie_genres_authorization ON app_public.movie_genres USING ((( SELECT ax_utils.user_has_permission('SETTINGS_VIEW,SETTINGS_EDIT,ADMIN'::text) AS user_has_permission) AND (1 = 1))) WITH CHECK ((( SELECT ax_utils.user_has_permission('SETTINGS_EDIT,ADMIN'::text) AS user_has_permission) AND (1 = 1)));
+CREATE POLICY movie_genres_authorization ON app_public.movie_genres USING ((( SELECT ax_utils.user_has_permission('MOVIES_VIEW,SETTINGS_VIEW,SETTINGS_EDIT,ADMIN'::text) AS user_has_permission) AND (1 = 1))) WITH CHECK ((( SELECT ax_utils.user_has_permission('SETTINGS_EDIT,ADMIN'::text) AS user_has_permission) AND (1 = 1)));
 
 
 --
@@ -10378,7 +10378,7 @@ ALTER TABLE app_public.tvshow_genres ENABLE ROW LEVEL SECURITY;
 -- Name: tvshow_genres tvshow_genres_authorization; Type: POLICY; Schema: app_public; Owner: -
 --
 
-CREATE POLICY tvshow_genres_authorization ON app_public.tvshow_genres USING ((( SELECT ax_utils.user_has_permission('SETTINGS_VIEW,SETTINGS_EDIT,ADMIN'::text) AS user_has_permission) AND (1 = 1))) WITH CHECK ((( SELECT ax_utils.user_has_permission('SETTINGS_EDIT,ADMIN'::text) AS user_has_permission) AND (1 = 1)));
+CREATE POLICY tvshow_genres_authorization ON app_public.tvshow_genres USING ((( SELECT ax_utils.user_has_permission('TVSHOWS_VIEW,SETTINGS_VIEW,SETTINGS_EDIT,ADMIN'::text) AS user_has_permission) AND (1 = 1))) WITH CHECK ((( SELECT ax_utils.user_has_permission('SETTINGS_EDIT,ADMIN'::text) AS user_has_permission) AND (1 = 1)));
 
 
 --

--- a/services/media/service/src/generated/graphql/schema.graphql
+++ b/services/media/service/src/generated/graphql/schema.graphql
@@ -7719,7 +7719,7 @@ type MoviesMovieGenre {
   movieGenres: MovieGenre
 }
 
-"""@permissions: SETTINGS_VIEW,SETTINGS_EDIT,ADMIN"""
+"""@permissions: MOVIES_VIEW,SETTINGS_VIEW,SETTINGS_EDIT,ADMIN"""
 type MovieGenre {
   id: Int!
   title: String!
@@ -8769,7 +8769,7 @@ type TvshowsTvshowGenre {
   tvshowGenres: TvshowGenre
 }
 
-"""@permissions: SETTINGS_VIEW,SETTINGS_EDIT,ADMIN"""
+"""@permissions: TVSHOWS_VIEW,SETTINGS_VIEW,SETTINGS_EDIT,ADMIN"""
 type TvshowGenre {
   id: Int!
   title: String!
@@ -12718,7 +12718,7 @@ input IngestDocumentCondition {
 
 """
 A connection to a list of `MovieGenre` values.
-@permissions: SETTINGS_VIEW,SETTINGS_EDIT,ADMIN
+@permissions: MOVIES_VIEW,SETTINGS_VIEW,SETTINGS_EDIT,ADMIN
 """
 type MovieGenresConnection {
   """A list of `MovieGenre` objects."""
@@ -13057,7 +13057,7 @@ input SnapshotCondition {
 
 """
 A connection to a list of `TvshowGenre` values.
-@permissions: SETTINGS_VIEW,SETTINGS_EDIT,ADMIN
+@permissions: TVSHOWS_VIEW,SETTINGS_VIEW,SETTINGS_EDIT,ADMIN
 """
 type TvshowGenresConnection {
   """A list of `TvshowGenre` objects."""


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Testing notes

Have a non-admin user that only has MOVIES_VIEW permission. Navigate to explorer which has at least one entity with assigned genres. it should load without errors. Same for loading the details of any selected movie. Same for episodes, seasons, and tvshows.

Manage Images and Manage Videos would show that video/image is not found atm. This will be adjusted separately and is acceptable in context of this PR.
