### PR TITLE
[AB#42148] catalog service whitelists custom locale header

### DIFF
--- a/services/catalog/service/src/graphql/postgraphile-options.ts
+++ b/services/catalog/service/src/graphql/postgraphile-options.ts
@@ -33,7 +33,7 @@ import {
 export function buildPostgraphileOptions(
   config: Config,
 ): PostGraphileOptions<Request, Response> {
-  return new PostgraphileOptionsBuilder()
+  let options = new PostgraphileOptionsBuilder()
     .setDefaultSettings(config.isDev, config.graphqlGuiEnabled)
     .setErrorsHandler((errors, req) => {
       return enhanceGraphqlErrors(
@@ -43,7 +43,6 @@ export function buildPostgraphileOptions(
         logGraphQlError(catalogLogMapper),
       );
     })
-    .setHeader('Access-Control-Max-Age', 86400)
     .setPgSettings(async (req) => ({
       role: config.dbGqlRole,
       [MOSAIC_LOCALE_PG_KEY]: req.headers[MOSAIC_LOCALE_HEADER_KEY],
@@ -60,6 +59,40 @@ export function buildPostgraphileOptions(
       AllCollectionPlugins,
       AddErrorCodesEnumPluginFactory([MosaicErrors, CommonErrors]),
     )
-    .addGraphileBuildOptions({ pgSkipInstallingWatchFixtures: true })
-    .build();
+    .addGraphileBuildOptions({ pgSkipInstallingWatchFixtures: true });
+
+  options = setCustomCorsHeaders(options);
+  return options.build();
 }
+
+/**
+ * Used to set custom CORS headers since the standard PostGraphile CORS headers which are added
+ * via the { `enableCors`: true } property in the buildPostgraphileOptions are not customizable
+ */
+const setCustomCorsHeaders = (
+  options: PostgraphileOptionsBuilder,
+): PostgraphileOptionsBuilder => {
+  return options
+    .setProperties({ enableCors: false })
+    .setHeader(
+      'Access-Control-Allow-Headers',
+      [
+        'Origin',
+        'X-Requested-With',
+        'Accept',
+        'Authorization',
+        'X-Apollo-Tracing',
+        'Content-Type',
+        'Content-Length',
+        'X-PostGraphile-Explain',
+        MOSAIC_LOCALE_HEADER_KEY, // allow the custom header used
+      ].join(', '),
+    )
+    .setHeader(
+      'Access-Control-Allow-Methods',
+      ['HEAD', 'GET', 'POST'].join(', '),
+    )
+    .setHeader('Access-Control-Allow-Origin', '*')
+    .setHeader('Access-Control-Expose-Headers', 'X-GraphQL-Event-Stream')
+    .setHeader('Access-Control-Max-Age', 86400);
+};


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

We are using a custom header `mosaic-locale` to filter content based on lspecific locale. This change allows setting such header in CORS settings.

## Testing Notes

Check that frontend samples that are related to catalog service and localizations are working. Regular smoke tests for catalog service would also do to make sure API is still working with a different approach to set CORS settings.
