### PR TITLE
[AB#42650] lock_timeout param moved to pg server level

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -5,6 +5,10 @@ version: '3.7'
 services:
   postgres:
     image: postgres:11.12-alpine
+    command:
+      - 'postgres'
+      - '-c'
+      - 'lock_timeout=60000'
     environment:
       POSTGRES_USER: '${POSTGRESQL_ROOT}'
       POSTGRES_PASSWORD: '${POSTGRESQL_ROOT_PASSWORD}'

--- a/services/catalog/service/src/index.ts
+++ b/services/catalog/service/src/index.ts
@@ -48,10 +48,7 @@ async function bootstrap(): Promise<void> {
 
   await applyMigrations(config);
   const shutdownActions = setupShutdownActions(app, logger);
-  const poolConfig: PoolConfig = {
-    max: config.pgPoolMaxConnections,
-    lock_timeout: config.pgLockTimeoutInMs,
-  };
+  const poolConfig: PoolConfig = { max: config.pgPoolMaxConnections };
   setupOwnerPgPool(
     app,
     config.dbOwnerConnectionString,

--- a/services/entitlement/service/src/index.ts
+++ b/services/entitlement/service/src/index.ts
@@ -72,10 +72,7 @@ async function bootstrap(): Promise<void> {
   await applyMigrations(config);
 
   const shutdownActions = setupShutdownActions(app, logger);
-  const poolConfig: PoolConfig = {
-    max: config.pgPoolMaxConnections,
-    lock_timeout: config.pgLockTimeoutInMs,
-  };
+  const poolConfig: PoolConfig = { max: config.pgPoolMaxConnections };
   setupOwnerPgPool(
     app,
     config.dbOwnerConnectionString,

--- a/services/media/service/src/index.ts
+++ b/services/media/service/src/index.ts
@@ -90,10 +90,7 @@ async function bootstrap(): Promise<void> {
 
   // Register shutdown actions. These actions will be performed on service shutdown; in the order of registration.
   const shutdownActions = setupShutdownActions(app, logger);
-  const poolConfig: PoolConfig = {
-    max: config.pgPoolMaxConnections,
-    lock_timeout: config.pgLockTimeoutInMs,
-  };
+  const poolConfig: PoolConfig = { max: config.pgPoolMaxConnections };
   // Create environment owner connection pool (internal use).
   setupOwnerPgPool(
     app,


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [x] appropriate labels for the PR applied

## Description

Previously, lock_timeout was set on pg pool level for potential cases, if one transaction locks a row and another transaction tries to access it - it would timeout in 1 minute (default value) instead of hanging.

In deployed scenarios, pgBouncer is not able to support the lock_timeout, so it will be defined on pg server level. Changes in infra file only affect the local dev pg server.
