### PR TITLE
[AB#42706] request body is no longer expected to be present for GraphQL error handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.organizeImports": false
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "never"
   },
   "jestrunner.jestCommand": "yarn util:load-vars jest",
   "files.associations": {

--- a/services/catalog/service/src/graphql/postgraphile-options.ts
+++ b/services/catalog/service/src/graphql/postgraphile-options.ts
@@ -30,7 +30,7 @@ export function buildPostgraphileOptions(
     .setErrorsHandler((errors, req) => {
       return enhanceGraphqlErrors(
         errors,
-        req.body.operationName,
+        req.body?.operationName,
         customizeGraphQlErrorFields(defaultPgErrorMapper),
         logGraphQlError(catalogLogMapper),
       );

--- a/services/catalog/service/src/tests/test-utils/test-context.ts
+++ b/services/catalog/service/src/tests/test-utils/test-context.ts
@@ -83,7 +83,7 @@ const runGqlQuery = async function (
       if (result.errors) {
         result.errors = enhanceGraphqlErrors(
           result.errors,
-          req.body.operationName,
+          req.body?.operationName,
           customizeGraphQlErrorFields(defaultPgErrorMapper),
           logGraphQlError(catalogLogMapper, this.logger),
         );

--- a/services/entitlement/service/src/graphql/postgraphile-options.ts
+++ b/services/entitlement/service/src/graphql/postgraphile-options.ts
@@ -47,7 +47,7 @@ export const buildPostgraphileOptions = (
     .setErrorsHandler((errors, req) => {
       return enhanceGraphqlErrors(
         errors,
-        req.body.operationName,
+        req.body?.operationName,
         customizeGraphQlErrorFields(defaultPgErrorMapper),
         logGraphQlError(entitlementLogMapper),
       );

--- a/services/entitlement/service/src/tests/test-utils/test-context.ts
+++ b/services/entitlement/service/src/tests/test-utils/test-context.ts
@@ -85,7 +85,7 @@ const runGqlQuery = async function (
       if (result.errors) {
         result.errors = enhanceGraphqlErrors(
           result.errors,
-          req.body.operationName,
+          req.body?.operationName,
           customizeGraphQlErrorFields(defaultPgErrorMapper),
           logGraphQlError(entitlementLogMapper, this.logger),
         );

--- a/services/media/service/src/graphql/postgraphile-options.ts
+++ b/services/media/service/src/graphql/postgraphile-options.ts
@@ -60,7 +60,7 @@ export const buildPostgraphileOptions = (
     .setErrorsHandler((errors, req) => {
       return enhanceGraphqlErrors(
         errors,
-        req.body.operationName,
+        req.body?.operationName,
         customizeGraphQlErrorFields(mediaPgErrorMapper),
         logGraphQlError(defaultWriteLogMapper),
       );

--- a/services/media/service/src/tests/test-utils/test-context.ts
+++ b/services/media/service/src/tests/test-utils/test-context.ts
@@ -91,7 +91,7 @@ const runGqlQuery = async function (
       if (result.errors) {
         result.errors = enhanceGraphqlErrors(
           result.errors,
-          req.body.operationName,
+          req.body?.operationName,
           customizeGraphQlErrorFields(mediaPgErrorMapper),
           logGraphQlError(defaultWriteLogMapper, this.logger),
         );


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [x] appropriate labels for the PR applied

## Description

`body` is not always defined on http req object, e.g. in case of subscription errors, so `graphql-ws` can throw an error because of it. Passed parameter is changed to  `req.body?.operationName` for `enhanceGraphqlErrors` calls.

