### PR TITLE
[AB#42671] Minimal update for release 75 to make video service communication work

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.organizeImports": false
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "never"
   },
   "jestrunner.jestCommand": "yarn util:load-vars jest",
   "files.associations": {

--- a/services/entitlement/service/.env.template
+++ b/services/entitlement/service/.env.template
@@ -32,7 +32,7 @@ GEOLITE2_LICENSE_KEY=
 
 # These variables are optional and are only needed for local development
 DEV_USER_SERVICE_MANAGEMENT_BASE_URL=https://user.service.eu.axinom.net
-DEV_ENCODING_SERVICE_BASE_URL=https://encoding.service.eu.axinom.net
+DEV_ENCODING_SERVICE_BASE_URL=https://video.service.eu.axinom.net
 DEV_APPLICATION_NAME="DEV Application (entitlement-service)"
 DEV_END_USER_ID=d68f0268-2703-49ef-9239-7396073fe77a
 

--- a/services/entitlement/service/README.md
+++ b/services/entitlement/service/README.md
@@ -83,7 +83,7 @@ The `yarn setup:webhooks` script is used for development environments. To get
 the values for `ENTITLEMENT_WEBHOOK_SECRET` and `MANIFEST_WEBHOOK_SECRET` env
 variables for the production environment, the following mutation must be
 launched against the Encoding Service GraphQL API. You can use GraphiQL UI for
-that (https://encoding.service.eu.axinom.net/graphiql):
+that (https://video.service.eu.axinom.net/graphiql):
 
 ```
   mutation GenerateSecrets {

--- a/services/entitlement/service/package.json
+++ b/services/entitlement/service/package.json
@@ -50,7 +50,7 @@
     "@axinom/mosaic-id-guard": "0.20.5",
     "@axinom/mosaic-id-utils": "0.15.3",
     "@axinom/mosaic-message-bus": "0.14.6",
-    "@axinom/mosaic-messages": "0.29.0",
+    "@axinom/mosaic-messages": "0.31.0",
     "@axinom/mosaic-service-common": "0.34.0",
     "ajv": "^7.2.4",
     "ajv-formats": "^1.6.1",

--- a/services/entitlement/service/scripts/resources/dev-user.json
+++ b/services/entitlement/service/scripts/resources/dev-user.json
@@ -8,7 +8,7 @@
     ]
   },
   {
-    "serviceId": "ax-encoding-service",
+    "serviceId": "ax-video-service",
     "permissions": ["SETTINGS_EDIT"]
   }
 ]

--- a/services/entitlement/service/src/domains/encoding/video-playback-middlewares.ts
+++ b/services/entitlement/service/src/domains/encoding/video-playback-middlewares.ts
@@ -37,8 +37,7 @@ const validateVideoPlaybackPermissionMiddleware = (
   }
 
   const permissions =
-    req.body?.payload?.management_user?.permissions?.['ax-encoding-service'] ??
-    [];
+    req.body?.payload?.management_user?.permissions?.['ax-video-service'] ?? [];
   if (!permissions.includes('VIDEOS_STREAMING')) {
     throw new MosaicError(CommonErrors.NoStreamingPermissions);
   }

--- a/services/media/service/.env.template
+++ b/services/media/service/.env.template
@@ -13,7 +13,7 @@ DATABASE_LOGIN=media_service_login
 DATABASE_LOGIN_PASSWORD=media_service_login_pwd
 DATABASE_GQL_ROLE=media_service_gql_role
 
-ENCODING_SERVICE_BASE_URL=https://encoding.service.eu.axinom.net
+ENCODING_SERVICE_BASE_URL=https://video.service.eu.axinom.net
 IMAGE_SERVICE_BASE_URL=https://image.service.eu.axinom.net
 
 SERVICE_ACCOUNT_CLIENT_ID=####

--- a/services/media/service/package.json
+++ b/services/media/service/package.json
@@ -50,7 +50,7 @@
     "@axinom/mosaic-id-link-be": "0.13.3",
     "@axinom/mosaic-message-bus": "0.14.6",
     "@axinom/mosaic-message-bus-abstractions": "0.5.6",
-    "@axinom/mosaic-messages": "0.29.0",
+    "@axinom/mosaic-messages": "0.31.0",
     "@axinom/mosaic-service-common": "0.34.0",
     "@faker-js/faker": "^7.5.0",
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",

--- a/services/media/service/scripts/resources/encoding-settings-view.json
+++ b/services/media/service/scripts/resources/encoding-settings-view.json
@@ -1,6 +1,6 @@
 [
   {
-    "serviceId": "ax-encoding-service",
+    "serviceId": "ax-video-service",
     "permissions": ["SETTINGS_VIEW"]
   }
 ]

--- a/services/media/service/scripts/resources/media-admin.json
+++ b/services/media/service/scripts/resources/media-admin.json
@@ -8,7 +8,7 @@
     "permissions": ["IMAGES_EDIT"]
   },
   {
-    "serviceId": "ax-encoding-service",
+    "serviceId": "ax-video-service",
     "permissions": ["VIDEOS_ENCODE"]
   }
 ]

--- a/services/media/service/scripts/setup.ts
+++ b/services/media/service/scripts/setup.ts
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
         permissions: ['IMAGE_TYPES_DECLARE'],
       },
       {
-        serviceId: 'ax-encoding-service',
+        serviceId: 'ax-video-service',
         permissions: ['CUE_POINT_TYPES_DECLARE'],
       },
     ],

--- a/services/media/service/src/generated/messaging/rascal-schema.json
+++ b/services/media/service/src/generated/messaging/rascal-schema.json
@@ -88,11 +88,11 @@
             }
           }
         },
-        "ax-encoding-service:video:ensure_exists": {
+        "ax-video-service:video:ensure_exists": {
           "options": {
             "arguments": {
               "x-dead-letter-exchange": "dead_letter",
-              "x-dead-letter-routing-key": "ax-encoding-service.dead_letter",
+              "x-dead-letter-routing-key": "ax-video-service.dead_letter",
               "x-queue-type": "quorum"
             }
           }
@@ -196,11 +196,11 @@
             }
           }
         },
-        "ax-encoding-service:cue_point_types:declare": {
+        "ax-video-service:cue_point_types:declare": {
           "options": {
             "arguments": {
               "x-dead-letter-exchange": "dead_letter",
-              "x-dead-letter-routing-key": "ax-encoding-service.dead_letter",
+              "x-dead-letter-routing-key": "ax-video-service.dead_letter",
               "x-queue-type": "quorum"
             }
           }
@@ -290,10 +290,10 @@
           "bindingKey": "media-service.ingest.check_finish_document",
           "destination": "media-service:ingest:check_finish_document"
         },
-        "retry:ax-encoding-service:video:ensure_exists": {
+        "retry:ax-video-service:video:ensure_exists": {
           "source": "retry",
-          "bindingKey": "ax-encoding-service:video:ensure_exists.#",
-          "destination": "ax-encoding-service:video:ensure_exists"
+          "bindingKey": "ax-video-service:video:ensure_exists.#",
+          "destination": "ax-video-service:video:ensure_exists"
         },
         "retry:media-service:video:ensure_exists_already_existed": {
           "source": "retry",
@@ -302,7 +302,7 @@
         },
         "media-service:video:ensure_exists_already_existed": {
           "source": "event",
-          "bindingKey": "ax-encoding-service.*.*.video.ensure_exists_already_existed",
+          "bindingKey": "ax-video-service.*.*.video.ensure_exists_already_existed",
           "destination": "media-service:video:ensure_exists_already_existed"
         },
         "retry:media-service:video:ensure_exists_creation_started": {
@@ -312,7 +312,7 @@
         },
         "media-service:video:ensure_exists_creation_started": {
           "source": "event",
-          "bindingKey": "ax-encoding-service.*.*.video.ensure_exists_creation_started",
+          "bindingKey": "ax-video-service.*.*.video.ensure_exists_creation_started",
           "destination": "media-service:video:ensure_exists_creation_started"
         },
         "retry:media-service:video:ensure_exists_failed": {
@@ -322,7 +322,7 @@
         },
         "media-service:video:ensure_exists_failed": {
           "source": "event",
-          "bindingKey": "ax-encoding-service.*.*.video.ensure_exists_failed",
+          "bindingKey": "ax-video-service.*.*.video.ensure_exists_failed",
           "destination": "media-service:video:ensure_exists_failed"
         },
         "retry:ax-image-service:image:ensure_exists": {
@@ -395,10 +395,10 @@
           "bindingKey": "ax-image-service:image_types:declare.#",
           "destination": "ax-image-service:image_types:declare"
         },
-        "retry:ax-encoding-service:cue_point_types:declare": {
+        "retry:ax-video-service:cue_point_types:declare": {
           "source": "retry",
-          "bindingKey": "ax-encoding-service:cue_point_types:declare.#",
-          "destination": "ax-encoding-service:cue_point_types:declare"
+          "bindingKey": "ax-video-service:cue_point_types:declare.#",
+          "destination": "ax-video-service:cue_point_types:declare"
         },
         "retry:media-service:cue_point_types:declared": {
           "source": "retry",
@@ -407,7 +407,7 @@
         },
         "media-service:cue_point_types:declared": {
           "source": "event",
-          "bindingKey": "ax-encoding-service.*.*.cue_point_types.declared",
+          "bindingKey": "ax-video-service.*.*.cue_point_types.declared",
           "destination": "media-service:cue_point_types:declared"
         },
         "retry:media-service:cue_point_types:declare_failed": {
@@ -417,7 +417,7 @@
         },
         "media-service:cue_point_types:declare_failed": {
           "source": "event",
-          "bindingKey": "ax-encoding-service.*.*.cue_point_types.declare_failed",
+          "bindingKey": "ax-video-service.*.*.cue_point_types.declare_failed",
           "destination": "media-service:cue_point_types:declare_failed"
         }
       },
@@ -460,7 +460,7 @@
         },
         "EnsureVideoExists": {
           "exchange": "command",
-          "routingKey": "ax-encoding-service.*.*.video.ensure_exists"
+          "routingKey": "ax-video-service.*.*.video.ensure_exists"
         },
         "EnsureImageExists": {
           "exchange": "command",
@@ -544,7 +544,7 @@
         },
         "DeclareCuePointTypes": {
           "exchange": "command",
-          "routingKey": "ax-encoding-service.*.*.cue_point_types.declare"
+          "routingKey": "ax-video-service.*.*.cue_point_types.declare"
         }
       },
       "subscriptions": {

--- a/services/media/service/src/tests/ingest/upload.db.spec.ts
+++ b/services/media/service/src/tests/ingest/upload.db.spec.ts
@@ -129,7 +129,7 @@ describe('Movies GraphQL endpoints', () => {
           'MOVIES_EDIT',
           'TVSHOWS_EDIT',
         ],
-        'ax-encoding-service': ['VIDEOS_EDIT'],
+        'ax-video-service': ['VIDEOS_EDIT'],
       },
     });
     defaultRequestContext = createTestRequestContext(

--- a/services/media/workflows/package.json
+++ b/services/media/workflows/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "@apollo/client": "^3.7.9",
-    "@axinom/mosaic-ui": "0.33.2",
+    "@axinom/mosaic-ui": "0.35.0",
     "apollo-upload-client": "^14.1.3",
     "clsx": "^1.2.1",
     "env-cmd": "^10.1.0",
@@ -38,7 +38,7 @@
     "yup": "^0.32.11"
   },
   "devDependencies": {
-    "@axinom/mosaic-portal": "0.17.1",
+    "@axinom/mosaic-portal": "0.19.0",
     "@dbeining/react-atom": "^4.1.21",
     "@graphql-codegen/cli": "^2.13.4",
     "@graphql-codegen/typescript": "^2.7.3",

--- a/services/vod-to-live/service/package.json
+++ b/services/vod-to-live/service/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@axinom/mosaic-id-guard": "0.20.5",
     "@axinom/mosaic-message-bus": "0.14.6",
-    "@axinom/mosaic-messages": "0.29.0",
+    "@axinom/mosaic-messages": "0.31.0",
     "@axinom/mosaic-service-common": "0.34.0",
     "@azure/storage-blob": "^12.12.0",
     "amqplib": "^0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,6 +223,11 @@
   resolved "https://registry.yarnpkg.com/@axinom/mosaic-core/-/mosaic-core-0.4.6.tgz#6244bc8829585046f6c3deaaa478504ee96984c7"
   integrity sha512-ICPPMWEBEYZS5mNH8GOgfYDMzXeT+qgbQ0lQ/6yl5jfLgdAKAgq8+1zTuxYbdcKwURJgnOIH9F6mCpMsW8+qAQ==
 
+"@axinom/mosaic-core@^0.4.8":
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/@axinom/mosaic-core/-/mosaic-core-0.4.13.tgz#e1a8d81f45b01c4cfcf6bbef4fece294a7acbb54"
+  integrity sha512-OU/sM/w00iw5emI5kjH3I/2nRErhk6+QSh3g3pYDrf3Lg8mBo2RSG2ULpJJpQ+P5Bb42q+cbYXFH03nzgQ7jfw==
+
 "@axinom/mosaic-db-common@0.25.1":
   version "0.25.1"
   resolved "https://registry.yarnpkg.com/@axinom/mosaic-db-common/-/mosaic-db-common-0.25.1.tgz#722a0d149b927f023e23698fb95c2e164b86d32a"
@@ -300,15 +305,15 @@
     rascal "^14.0.1"
     uuid "^8.3.2"
 
-"@axinom/mosaic-messages@0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@axinom/mosaic-messages/-/mosaic-messages-0.29.0.tgz#da8828cc21e04699bfaeb495c763fd3843a9b787"
-  integrity sha512-iMoVHV3DqLvG++1gWsb/23tmryJTLWtkCnphbb2h0ZfYTzRj5ZGuOTo0qm9dsRFOZFSQG6o1/rVWVaF6ThHwIw==
+"@axinom/mosaic-messages@0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@axinom/mosaic-messages/-/mosaic-messages-0.31.0.tgz#b513989a4909d68fd74de22acf48e73c4ee1e758"
+  integrity sha512-kvtZL/Tgr5WLLZ7FzTOE2YBS9fwceCdP9nT9MFHUPq5C3HhSYrO0UTqwIKasrT+QUr+pDfwUAjO/1crsJys0pA==
 
-"@axinom/mosaic-portal@0.17.1":
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/@axinom/mosaic-portal/-/mosaic-portal-0.17.1.tgz#407442634f20d358cd8cf3bfedad0ea4b17a1dd4"
-  integrity sha512-s5T5vf+vZ7ild1K9ec1hprjn+rXC7iyffFqOi4SMqnQ/fx9paht+jBD2yjDAAPBehF1mWEV7aQLFPqe6IiSIcg==
+"@axinom/mosaic-portal@0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@axinom/mosaic-portal/-/mosaic-portal-0.19.0.tgz#b489bdf472d52acd4c6084379b7a4e6dca953097"
+  integrity sha512-ncZirnRgNE3Msb8nW43OCa3BD7orJlydXphN9hAqY3xRgoTBhOD8Pm6O3GKMjjfNVhUECPyDlkSjHN8uU/DZDQ==
 
 "@axinom/mosaic-service-common@0.34.0", "@axinom/mosaic-service-common@^0.34.0":
   version "0.34.0"
@@ -340,17 +345,18 @@
     uuid-encoder "^1.2.0"
     verror "^1.10.1"
 
-"@axinom/mosaic-ui@0.33.2":
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/@axinom/mosaic-ui/-/mosaic-ui-0.33.2.tgz#c3fe0a10e58598a4ee02c00afc983f4319046510"
-  integrity sha512-R9i3ezDf7b6hEgpnwBMR8Z96/pcJ5G8PM7XFIXJIcFWQlvClxCJ6zdV0Noz+997kLO3YR0n5TPH6EcS0mnYerQ==
+"@axinom/mosaic-ui@0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@axinom/mosaic-ui/-/mosaic-ui-0.35.0.tgz#45aee8a516efe947cc65ea9230db0a6b7629f6ed"
+  integrity sha512-x+IxqF0RDO6tfh8jwZZTpYj+Fpheuq5RLxifXVK2oh1QY6XEmKzLty3FCQBxtBqZj2RRUVIn3N3wLFy2Va5/0Q==
   dependencies:
-    "@axinom/mosaic-core" "^0.4.6"
+    "@axinom/mosaic-core" "^0.4.8"
     "@faker-js/faker" "^7.4.0"
     "@popperjs/core" "^2.9.2"
     clsx "^1.1.0"
     lodash "^4.17.21"
     luxon "^3.3.0"
+    react-beautiful-dnd "^13.1.1"
     react-calendar "^3.3.1"
     react-content-loader "^6.0.3"
     react-imask "^6.4.3"
@@ -1404,6 +1410,13 @@
   integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
   dependencies:
     regenerator-runtime "^0.13.11"
+
+"@babel/runtime@^7.9.2":
+  version "7.23.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.8.tgz#8ee6fe1ac47add7122902f257b8ddf55c898f650"
+  integrity sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
 
 "@babel/template@^7.18.10", "@babel/template@^7.3.3":
   version "7.18.10"
@@ -2986,6 +2999,14 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
   integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz#dab7867ef789d87e2b4b0003c9d65c49cc44a494"
+  integrity sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -3205,6 +3226,16 @@
   integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
   dependencies:
     "@types/react" "^17"
+
+"@types/react-redux@^7.1.20":
+  version "7.1.26"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.26.tgz#84149f5614e40274bb70fcbe8f7cae6267d548b1"
+  integrity sha512-UKPo7Cm7rswYU6PH6CmTNCRv5NYF3HrgKuHEYTK8g/3czYLrUux50gQ2pkxc9c7ZpQZi+PNhgmI8oNIRoiVIxg==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react-router-dom@^5.3.3":
   version "5.3.3"
@@ -5019,6 +5050,13 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+css-box-model@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  dependencies:
+    tiny-invariant "^1.0.6"
 
 css-declaration-sorter@^6.3.1:
   version "6.3.1"
@@ -8796,6 +8834,11 @@ memfs@^3.1.2:
   dependencies:
     fs-monkey "^1.0.3"
 
+memoize-one@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 memory-fs@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.5.0.tgz#324c01288b88652966d161db77838720845a8e3c"
@@ -10389,6 +10432,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+raf-schd@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
 ramda@^0.27.0:
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.2.tgz#84463226f7f36dc33592f6f4ed6374c48306c3f1"
@@ -10453,6 +10501,19 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-beautiful-dnd@^13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz#b0f3087a5840920abf8bb2325f1ffa46d8c4d0a2"
+  integrity sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.2.0"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
+
 react-calendar@^3.3.1:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-3.9.0.tgz#4dfe342ef61574c0e819e49847981076c7af58ea"
@@ -10500,6 +10561,11 @@ react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
 react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
@@ -10512,6 +10578,18 @@ react-popper@^2.2.5:
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
+
+react-redux@^7.2.0:
+  version "7.2.9"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.9.tgz#09488fbb9416a4efe3735b7235055442b042481d"
+  integrity sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-router-dom@^5.3.4:
   version "5.3.4"
@@ -10607,6 +10685,13 @@ readdirp@^3.4.0, readdirp@^3.6.0, readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+redux@^4.0.0, redux@^4.0.4:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
 reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
@@ -10628,6 +10713,11 @@ regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.4:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regenerator-transform@^0.15.1:
   version "0.15.1"
@@ -11813,7 +11903,7 @@ through@2, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-tiny-invariant@^1.0.2:
+tiny-invariant@^1.0.2, tiny-invariant@^1.0.6:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
   integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
@@ -12256,6 +12346,11 @@ url-parse@~1.5.10:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-memo-one@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
+  integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Due to the deprecation of the encoding service API (`encoding` service was renamed to `video` service), and the drop of the backward compatibility in the video service for this renaming, the following changes were made to enable the work of the service:
- update `@axinom/mosaic-messages` everywhere in the monorepo to `0.31.0`
- global replace: `ax-encoding-service` -> `ax-video-service`
- global replace: `encoding.service.eu.axinom.net` -> `video.service.eu.axinom.net`
- Double-check the media-service service account permissions in the Admin Portal, e.g. it should have `CUE_POINT_TYPES_DECLARE` for Video Service enabled.

In the current PR, the package versions were chosen to be the earliest stable ones after the video service rename to reduce the amount of necessary changes.

In addition, to have proper developer experience, the workflows are updated with newer packages, and the following actions are expected to be made:
- in media-workflows, update:
   - `@axinom/mosaic-ui` to `0.35.0`
   - `@axinom/mosaic-portal` to `0.19.0`
- run `yarn` from the monorepo root
- perform the replace in `yarn.lock`:
```
"@types/react-redux@^7.1.20":
  version "7.1.26"
  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.26.tgz#84149f5614e40274bb70fcbe8f7cae6267d548b1"
  integrity sha512-UKPo7Cm7rswYU6PH6CmTNCRv5NYF3HrgKuHEYTK8g/3czYLrUux50gQ2pkxc9c7ZpQZi+PNhgmI8oNIRoiVIxg==
  dependencies:
    "@types/hoist-non-react-statics" "^3.3.0"
    "@types/react" "*"
    hoist-non-react-statics "^3.3.0"
    redux "^4.0.0"
```
