### PR TITLE
[AB#42787] Add hosting v3 artefacts to canary-73

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -14,6 +14,11 @@ RABBITMQ_PASSWORD=
 DEV_SERVICE_ACCOUNT_CLIENT_ID=
 DEV_SERVICE_ACCOUNT_CLIENT_SECRET=
 
+# Only for Deployments through Mosaic Hosting Service
+# Can set by running `yarn setup:hosting` script from root.
+MOSAIC_HOSTING_CLIENT_ID=
+MOSAIC_HOSTING_CLIENT_SECRET=
+
 
 ########################################################
 ### Advanced options below - change at your own risk ###
@@ -22,6 +27,7 @@ DEV_SERVICE_ACCOUNT_CLIENT_SECRET=
 # Managed Service Endpoint URLs
 MICRO_FRONTEND_SERVICE_BASE_URL=https://frontends.service.eu.axinom.net
 ID_SERVICE_AUTH_BASE_URL=https://id.service.eu.axinom.net
+HOSTING_SERVICE_BASE_URL=https://hosting.service.eu.axinom.net
 
 # Local Proxy Ports
 ID_SERVICE_LOCAL_PROXY_PORT=10505

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN cp -rL node_modules node_modules_full
 RUN rm -rf node_modules
 RUN mv node_modules_full node_modules
 RUN mkdir -p "$PACKAGE_ROOT/node_modules"
+RUN if [ ! -d /checkout/$PACKAGE_ROOT/migrations ]; then mkdir -p /checkout/$PACKAGE_ROOT/migrations; fi
 
 # RELEASE
 FROM node:18-buster-slim
@@ -41,5 +42,8 @@ COPY --from=build ["/checkout/node_modules", "/app/node_modules/"]
 COPY --from=build ["/checkout/$PACKAGE_ROOT/node_modules", "./node_modules/"]
 COPY --from=build ["/checkout/$PACKAGE_ROOT/dist", "./dist/"]
 COPY --from=build ["/checkout/$PACKAGE_ROOT/migrations", "./migrations/"]
+
+RUN chown -R node:node /app
+USER node
 
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -204,3 +204,127 @@ workflow.
   in that service's workspace. There should also be a corresponding permissions
   file under that service's `scripts/resources`. For a working example see
   `package.json` in the Media Service.
+
+## Deploying the services via Mosaic Hosting Service
+
+### Pre-requisites for deploying any service
+
+1. Ensure you've configured the Container Registry for your environment in the
+   Admin Portal under Hosting Service (the following steps assumes `Docker Hub`
+   as the Container Registry provider for simplicity).
+2. For each service you wish to host in Axinom, ensure you've created a
+   `Customized Service` entity via the Admin Portal, and that the correct
+   repository name has been set as expected.
+3. Ensure you've run `yarn setup:hosting` from the root of the
+   mosaic-media-template. This will setup the required service-account for using
+   the Mosaic CLI commands shown below with the correct permissions.
+
+NOTE: `yarn util:load-vars` is used in the below commands to load values for
+certain CLI arguments from the `.env` file. If required, the CLI arguments can
+also be directly provided as necessary (i.e. when used in a CI
+environment/agent).
+
+NOTE: The final deployment step (i.e. the `mosaic hosting service deploy` step)
+can also be performed via the Admin Portal under Hosting Service.
+
+A detailed guide on how to deploy services via Mosaic Hosting Service can be
+found at
+https://portal.axinom.com/mosaic/documentation/deploy-a-customized-service-with-hosting-service
+
+### Deploying Media Service
+
+1. Build the service using the provided Dockerfile
+   - CLI Command
+     - `docker build -t <username>/<repository_name>:<tag> --build-arg PACKAGE_ROOT=services/media/service --build-arg PACKAGE_BUILD_COMMAND=build:media-service:prod .`
+     - i.e.
+       `docker build -t my-user/media-service:20230927.1 --build-arg PACKAGE_ROOT=services/media/service --build-arg PACKAGE_BUILD_COMMAND=build:media-service:prod .`
+   - Ensure to use the same `<repository_name>` you decide on here, also in the
+     `Customized Service` details station of the Admin Portal.
+2. Push the container image to Docker Hub
+   - CLI Command
+     - `docker push <dockerhub_username>/<repository_name>:<tag>`
+     - i.e. `docker push my-user/media-service:20230927.1`
+3. Build the workflows of the media-service
+   - CLI Command
+     - `yarn build:media-workflows:prod`
+   - This will produce a `.tgz` pilet artifact on the project root
+4. Register the pilet artifact on the Mosaic Hosting Service
+   - CLI Command
+     - `yarn util:load-vars mosaic hosting pilet register -i <custom-service-id> -p <path-to-workflow-build-artifact>`
+     - i.e.
+       `yarn util:load-vars mosaic hosting pilet register -i media-service -p ./`
+5. Upload the deployment manifest to the Mosaic Hosting Service
+   - CLI Command
+     - `yarn util:load-vars mosaic hosting manifest upload -i <custom-service-id> -p <path-to-deployment-manifest-yaml> -n <unique-name-for-deployment-manifest>`
+     - i.e.
+       `yarn util:load-vars mosaic hosting manifest upload -i media-service -p ./services/media/service/mosaic-hosting-deployment-manifest.yaml -n media-service-manifest-20230927`
+   - Ensure you provide a unique value for the manifest name
+6. Deploy the service with the specific artifacts (i.e. container image tag,
+   pilet artifact, deployment manifest)
+   - CLI Command
+     - `yarn util:load-vars mosaic hosting service deploy -i <custom-service-id> -t <tag> -p <workflow-package@version> -m <deployment-manifest-name>`
+     - i.e.
+       `yarn util:load-vars mosaic hosting service deploy -i media-service -t 20230927.1 -p media-workflows@1.0.1 -m media-service-manifest-20230927 -n media-service-deployment-20230927.1`
+   - Ensure you provide a unique value for the deployment name
+
+### Deploying Catalog Service
+
+1. Build the service using the provided Dockerfile
+   - CLI Command
+     - `docker build -t <username>/<repository_name>:<tag> --build-arg PACKAGE_ROOT=services/catalog/service --build-arg PACKAGE_BUILD_COMMAND=build:catalog-service:prod .`
+     - i.e.
+       `docker build -t my-user/catalog-service:20230927.1 --build-arg PACKAGE_ROOT=services/catalog/service --build-arg PACKAGE_BUILD_COMMAND=build:catalog-service:prod .`
+   - Ensure to use the same `<repository_name>` you decide on here, also in the
+     `Customized Service` details station of the Admin Portal.
+2. Push the container image to Docker Hub
+   - CLI Command
+     - `docker push <dockerhub_username>/<repository_name>:<tag>`
+     - i.e. `docker push my-user/catalog-service:20230927.1`
+3. Since this service has no workflows, we do not need to build them nor
+   register them
+4. Upload the deployment manifest to the Mosaic Hosting Service
+   - CLI Command
+     - `yarn util:load-vars mosaic hosting manifest upload -i <custom-service-id> -p <path-to-deployment-manifest-yaml> -n <unique-name-for-deployment-manifest>`
+     - i.e.
+       `yarn util:load-vars mosaic hosting manifest upload -i catalog-service -p ./services/catalog/service/mosaic-hosting-deployment-manifest.yaml -n catalog-service-manifest-20230927`
+   - Ensure you provide a unique value for the manifest name
+5. Deploy the service with the specific artifacts (i.e. container image tag,
+   deployment manifest)
+   - CLI Command
+     - `yarn util:load-vars mosaic hosting service deploy -i <custom-service-id> -t <tag> -m <deployment-manifest-name>`
+     - i.e.
+       `yarn util:load-vars mosaic hosting service deploy -i catalog-service -t 20230927.1 -m catalog-service-manifest-20230927 -n catalog-service-deployment-20230927.1`
+   - Ensure you provide a unique value for the deployment name
+
+### Deploying Entitlement Service
+
+1. Build the service using the provided Dockerfile
+   - CLI Command
+     - `docker build -t <username>/<repository_name>:<tag> --build-arg PACKAGE_ROOT=services/entitlement/service --build-arg PACKAGE_BUILD_COMMAND=build:entitlement-service:prod .`
+     - i.e.
+       `docker build -t my-user/entitlement-service:20230927.1 --build-arg PACKAGE_ROOT=services/entitlement/service --build-arg PACKAGE_BUILD_COMMAND=build:entitlement-service:prod .`
+   - Ensure to use the same `<repository_name>` you decide on here, also in the
+     `Customized Service` details station of the Admin Portal.
+2. Push the container image to Docker Hub
+   - CLI Command
+     - `docker push <dockerhub_username>/<repository_name>:<tag>`
+     - i.e. `docker push my-user/entitlement-service:20230927.1`
+3. Since this service has no workflows, we do not need to build them nor
+   register them
+4. Upload the deployment manifest to the Mosaic Hosting Service
+   - CLI Command
+     - `yarn util:load-vars mosaic hosting manifest upload -i <custom-service-id> -p <path-to-deployment-manifest-yaml> -n <unique-name-for-deployment-manifest>`
+     - i.e.
+       `yarn util:load-vars mosaic hosting manifest upload -i entitlement-service -p ./services/entitlement/service/mosaic-hosting-deployment-manifest.yaml -n entitlement-service-manifest-20230927`
+   - Ensure you provide a unique value for the manifest name
+   - NOTE: The entitlement-service requires certain environment variables to be
+     configured that are user specific (i.e. `GEOLITE` & `DRM Keys`). Therefore
+     ensure that you've followed the necessary steps to retrieve these values
+     and have updated the deployment manifest YAML with the correct values.
+5. Deploy the service with the specific artifacts (i.e. container image tag,
+   deployment manifest)
+   - CLI Command
+     - `yarn util:load-vars mosaic hosting service deploy -i <custom-service-id> -t <tag> -m <deployment-manifest-name>`
+     - i.e.
+       `yarn util:load-vars mosaic hosting service deploy -i entitlement-service -t 20230927.1 -m entitlement-service-manifest-20230927 -n entitlement-service-deployment-20230927.1`
+   - Ensure you provide a unique value for the deployment name

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
     "build:media-service:prod": "yarn && wsrun -trm -p media-service -c build && yarn install --prod",
     "build:catalog-service:prod": "yarn && wsrun -trm -p catalog-service -c build && yarn install --prod",
     "build:entitlement-service:prod": "yarn && wsrun -trm -p entitlement-service -c build && yarn install --prod",
-    "build:media-workflows:prod": "yarn && wsrun -trm -p media-workflows -c build && pilet pack services/media/workflows"
+    "build:vod-to-live-service:prod": "yarn && wsrun -trm -p vod-to-live-service -c build && yarn install --prod",
+    "build:media-workflows:prod": "yarn && wsrun -trm -p media-workflows -c build && pilet pack services/media/workflows",
+    "setup:hosting": "yarn util:load-vars ts-node ./scripts/setup-hosting.ts",
+    "yarn:de-dupe": "npx yarn-deduplicate yarn.lock"
   },
   "devDependencies": {
     "@axinom/mosaic-cli": "0.18.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "build:media-service:prod": "yarn && wsrun -trm -p media-service -c build && yarn install --prod",
     "build:catalog-service:prod": "yarn && wsrun -trm -p catalog-service -c build && yarn install --prod",
     "build:entitlement-service:prod": "yarn && wsrun -trm -p entitlement-service -c build && yarn install --prod",
-    "build:vod-to-live-service:prod": "yarn && wsrun -trm -p vod-to-live-service -c build && yarn install --prod",
     "build:media-workflows:prod": "yarn && wsrun -trm -p media-workflows -c build && pilet pack services/media/workflows",
     "setup:hosting": "yarn util:load-vars ts-node ./scripts/setup-hosting.ts",
     "yarn:de-dupe": "npx yarn-deduplicate yarn.lock"

--- a/scripts/setup-hosting.ts
+++ b/scripts/setup-hosting.ts
@@ -51,6 +51,7 @@ async function main(): Promise<void> {
       {
         serviceId: 'ax-hosting-service',
         permissions: [
+          'CONFIGURATIONS_VIEW',
           'SERVICE_DEFINITIONS_VIEW',
           'CONTAINER_REGISTRY_CONNECTIONS_VIEW',
           'SERVICE_PILET_ARTIFACTS_EDIT',

--- a/scripts/setup-hosting.ts
+++ b/scripts/setup-hosting.ts
@@ -54,6 +54,7 @@ async function main(): Promise<void> {
           'SERVICE_DEFINITIONS_VIEW',
           'SERVICE_PILET_ARTIFACTS_EDIT',
           'SERVICE_DEPLOYMENT_CONFIG_EDIT',
+          'SERVICE_DEPLOYMENTS_EDIT',
         ],
       },
       {

--- a/scripts/setup-hosting.ts
+++ b/scripts/setup-hosting.ts
@@ -52,6 +52,7 @@ async function main(): Promise<void> {
         serviceId: 'ax-hosting-service',
         permissions: [
           'SERVICE_DEFINITIONS_VIEW',
+          'CONTAINER_REGISTRY_CONNECTIONS_VIEW',
           'SERVICE_PILET_ARTIFACTS_EDIT',
           'SERVICE_DEPLOYMENT_CONFIG_EDIT',
           'SERVICE_DEPLOYMENTS_EDIT',

--- a/scripts/setup-hosting.ts
+++ b/scripts/setup-hosting.ts
@@ -1,0 +1,126 @@
+/* eslint-disable no-console */
+import {
+  devSetupServiceAccountWithPermissions,
+  getServiceAccountToken,
+} from '@axinom/mosaic-id-link-be';
+import { PermissionStructure } from '@axinom/mosaic-id-utils';
+import {
+  getBasicCustomizableConfigDefinitions,
+  getValidatedConfig,
+  isNullOrWhitespace,
+  pick,
+} from '@axinom/mosaic-service-common';
+import { from } from 'env-var';
+import { promises as fs } from 'fs';
+import { join, resolve } from 'path';
+
+async function main(): Promise<void> {
+  const env = from(process.env);
+
+  const config = getValidatedConfig(
+    pick(
+      getBasicCustomizableConfigDefinitions(),
+      'idServiceAuthBaseUrl',
+      'tenantId',
+      'environmentId',
+    ),
+  );
+
+  const devServiceAccountClientId = env
+    .get('DEV_SERVICE_ACCOUNT_CLIENT_ID')
+    .asString();
+
+  const devServiceAccountClientSecret = env
+    .get('DEV_SERVICE_ACCOUNT_CLIENT_SECRET')
+    .asString();
+
+  if (
+    isNullOrWhitespace(devServiceAccountClientId) ||
+    isNullOrWhitespace(devServiceAccountClientSecret)
+  ) {
+    throw new Error(
+      'Please ensure the root environment variables [DEV_SERVICE_ACCOUNT_CLIENT_ID] & [DEV_SERVICE_ACCOUNT_CLIENT_SECRET] have been configured.',
+    );
+  }
+
+  await serviceAccountSetup(
+    config.idServiceAuthBaseUrl,
+    devServiceAccountClientId,
+    devServiceAccountClientSecret,
+    [
+      {
+        serviceId: 'ax-hosting-service',
+        permissions: [
+          'SERVICE_DEFINITIONS_VIEW',
+          'SERVICE_PILET_ARTIFACTS_EDIT',
+          'SERVICE_DEPLOYMENT_CONFIG_EDIT',
+        ],
+      },
+      {
+        serviceId: 'ax-micro-frontend-service',
+        permissions: ['PILETS_REGISTER'],
+      },
+    ],
+  );
+}
+
+const serviceAccountSetup = async (
+  idServiceAuthBaseUrl: string,
+  devServiceAccountClientId: string,
+  devServiceAccountClientSecret: string,
+  permissions: PermissionStructure[],
+): Promise<void> => {
+  const tokenResult = await getServiceAccountToken(
+    idServiceAuthBaseUrl,
+    devServiceAccountClientId,
+    devServiceAccountClientSecret,
+  );
+
+  const serviceAccountName = `hosting-service-account`;
+  const serviceAccount = await devSetupServiceAccountWithPermissions(
+    idServiceAuthBaseUrl,
+    tokenResult.accessToken,
+    serviceAccountName,
+    permissions,
+  );
+
+  await updateEnvFile(serviceAccount.clientId, serviceAccount.clientSecret);
+
+  console.log({
+    message: `Service account "${serviceAccountName}" successfully created and its credentials added to the .env file.`,
+    ...serviceAccount,
+  });
+};
+
+async function updateEnvFile(
+  clientId: string,
+  clientSecret: string,
+): Promise<void> {
+  const envVarPath = resolve(join(process.cwd(), '.env'));
+  let envFileContent = await fs.readFile(envVarPath, { encoding: 'utf8' });
+
+  const clientIdRegex = /^MOSAIC_HOSTING_CLIENT_ID=.*$/gm;
+  const clientSecretRegex = /^MOSAIC_HOSTING_CLIENT_SECRET=.*$/gm;
+
+  const clientIdEnv = 'MOSAIC_HOSTING_CLIENT_ID=' + clientId;
+  const clientSecretEnv = 'MOSAIC_HOSTING_CLIENT_SECRET=' + clientSecret;
+
+  if (envFileContent.match(clientIdRegex) !== null) {
+    envFileContent = envFileContent.replace(clientIdRegex, clientIdEnv);
+  } else {
+    envFileContent += '\n' + clientIdEnv;
+  }
+
+  if (envFileContent.match(clientSecretRegex) !== null) {
+    envFileContent = envFileContent.replace(clientSecretRegex, clientSecretEnv);
+  } else {
+    envFileContent += '\n' + clientSecretEnv;
+  }
+
+  await fs.writeFile(envVarPath, envFileContent, 'utf8');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});

--- a/scripts/setup-hosting.ts
+++ b/scripts/setup-hosting.ts
@@ -78,7 +78,7 @@ const serviceAccountSetup = async (
     devServiceAccountClientSecret,
   );
 
-  const serviceAccountName = `hosting-service-account`;
+  const serviceAccountName = `hosting-CLI-service-account`;
   const serviceAccount = await devSetupServiceAccountWithPermissions(
     idServiceAuthBaseUrl,
     tokenResult.accessToken,

--- a/services/catalog/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/catalog/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,43 +1,65 @@
-# This YAML contains the Deployment Configuration template
-# for Catalog Service.
-# This configuration file is required when deploying the service via
-# Mosaic Hosting Service.
-# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
-# mosaic hosting manifest upload
+# This YAML contains the Deployment Manifest for the Catalog Service.
+# It is required when deploying the service via the Mosaic Hosting Service.
+# Refer to the README.md file for instructions on how to use this.
 
 version: '1.0'
-serviceId: 'ax-catalog-service'
-dnsMappedPorts:
-  - name: 'api'
-    port: 10300
-pilets: []
-serviceAccounts: []
-secureVariables:
-  PGSSLMODE: 'prefer'
-  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
-  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
-  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
-  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
-  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
-  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
-  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+serviceId: 'catalog-service'
+
+regularVariables:
+  # Service General Variables
+  SERVICE_ID: 'catalog-service'
+  NODE_ENV: 'production'
+  LOG_LEVEL: 'DEBUG'
+  GRAPHQL_GUI_ENABLED: true
+  PORT: '${__ax_hosted__.port.api}'
+
+  # Mosaic Environment Info
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+
+  # Database Server Variables
+  PGSSLMODE: '${__ax_hosted__.pg.sslmode}'
   POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
   POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
+  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
+
+  # Database Variables
+  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
   DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
-  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+
+  # RabbitMQ Variables
   RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
+  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
+  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
+  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
   RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
   RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
-  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
-  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
-  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
-  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
-regularVariables:
-  PORT: '${__ax_hosted__.port.api}'
-  NODE_ENV: 'test'
-  LOG_LEVEL: 'DEBUG'
-  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
-  SERVICE_ID: 'catalog-service'
-  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
-  GRAPHQL_GUI_ENABLED: true
+  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
+  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+
+  # Managed Service URLs
   ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
+
+secureVariables:
+  # Use this section to store any custom environment variables which contain sensitive data.
+  # i.e.
+  # YOUR_KEY: 'SENSITIVE_DATA'
+  {}
+
+serviceAccounts:
+  # Defines the service accounts that will be provisioned for this service.
+  []
+
+pilets:
+  # Defines the pilets (i.e. micro-frontends) associated with the service, and the required key-value pairs to run the pilet.
+  []
+
+dnsMappedPorts:
+  # Defines the DNS subdomains that will provisioned and be mapped to the ports exposed by the service
+  - name: 'api'
+    port: 10300

--- a/services/catalog/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/catalog/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,0 +1,43 @@
+# This YAML contains the Deployment Configuration template
+# for Catalog Service.
+# This configuration file is required when deploying the service via
+# Mosaic Hosting Service.
+# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
+# mosaic hosting manifest upload
+
+version: '1.0'
+serviceId: 'ax-catalog-service'
+dnsMappedPorts:
+  - name: 'api'
+    port: 10300
+pilets: []
+serviceAccounts: []
+secureVariables:
+  PGSSLMODE: 'prefer'
+  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
+  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
+  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+  POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
+  POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
+  DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
+  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+  RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
+  RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
+  RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
+  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
+  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+regularVariables:
+  PORT: '${__ax_hosted__.port.api}'
+  NODE_ENV: 'test'
+  LOG_LEVEL: 'DEBUG'
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  SERVICE_ID: 'catalog-service'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+  GRAPHQL_GUI_ENABLED: true
+  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'

--- a/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,0 +1,58 @@
+# This YAML contains the Deployment Configuration template
+# for Entitlement Service.
+# This configuration file is required when deploying the service via
+# Mosaic Hosting Service.
+# Make sure to replace the license key values for DRM and Geo Lite.
+# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
+# mosaic hosting manifest upload
+
+pilets: []
+version: '1.0'
+serviceId: 'entitlement-service'
+dnsMappedPorts:
+  - name: 'api'
+    port: 11600
+secureVariables:
+  PGSSLMODE: 'prefer'
+  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
+  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
+  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+  POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
+  POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
+  DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
+  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+  RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
+  RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
+  RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
+  GEOLITE2_LICENSE_KEY: [REPLACE_WITH_VALID_LICENSE_KEY]
+  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
+  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  SERVICE_ACCOUNT_CLIENT_ID: '${__ax_hosted__.sa.client_id.primary}'
+  DRM_LICENSE_COMMUNICATION_KEY: [REPLACE_WITH_VALID_LICENSE_KEY]
+  SERVICE_ACCOUNT_CLIENT_SECRET: '${__ax_hosted__.sa.client_secret.primary}'
+  DRM_LICENSE_COMMUNICATION_KEY_ID: [REPLACE_WITH_VALID_COMMUNICATION_KEY]
+serviceAccounts:
+  - name: 'primary'
+    permissionStructure:
+      - serviceId: 'ax-monetization-grants-service'
+        permissions:
+          - 'CLAIM_DEFINITIONS_SYNCHRONIZE'
+regularVariables:
+  PORT: '${__ax_hosted__.port.api}'
+  NODE_ENV: 'production'
+  DEMO_MODE: true
+  LOG_LEVEL: 'DEBUG'
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  SERVICE_ID: 'entitlement-service'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+  GRAPHQL_GUI_ENABLED: true
+  BILLING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-billing-service.end_user_base_url}'
+  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.catalog-service.api}'
+  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
+  USER_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-user-service.auth_base_url}'

--- a/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
@@ -56,7 +56,7 @@ regularVariables:
   USER_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-user-service.auth_base_url}'
 
   # Custom Service URLs
-  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.catalog-service.api}'
+  CATALOG_SERVICE_BASE_URL: 'https://${__ax_hosted__.dns.catalog-service.api}'
 
 secureVariables:
   # Use this section to store any custom environment variables which contain sensitive data.

--- a/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,58 +1,88 @@
-# This YAML contains the Deployment Configuration template
-# for Entitlement Service.
-# This configuration file is required when deploying the service via
-# Mosaic Hosting Service.
-# Make sure to replace the license key values for DRM and Geo Lite.
-# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
-# mosaic hosting manifest upload
+# This YAML contains the Deployment Manifest for the Entitlement Service.
+# It is required when deploying the service via the Mosaic Hosting Service.
+# Refer to the README.md file for instructions on how to use this.
 
-pilets: []
+# NOTE:
+# The following environment variables need to be replaced with your own values.
+#
+# GEOLITE2_LICENSE_KEY
+# DRM_LICENSE_COMMUNICATION_KEY
+# DRM_LICENSE_COMMUNICATION_KEY_ID
+
 version: '1.0'
 serviceId: 'entitlement-service'
-dnsMappedPorts:
-  - name: 'api'
-    port: 11600
-secureVariables:
-  PGSSLMODE: 'prefer'
-  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
-  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
-  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
-  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
-  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
-  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
-  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+
+regularVariables:
+  # Service General Variables
+  SERVICE_ID: 'entitlement-service'
+  NODE_ENV: 'production'
+  LOG_LEVEL: 'DEBUG'
+  GRAPHQL_GUI_ENABLED: true
+  DEMO_MODE: true
+  PORT: '${__ax_hosted__.port.api}'
+
+  # Mosaic Environment Info
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+
+  # Database Server Variables
+  PGSSLMODE: '${__ax_hosted__.pg.sslmode}'
   POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
   POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
+  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
+
+  # Database Variables
+  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
   DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
-  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+
+  # RabbitMQ Variables
   RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
+  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
+  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
+  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
   RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
   RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
-  GEOLITE2_LICENSE_KEY: [REPLACE_WITH_VALID_LICENSE_KEY]
-  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
-  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
-  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
-  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
+  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+
+  # Managed Service URLs
+  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
+  BILLING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-billing-service.end_user_base_url}'
+  USER_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-user-service.auth_base_url}'
+
+  # Custom Service URLs
+  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.catalog-service.api}'
+
+secureVariables:
+  # Use this section to store any custom environment variables which contain sensitive data.
+
+  # Service Account Variables
   SERVICE_ACCOUNT_CLIENT_ID: '${__ax_hosted__.sa.client_id.primary}'
-  DRM_LICENSE_COMMUNICATION_KEY: [REPLACE_WITH_VALID_LICENSE_KEY]
   SERVICE_ACCOUNT_CLIENT_SECRET: '${__ax_hosted__.sa.client_secret.primary}'
-  DRM_LICENSE_COMMUNICATION_KEY_ID: [REPLACE_WITH_VALID_COMMUNICATION_KEY]
+
+  # GeoLite License Key
+  GEOLITE2_LICENSE_KEY: 'REPLACE_WITH_VALID_GEOLITE2_LICENSE_KEY'
+
+  # DRM License Communication Key and ID
+  DRM_LICENSE_COMMUNICATION_KEY: 'REPLACE_WITH_VALID_DRM_LICENSE_COMMUNICATION_KEY'
+  DRM_LICENSE_COMMUNICATION_KEY_ID: 'REPLACE_WITH_VALID_DRM_LICENSE_COMMUNICATION_KEY_ID'
+
 serviceAccounts:
   - name: 'primary'
     permissionStructure:
       - serviceId: 'ax-monetization-grants-service'
         permissions:
           - 'CLAIM_DEFINITIONS_SYNCHRONIZE'
-regularVariables:
-  PORT: '${__ax_hosted__.port.api}'
-  NODE_ENV: 'production'
-  DEMO_MODE: true
-  LOG_LEVEL: 'DEBUG'
-  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
-  SERVICE_ID: 'entitlement-service'
-  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
-  GRAPHQL_GUI_ENABLED: true
-  BILLING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-billing-service.end_user_base_url}'
-  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.catalog-service.api}'
-  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
-  USER_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-user-service.auth_base_url}'
+
+pilets:
+  # Defines the pilets (i.e. micro-frontends) associated with the service, and the required key-value pairs to run the pilet.
+  []
+
+dnsMappedPorts:
+  - name: 'api'
+    port: 11600

--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,35 +1,37 @@
-# This YAML contains the Deployment Configuration template
-# for Media Service.
-# This configuration file is required when deploying the service via
-# Mosaic Hosting Service.
-# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
-# mosaic hosting manifest upload
+# This YAML contains the Deployment Manifest for the Media Service.
+# It is required when deploying the service via the Mosaic Hosting Service.
+# Refer to the README.md file for instructions on how to use this.
 
 version: '1.0'
 serviceId: 'media-service'
-dnsMappedPorts:
-  - name: 'api'
-    port: 10200
-pilets:
-  - name: 'media_workflows'
-    args:
-      MEDIA_SERVICE_BASE_URL: 'https://${__ax_hosted__.dns.self.api}'
-serviceAccounts:
-  - name: 'primary'
-    permissionStructure:
-      - serviceId: 'ax-id-service'
-        permissions:
-          - 'PERMISSIONS_SYNCHRONIZE'
-          - 'ACCESS_TOKENS_GENERATE_LONG_LIVED_TOKEN'
-      - serviceId: 'ax-image-service'
-        permissions:
-          - 'IMAGE_TYPES_DECLARE'
+
 regularVariables:
+  # Service General Variables
+  SERVICE_ID: 'media-service'
+  NODE_ENV: 'production'
+  LOG_LEVEL: 'DEBUG'
+  GRAPHQL_GUI_ENABLED: true
+  PORT: '${__ax_hosted__.port.api}'
+
+  # Mosaic Environment Info
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+
+  # Database Server Variables
+  PGSSLMODE: '${__ax_hosted__.pg.sslmode}'
   POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
   POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
   POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
-  PGSSLMODE: '${__ax_hosted__.pg.sslmode}'
+
+  # Database Variables
   DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
+  DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
+
+  # RabbitMQ Variables
   RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
   RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
   RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
@@ -37,23 +39,41 @@ regularVariables:
   RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
   RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
   RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
-  NODE_ENV: 'production'
-  SERVICE_ID: 'media-service'
-  LOG_LEVEL: 'DEBUG'
-  GRAPHQL_GUI_ENABLED: true
-  PORT: '${__ax_hosted__.port.api}'
-  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
-  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
-  IMAGE_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-image-service.management_base_url}'
-  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
-  ENCODING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-encoding-service.management_base_url}'
-secureVariables:
   RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
   RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
-  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
-  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
-  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
-  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
-  DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
+
+  # Managed Service URLs
+  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
+  IMAGE_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-image-service.management_base_url}'
+  ENCODING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-encoding-service.management_base_url}'
+
+secureVariables:
+  # Use this section to store any custom environment variables which contain sensitive data.
+
+  # Service Account Variables
   SERVICE_ACCOUNT_CLIENT_ID: '${__ax_hosted__.sa.client_id.primary}'
   SERVICE_ACCOUNT_CLIENT_SECRET: '${__ax_hosted__.sa.client_secret.primary}'
+
+serviceAccounts:
+  # Defines the service accounts that will be provisioned for this service.
+  - name: 'primary'
+    permissionStructure:
+      - serviceId: 'ax-id-service'
+        permissions:
+          - 'PERMISSIONS_SYNCHRONIZE'
+          - 'ACCESS_TOKENS_GENERATE_LONG_LIVED_TOKEN'
+
+      - serviceId: 'ax-image-service'
+        permissions:
+          - 'IMAGE_TYPES_DECLARE'
+
+pilets:
+  # Defines the pilets (i.e. micro-frontends) associated with the service, and the required key-value pairs to run the pilet.
+  - name: 'media_workflows'
+    args:
+      MEDIA_SERVICE_BASE_URL: 'https://${__ax_hosted__.dns.self.api}'
+
+dnsMappedPorts:
+  # Defines the DNS subdomains that will provisioned and be mapped to the ports exposed by the service
+  - name: 'api'
+    port: 10200

--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -45,7 +45,6 @@ regularVariables:
   TENANT_ID: '${__ax_hosted__.env.tenant_id}'
   ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
   IMAGE_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-image-service.management_base_url}'
-  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.ax-catalog-service.api}'
   ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
   ENCODING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-encoding-service.management_base_url}'
 secureVariables:

--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -45,7 +45,7 @@ regularVariables:
   # Managed Service URLs
   ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
   IMAGE_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-image-service.management_base_url}'
-  ENCODING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-encoding-service.management_base_url}'
+  ENCODING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-video-service.management_base_url}'
 
 secureVariables:
   # Use this section to store any custom environment variables which contain sensitive data.

--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -69,9 +69,11 @@ serviceAccounts:
 
 pilets:
   # Defines the pilets (i.e. micro-frontends) associated with the service, and the required key-value pairs to run the pilet.
-  - name: 'media_workflows'
+  # Use the pilet's package name as the 'name', and any ENV arguments required by the pilet under 'args'.
+  - name: 'media-workflows'
     args:
-      MEDIA_SERVICE_BASE_URL: 'https://${__ax_hosted__.dns.self.api}'
+      MEDIA_MANAGEMENT_HOST: '${__ax_hosted__.dns.self.api}'
+      MEDIA_MANAGEMENT_HTTP_PROTOCOL: 'https'
 
 dnsMappedPorts:
   # Defines the DNS subdomains that will provisioned and be mapped to the ports exposed by the service

--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -1,0 +1,60 @@
+# This YAML contains the Deployment Configuration template
+# for Media Service.
+# This configuration file is required when deploying the service via
+# Mosaic Hosting Service.
+# You can upload this to Mosaic Hosting Service using the following Mosaic CLI command:
+# mosaic hosting manifest upload
+
+version: '1.0'
+serviceId: 'media-service'
+dnsMappedPorts:
+  - name: 'api'
+    port: 10200
+pilets:
+  - name: 'media_workflows'
+    args:
+      MEDIA_SERVICE_BASE_URL: 'https://${__ax_hosted__.dns.self.api}'
+serviceAccounts:
+  - name: 'primary'
+    permissionStructure:
+      - serviceId: 'ax-id-service'
+        permissions:
+          - 'PERMISSIONS_SYNCHRONIZE'
+          - 'ACCESS_TOKENS_GENERATE_LONG_LIVED_TOKEN'
+      - serviceId: 'ax-image-service'
+        permissions:
+          - 'IMAGE_TYPES_DECLARE'
+regularVariables:
+  POSTGRESQL_HOST: '${__ax_hosted__.pg.host}'
+  POSTGRESQL_PORT: '${__ax_hosted__.pg.port}'
+  POSTGRESQL_USER_SUFFIX: '${__ax_hosted__.pg.user_suffix}'
+  PGSSLMODE: '${__ax_hosted__.pg.sslmode}'
+  DATABASE_NAME: '${__ax_hosted__.pg.database_name}'
+  RABBITMQ_PROTOCOL: '${__ax_hosted__.rmq.protocol}'
+  RABBITMQ_HOST: '${__ax_hosted__.rmq.host}'
+  RABBITMQ_PORT: '${__ax_hosted__.rmq.port}'
+  RABBITMQ_MGMT_PROTOCOL: '${__ax_hosted__.rmq.mgmt_protocol}'
+  RABBITMQ_MGMT_HOST: '${__ax_hosted__.rmq.mgmt_host}'
+  RABBITMQ_MGMT_PORT: '${__ax_hosted__.rmq.mgmt_port}'
+  RABBITMQ_VHOST: '${__ax_hosted__.rmq.vhost}'
+  NODE_ENV: 'production'
+  SERVICE_ID: 'media-service'
+  LOG_LEVEL: 'DEBUG'
+  GRAPHQL_GUI_ENABLED: true
+  PORT: '${__ax_hosted__.port.api}'
+  TENANT_ID: '${__ax_hosted__.env.tenant_id}'
+  ENVIRONMENT_ID: '${__ax_hosted__.env.environment_id}'
+  IMAGE_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-image-service.management_base_url}'
+  CATALOG_SERVICE_BASE_URL: '${__ax_hosted__.dns.ax-catalog-service.api}'
+  ID_SERVICE_AUTH_BASE_URL: '${__ax_hosted__.svc.ax-id-service.auth_base_url}'
+  ENCODING_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-encoding-service.management_base_url}'
+secureVariables:
+  RABBITMQ_USER: '${__ax_hosted__.rmq.username}'
+  RABBITMQ_PASSWORD: '${__ax_hosted__.rmq.password}'
+  DATABASE_OWNER: '${__ax_hosted__.pg.db_owner_role}'
+  DATABASE_OWNER_PASSWORD: '${__ax_hosted__.pg.db_owner_password}'
+  DATABASE_LOGIN: '${__ax_hosted__.pg.db_login_role}'
+  DATABASE_LOGIN_PASSWORD: '${__ax_hosted__.pg.db_login_password}'
+  DATABASE_GQL_ROLE: '${__ax_hosted__.pg.db_gql_role}'
+  SERVICE_ACCOUNT_CLIENT_ID: '${__ax_hosted__.sa.client_id.primary}'
+  SERVICE_ACCOUNT_CLIENT_SECRET: '${__ax_hosted__.sa.client_secret.primary}'


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Add Hosting V3 artefacts to the canary-73 branch. This enables the deployment of canary-73 through Hosting Service. However, the mosaic-cli was not updated due to dependencies with other services. So when deploying, use the latest mosaic-cli (`npx @axinom/mosaic-cli@latest`)along with the deployment manifests introduced.