### PR TITLE
[AB#42984] Add platform to docker build cmd

### DIFF
--- a/scripts/quick-deploy-service.ts
+++ b/scripts/quick-deploy-service.ts
@@ -212,7 +212,7 @@ function buildDockerImageAndPush(
   const servicePrefix = serviceId.split('-service')[0];
   const imageTag = `${username}/${serviceId}:${uniqueID}`;
 
-  const dockerBuildCommand = `docker build -t ${imageTag} --build-arg PACKAGE_ROOT=services/${servicePrefix}/service --build-arg PACKAGE_BUILD_COMMAND=build:${serviceId}:prod .`;
+  const dockerBuildCommand = `docker build -t ${imageTag} --build-arg PACKAGE_ROOT=services/${servicePrefix}/service --build-arg PACKAGE_BUILD_COMMAND=build:${serviceId}:prod . --platform linux/amd64`;
 
   console.log(
     `\nRunning Docker Build command:\n${chalk.green(dockerBuildCommand)}\n`,

--- a/scripts/quick-deploy-service.ts
+++ b/scripts/quick-deploy-service.ts
@@ -212,7 +212,7 @@ function buildDockerImageAndPush(
   const servicePrefix = serviceId.split('-service')[0];
   const imageTag = `${username}/${serviceId}:${uniqueID}`;
 
-  const dockerBuildCommand = `docker build -t ${imageTag} --build-arg PACKAGE_ROOT=services/${servicePrefix}/service --build-arg PACKAGE_BUILD_COMMAND=build:${serviceId}:prod . --platform linux/amd64`;
+  const dockerBuildCommand = `docker build -t ${imageTag} --build-arg PACKAGE_ROOT=services/${servicePrefix}/service --build-arg PACKAGE_BUILD_COMMAND=build:${serviceId}:prod --platform linux/amd64 .`;
 
   console.log(
     `\nRunning Docker Build command:\n${chalk.green(dockerBuildCommand)}\n`,


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [ ] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Adds the platform explicitly to the docker build command so that the docker image is built consistently across platforms.

Testing Notes:
- Build a docker image using quick-deploy command in a Mac and initiate a deployment. The deployment should succeed.
