### PR TITLE
[AB#42805] fix: transformNavigationTree no longer crashes the navigation if no settings items are in the tree

### DIFF
--- a/services/media/workflows/src/transformNavigation/transformNavigation.ts
+++ b/services/media/workflows/src/transformNavigation/transformNavigation.ts
@@ -36,12 +36,15 @@ export const transformNavigationTree = (
     ({ categoryName }) => categoryName === 'Settings',
   );
 
-  // move Settings to the end of the list
-  const transformedTree = [
-    ...sortedTree.slice(0, settingsIndex),
-    ...sortedTree.slice(settingsIndex + 1),
-    sortedTree[settingsIndex],
-  ];
+  const transformedTree =
+    settingsIndex !== -1
+      ? [
+          ...sortedTree.slice(0, settingsIndex),
+          ...sortedTree.slice(settingsIndex + 1),
+          // move Settings to the end of the list
+          sortedTree[settingsIndex],
+        ]
+      : sortedTree;
 
   // sort items in each category
   transformedTree.forEach(categoryItemSorter);


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [x] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [x] appropriate labels for the PR applied

## Description

There was an issue with the `transformNavigationTree` method, used to generate a the sort order of the navigation items. The function did not support the case where no items of type "Setting" were in the navigation (e.g. due to limited permissions of a user).
This fix makes the function work correctly also in these cases.