### PR TITLE
[AB#43264] fix: :heavy_plus_sign: add missing deps

### DIFF
--- a/services/catalog/service/package.json
+++ b/services/catalog/service/package.json
@@ -42,8 +42,10 @@
   },
   "dependencies": {
     "@axinom/mosaic-db-common": "0.32.0-rc.0",
+    "@axinom/mosaic-id-guard": "0.27.0-rc.0",
     "@axinom/mosaic-message-bus": "0.22.0-rc.0",
     "@axinom/mosaic-message-bus-abstractions": "0.9.0-rc.0",
+    "@axinom/mosaic-messages": "0.38.0-rc.0",
     "@axinom/mosaic-service-common": "0.44.0-rc.0",
     "@axinom/mosaic-graphql-common": "0.8.0-rc.0",
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
@@ -67,8 +69,11 @@
     "zapatos": "^3.6.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.14",
     "@types/jest": "^29",
     "@types/pg": "^8.6.5",
+    "@types/rascal": "^10.0.6",
+    "@types/verror": "^1.10.6",
     "jest": "^29",
     "jest-extended": "^3.1.0",
     "pg-formatter": "^1.3.0",

--- a/services/entitlement/service/package.json
+++ b/services/entitlement/service/package.json
@@ -95,6 +95,7 @@
     "@types/mock-req-res": "^1.1.3",
     "@types/pg": "^8.6.5",
     "@types/pluralize": "^0.0.29",
+    "@types/rascal": "^10.0.6",
     "@types/uuid": "^8.3.4",
     "@types/verror": "^1.10.6",
     "axios": "^0.24.0",

--- a/services/vod-to-live/service/package.json
+++ b/services/vod-to-live/service/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29",
+    "@types/rascal": "^10.0.6",
     "graphql": "^15.4.0",
     "graphql-tag": "^2.12.6",
     "jest": "^29",


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [X] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [X] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

We discovered that some services are missing their required deps in the package.json. Since we are in a monorepo, these deps were supplied by other services, and therefore everything appers to work well.

But when we try to build a service in isolation, the missing deps would produce build errors

## Testing Notes
Checkout the `dev` branch locally and perform the following steps for each custom service.

- Update the root package.json (change the middle * into the service-folder i.e. media-service)

FROM:
```json
"workspaces": [
    "services/*/*",
    "libs/*"
  ],
```
TO:
```json
"workspaces": [
    "services/put-the-custom-service-folder-name-here/*",
    "libs/*"
  ],
```

- run `yarn` from project root
- change directory to the `service` folder (i.e. services/media-service/service)
- run `yarn build` from there - this should not produce any errors