### PR TITLE
[AB#41828] feat: redirect browser requests to graphiql

### DIFF
--- a/.adops/pr-name-validation.yml
+++ b/.adops/pr-name-validation.yml
@@ -19,6 +19,8 @@ jobs:
           echo "Pull Request Number: $prNumber"
 
           repoUrl=$(System.PullRequest.SourceRepositoryURI)
+          # remove .git from repoUrl if present (when raising PRs from vscode, this can happen)
+          repoUrl="${repoUrl%.git}"
 
           # extract org and repo name from repoUrl
           orgRepo=$(echo "$repoUrl" | sed -e 's/.*github.com\/\(.*\)/\1/')

--- a/services/catalog/service/package.json
+++ b/services/catalog/service/package.json
@@ -47,7 +47,7 @@
     "@axinom/mosaic-message-bus-abstractions": "0.9.0-rc.0",
     "@axinom/mosaic-messages": "0.38.0-rc.0",
     "@axinom/mosaic-service-common": "0.44.0-rc.0",
-    "@axinom/mosaic-graphql-common": "0.8.0-rc.0",
+    "@axinom/mosaic-graphql-common": "0.8.0",
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "add": "^2.0.6",
     "amqplib": "^0.6.0",

--- a/services/catalog/service/src/index.ts
+++ b/services/catalog/service/src/index.ts
@@ -6,6 +6,7 @@ import {
   setupLoginPgPool,
   setupOwnerPgPool,
 } from '@axinom/mosaic-db-common';
+import { forwardToGraphiQl } from '@axinom/mosaic-graphql-common';
 import {
   createRabbitMQConnectivityMetric,
   envelopeLoggingMiddleware,
@@ -81,6 +82,10 @@ async function bootstrap(): Promise<void> {
       createRabbitMQConnectivityMetric(broker),
     ],
   });
+
+  if (config.graphqlGuiEnabled) {
+    app.use(forwardToGraphiQl());
+  }
 
   app.use(
     postgraphile(loginPool, 'app_public', buildPostgraphileOptions(config)),

--- a/services/entitlement/service/package.json
+++ b/services/entitlement/service/package.json
@@ -52,7 +52,7 @@
     "@axinom/mosaic-message-bus": "0.22.0-rc.0",
     "@axinom/mosaic-messages": "0.38.0-rc.0",
     "@axinom/mosaic-service-common": "0.44.0-rc.0",
-    "@axinom/mosaic-graphql-common": "0.8.0-rc.0",
+    "@axinom/mosaic-graphql-common": "0.8.0",
     "ajv": "^7.2.4",
     "ajv-formats": "^1.6.1",
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",

--- a/services/entitlement/service/src/graphql/postgraphile-middleware.ts
+++ b/services/entitlement/service/src/graphql/postgraphile-middleware.ts
@@ -1,4 +1,5 @@
 import { getLoginPgPool, getOwnerPgPool } from '@axinom/mosaic-db-common';
+import { forwardToGraphiQl } from '@axinom/mosaic-graphql-common';
 import { AuthenticationConfig } from '@axinom/mosaic-id-guard';
 import { Express } from 'express';
 import { postgraphile } from 'postgraphile';
@@ -13,6 +14,10 @@ export const setupPostGraphile = async (
   const ownerPool = getOwnerPgPool(app);
   const loginPool = getLoginPgPool(app);
   const options = buildPostgraphileOptions(config, ownerPool, authConfig);
+
+  if (config.graphqlGuiEnabled) {
+    app.use(forwardToGraphiQl());
+  }
 
   const middleware = postgraphile(loginPool, 'app_public', options);
 

--- a/services/media/service/package.json
+++ b/services/media/service/package.json
@@ -53,7 +53,7 @@
     "@axinom/mosaic-message-bus-abstractions": "0.9.0-rc.0",
     "@axinom/mosaic-messages": "0.38.0-rc.0",
     "@axinom/mosaic-service-common": "0.44.0-rc.0",
-    "@axinom/mosaic-graphql-common": "0.8.0-rc.0",
+    "@axinom/mosaic-graphql-common": "0.8.0",
     "@faker-js/faker": "^7.5.0",
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "ajv": "^7.2.4",

--- a/services/media/service/src/graphql/postgraphile-middleware.ts
+++ b/services/media/service/src/graphql/postgraphile-middleware.ts
@@ -1,4 +1,5 @@
 import { getLoginPgPool, getOwnerPgPool } from '@axinom/mosaic-db-common';
+import { forwardToGraphiQl } from '@axinom/mosaic-graphql-common';
 import { AuthenticationConfig } from '@axinom/mosaic-id-guard';
 import { getMessagingBroker } from '@axinom/mosaic-message-bus';
 import {
@@ -28,15 +29,16 @@ export const setupPostGraphile = async (
     authConfig,
   );
 
+  if (config.graphqlGuiEnabled) {
+    app.use(forwardToGraphiQl());
+    app.use('/altair', altairExpress({ endpointURL: '/graphql' }));
+  }
+
   const middleware = postgraphile(loginPool, 'app_public', options);
   app.use(middleware);
 
   const httpServer = getHttpServer(app);
   if (httpServer) {
     await enhanceHttpServerWithSubscriptions(httpServer, middleware);
-  }
-
-  if (config.graphqlGuiEnabled) {
-    app.use('/altair', altairExpress({ endpointURL: '/graphql' }));
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,10 +251,10 @@
     yargs "^16.2.0"
     zapatos "3.6.0"
 
-"@axinom/mosaic-graphql-common@0.8.0-rc.0":
-  version "0.8.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@axinom/mosaic-graphql-common/-/mosaic-graphql-common-0.8.0-rc.0.tgz#1156d931b870075938ca10213c30a293cd6b1051"
-  integrity sha512-6MLnHq1pPfygDtl4FL+8G6RnFgMJsTzIFfcoEhgu8dJQbXwDZJ/znBpG+rshnyfTzOyLhWYF2qsCJZ3BF3gQhg==
+"@axinom/mosaic-graphql-common@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@axinom/mosaic-graphql-common/-/mosaic-graphql-common-0.8.0.tgz#345640b1d8548b2e48e02fdc050f9538e79640c9"
+  integrity sha512-h/8FCy1T5mBRz5EOcOtdylKVtfY/gJ6BW6GcpzhXrKIUiJeTR1elLdbgParhhpa4WfI7zr1kUS8JIHvrURBIaQ==
   dependencies:
     "@graphile/pg-pubsub" "^4.12.3"
     endent "^2.1.0"


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [ ] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

This PR adds the new `forwardToGraphiQl` middleware to the media, catalog and entitlement service. This middlware will redirect users requesting the `/` route via a 'GET' request that `accepts: html` as well as requests to `/graphql` that in addition also not contain any query parameters to the `/graphiql` endpoint.
This is for example useful if someone uses the `Open in new Tab` feature on a request in the browser devtools.