### PR TITLE
[AB#42066] The catalog service GQL database role only needs select grants

### DIFF
--- a/services/catalog/service/migrations/committed/000012-improve-grants-on-gql-role.sql
+++ b/services/catalog/service/migrations/committed/000012-improve-grants-on-gql-role.sql
@@ -1,0 +1,5 @@
+--! Previous: sha1:a588014c99783319a56e38380e970b4877d2257c
+--! Hash: sha1:4a82e9d577afc339b96a80e41df75fee7615c479
+--! Message: improve-grants-on-gql-role
+
+REVOKE INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA app_public FROM ":DATABASE_GQL_ROLE";

--- a/services/catalog/service/src/domains/channels/handlers/channel-published-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/channels/handlers/channel-published-event-handler.db.spec.ts
@@ -35,7 +35,7 @@ describe('ChannelPublishEventHandler', () => {
       const channelId = getChannelId(payload.id);
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 
@@ -77,7 +77,7 @@ describe('ChannelPublishEventHandler', () => {
       payload.title = 'New title';
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/channels/handlers/channel-unpublished-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/channels/handlers/channel-unpublished-event-handler.db.spec.ts
@@ -47,7 +47,7 @@ describe('ChannelPublishEventHandler', () => {
       } as unknown as TypedTransactionalMessage<ChannelUnpublishedEvent>;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/channels/handlers/check-channel-job-status-succeeded-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/channels/handlers/check-channel-job-status-succeeded-event-handler.db.spec.ts
@@ -39,7 +39,7 @@ describe('CheckChannelJobStatusSucceededEventHandler', () => {
       } as unknown as TypedTransactionalMessage<CheckChannelJobStatusSucceededEvent>;
 
       // Act
-      const error = await ctx.executeGqlSql(async (txn) => {
+      const error = await ctx.executeOwnerSql(async (txn) => {
         return rejectionOf(handler.handleMessage(message, txn));
       });
 
@@ -73,7 +73,7 @@ describe('CheckChannelJobStatusSucceededEventHandler', () => {
       } as unknown as TypedTransactionalMessage<CheckChannelJobStatusSucceededEvent>;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/channels/handlers/live-stream-protection-key-created-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/channels/handlers/live-stream-protection-key-created-event-handler.db.spec.ts
@@ -38,7 +38,7 @@ describe('LiveStreamProtectionKeyCreatedEventHandler', () => {
       } as unknown as TypedTransactionalMessage<LiveStreamProtectionKeyCreatedEvent>;
 
       // Act
-      const error = await ctx.executeGqlSql(async (txn) => {
+      const error = await ctx.executeOwnerSql(async (txn) => {
         return rejectionOf(handler.handleMessage(message, txn));
       });
 
@@ -71,7 +71,7 @@ describe('LiveStreamProtectionKeyCreatedEventHandler', () => {
       } as unknown as TypedTransactionalMessage<LiveStreamProtectionKeyCreatedEvent>;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/collections/handlers/collection-published-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/collections/handlers/collection-published-event-handler.db.spec.ts
@@ -32,7 +32,7 @@ describe('CollectionPublishEventHandler', () => {
       const payload = message.payload;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 
@@ -98,7 +98,7 @@ describe('CollectionPublishEventHandler', () => {
       payload.title = 'New title';
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/collections/handlers/collection-unpublished-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/collections/handlers/collection-unpublished-event-handler.db.spec.ts
@@ -35,7 +35,7 @@ describe('CollectionPublishEventHandler', () => {
       } as unknown as TypedTransactionalMessage<CollectionUnpublishedEvent>;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/movies/handlers/movie-genres-published-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/movies/handlers/movie-genres-published-event-handler.db.spec.ts
@@ -31,7 +31,7 @@ describe('MovieGenrePublishEventHandler', () => {
       const message = createGenrePublishedMessage('movie_genre-1', 'New title');
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 
@@ -57,7 +57,7 @@ describe('MovieGenrePublishEventHandler', () => {
       const message = createGenrePublishedMessage(contentId, 'New title');
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 
@@ -78,7 +78,7 @@ describe('MovieGenrePublishEventHandler', () => {
       const message = createGenrePublishedMessage('movie_genre-2', 'New title');
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/movies/handlers/movie-genres-unpublished-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/movies/handlers/movie-genres-unpublished-event-handler.db.spec.ts
@@ -33,7 +33,7 @@ describe('MovieGenrePublishEventHandler', () => {
       }).run(ctx.ownerPool);
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(
           {} as unknown as TypedTransactionalMessage<MovieGenresUnpublishedEvent>,
           txn,
@@ -60,7 +60,7 @@ describe('MovieGenrePublishEventHandler', () => {
       ]).run(ctx.ownerPool);
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(
           {} as unknown as TypedTransactionalMessage<MovieGenresUnpublishedEvent>,
           txn,
@@ -90,7 +90,7 @@ describe('MovieGenrePublishEventHandler', () => {
       }).run(ctx.ownerPool);
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(
           {} as unknown as TypedTransactionalMessage<MovieGenresUnpublishedEvent>,
           txn,

--- a/services/catalog/service/src/domains/movies/handlers/movie-published-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/movies/handlers/movie-published-event-handler.db.spec.ts
@@ -33,7 +33,7 @@ describe('MoviePublishEventHandler', () => {
       const payload = message.payload;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 
@@ -123,7 +123,7 @@ describe('MoviePublishEventHandler', () => {
       payload.title = 'New title';
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/movies/handlers/movie-unpublished-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/movies/handlers/movie-unpublished-event-handler.db.spec.ts
@@ -34,7 +34,7 @@ describe('MoviePublishEventHandler', () => {
       } as unknown as TypedTransactionalMessage<MovieUnpublishedEvent>;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/tvshows/handlers/episode-published-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/episode-published-event-handler.db.spec.ts
@@ -33,7 +33,7 @@ describe('EpisodePublishEventHandler', () => {
       const payload = message.payload;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 
@@ -108,7 +108,7 @@ describe('EpisodePublishEventHandler', () => {
       message.payload.title = 'New title';
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/tvshows/handlers/episode-unpublished-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/episode-unpublished-event-handler.db.spec.ts
@@ -35,7 +35,7 @@ describe('EpisodePublishEventHandler', () => {
       } as unknown as TypedTransactionalMessage<EpisodeUnpublishedEvent>;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/tvshows/handlers/season-published-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/season-published-event-handler.db.spec.ts
@@ -33,7 +33,7 @@ describe('SeasonPublishEventHandler', () => {
       const payload = message.payload;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 
@@ -124,7 +124,7 @@ describe('SeasonPublishEventHandler', () => {
       message.payload.description = 'New description';
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 

--- a/services/catalog/service/src/domains/tvshows/handlers/season-unpublished-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/season-unpublished-event-handler.db.spec.ts
@@ -35,7 +35,7 @@ describe('SeasonPublishEventHandler', () => {
       } as unknown as TypedTransactionalMessage<SeasonUnpublishedEvent>;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
       // Assert

--- a/services/catalog/service/src/domains/tvshows/handlers/tvshow-genres-published-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/tvshow-genres-published-event-handler.db.spec.ts
@@ -34,7 +34,7 @@ describe('TvshowGenrePublishEventHandler', () => {
       );
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
       // TODO: Consider verifying via the GQL API.
@@ -59,7 +59,7 @@ describe('TvshowGenrePublishEventHandler', () => {
       const message = createGenrePublishedMessage(contentId, 'New title');
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 
@@ -83,7 +83,7 @@ describe('TvshowGenrePublishEventHandler', () => {
       );
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
       // Assert

--- a/services/catalog/service/src/domains/tvshows/handlers/tvshow-genres-unpublished-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/tvshow-genres-unpublished-event-handler.db.spec.ts
@@ -33,7 +33,7 @@ describe('TvshowGenrePublishEventHandler', () => {
       }).run(ctx.ownerPool);
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(
           {} as TypedTransactionalMessage<TvshowGenresUnpublishedEvent>,
           txn,
@@ -60,7 +60,7 @@ describe('TvshowGenrePublishEventHandler', () => {
       ]).run(ctx.ownerPool);
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(
           {} as TypedTransactionalMessage<TvshowGenresUnpublishedEvent>,
           txn,
@@ -90,7 +90,7 @@ describe('TvshowGenrePublishEventHandler', () => {
       }).run(ctx.ownerPool);
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(
           {} as TypedTransactionalMessage<TvshowGenresUnpublishedEvent>,
           txn,

--- a/services/catalog/service/src/domains/tvshows/handlers/tvshow-published-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/tvshow-published-event-handler.db.spec.ts
@@ -33,7 +33,7 @@ describe('TvshowPublishEventHandler', () => {
       const payload = message.payload;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
 
@@ -121,7 +121,7 @@ describe('TvshowPublishEventHandler', () => {
       message.payload.title = 'New title';
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
       // Assert

--- a/services/catalog/service/src/domains/tvshows/handlers/tvshow-unpublished-event-handler.db.spec.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/tvshow-unpublished-event-handler.db.spec.ts
@@ -34,7 +34,7 @@ describe('TvshowPublishEventHandler', () => {
       } as unknown as TypedTransactionalMessage<TvshowUnpublishedEvent>;
 
       // Act
-      await ctx.executeGqlSql(async (txn) => {
+      await ctx.executeOwnerSql(async (txn) => {
         await handler.handleMessage(message, txn);
       });
       // Assert

--- a/services/catalog/service/src/generated/db/schema.sql
+++ b/services/catalog/service/src/generated/db/schema.sql
@@ -4325,14 +4325,14 @@ GRANT ALL ON FUNCTION ax_utils.validation_valid_url_array(input_value text[]) TO
 -- Name: TABLE channel; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.channel TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.channel TO catalog_service_gql_role;
 
 
 --
 -- Name: TABLE channel_images; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.channel_images TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.channel_images TO catalog_service_gql_role;
 
 
 --
@@ -4346,14 +4346,14 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.channel_images_id_seq TO catalog_servi
 -- Name: TABLE collection; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.collection TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.collection TO catalog_service_gql_role;
 
 
 --
 -- Name: TABLE collection_images; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.collection_images TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.collection_images TO catalog_service_gql_role;
 
 
 --
@@ -4367,7 +4367,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.collection_images_id_seq TO catalog_se
 -- Name: TABLE collection_items_relation; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.collection_items_relation TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.collection_items_relation TO catalog_service_gql_role;
 
 
 --
@@ -4381,14 +4381,14 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.collection_items_relation_id_seq TO ca
 -- Name: TABLE episode; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.episode TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.episode TO catalog_service_gql_role;
 
 
 --
 -- Name: TABLE episode_genres_relation; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.episode_genres_relation TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.episode_genres_relation TO catalog_service_gql_role;
 
 
 --
@@ -4402,7 +4402,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.episode_genres_relation_id_seq TO cata
 -- Name: TABLE episode_images; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.episode_images TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.episode_images TO catalog_service_gql_role;
 
 
 --
@@ -4416,7 +4416,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.episode_images_id_seq TO catalog_servi
 -- Name: TABLE episode_licenses; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.episode_licenses TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.episode_licenses TO catalog_service_gql_role;
 
 
 --
@@ -4430,7 +4430,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.episode_licenses_id_seq TO catalog_ser
 -- Name: TABLE episode_video_cue_points; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.episode_video_cue_points TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.episode_video_cue_points TO catalog_service_gql_role;
 
 
 --
@@ -4444,7 +4444,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.episode_video_cue_points_id_seq TO cat
 -- Name: TABLE episode_video_streams; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.episode_video_streams TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.episode_video_streams TO catalog_service_gql_role;
 
 
 --
@@ -4458,7 +4458,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.episode_video_streams_id_seq TO catalo
 -- Name: TABLE episode_videos; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.episode_videos TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.episode_videos TO catalog_service_gql_role;
 
 
 --
@@ -4472,21 +4472,21 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.episode_videos_id_seq TO catalog_servi
 -- Name: TABLE movie; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.movie TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.movie TO catalog_service_gql_role;
 
 
 --
 -- Name: TABLE movie_genre; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.movie_genre TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.movie_genre TO catalog_service_gql_role;
 
 
 --
 -- Name: TABLE movie_genres_relation; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.movie_genres_relation TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.movie_genres_relation TO catalog_service_gql_role;
 
 
 --
@@ -4500,7 +4500,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.movie_genres_relation_id_seq TO catalo
 -- Name: TABLE movie_images; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.movie_images TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.movie_images TO catalog_service_gql_role;
 
 
 --
@@ -4514,7 +4514,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.movie_images_id_seq TO catalog_service
 -- Name: TABLE movie_licenses; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.movie_licenses TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.movie_licenses TO catalog_service_gql_role;
 
 
 --
@@ -4528,7 +4528,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.movie_licenses_id_seq TO catalog_servi
 -- Name: TABLE movie_video_cue_points; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.movie_video_cue_points TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.movie_video_cue_points TO catalog_service_gql_role;
 
 
 --
@@ -4542,7 +4542,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.movie_video_cue_points_id_seq TO catal
 -- Name: TABLE movie_video_streams; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.movie_video_streams TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.movie_video_streams TO catalog_service_gql_role;
 
 
 --
@@ -4556,7 +4556,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.movie_video_streams_id_seq TO catalog_
 -- Name: TABLE movie_videos; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.movie_videos TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.movie_videos TO catalog_service_gql_role;
 
 
 --
@@ -4570,14 +4570,14 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.movie_videos_id_seq TO catalog_service
 -- Name: TABLE season; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.season TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.season TO catalog_service_gql_role;
 
 
 --
 -- Name: TABLE season_genres_relation; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.season_genres_relation TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.season_genres_relation TO catalog_service_gql_role;
 
 
 --
@@ -4591,7 +4591,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.season_genres_relation_id_seq TO catal
 -- Name: TABLE season_images; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.season_images TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.season_images TO catalog_service_gql_role;
 
 
 --
@@ -4605,7 +4605,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.season_images_id_seq TO catalog_servic
 -- Name: TABLE season_licenses; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.season_licenses TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.season_licenses TO catalog_service_gql_role;
 
 
 --
@@ -4619,7 +4619,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.season_licenses_id_seq TO catalog_serv
 -- Name: TABLE season_video_cue_points; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.season_video_cue_points TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.season_video_cue_points TO catalog_service_gql_role;
 
 
 --
@@ -4633,7 +4633,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.season_video_cue_points_id_seq TO cata
 -- Name: TABLE season_video_streams; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.season_video_streams TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.season_video_streams TO catalog_service_gql_role;
 
 
 --
@@ -4647,7 +4647,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.season_video_streams_id_seq TO catalog
 -- Name: TABLE season_videos; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.season_videos TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.season_videos TO catalog_service_gql_role;
 
 
 --
@@ -4661,21 +4661,21 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.season_videos_id_seq TO catalog_servic
 -- Name: TABLE tvshow; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.tvshow TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.tvshow TO catalog_service_gql_role;
 
 
 --
 -- Name: TABLE tvshow_genre; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.tvshow_genre TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.tvshow_genre TO catalog_service_gql_role;
 
 
 --
 -- Name: TABLE tvshow_genres_relation; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.tvshow_genres_relation TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.tvshow_genres_relation TO catalog_service_gql_role;
 
 
 --
@@ -4689,7 +4689,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.tvshow_genres_relation_id_seq TO catal
 -- Name: TABLE tvshow_images; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.tvshow_images TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.tvshow_images TO catalog_service_gql_role;
 
 
 --
@@ -4703,7 +4703,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.tvshow_images_id_seq TO catalog_servic
 -- Name: TABLE tvshow_licenses; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.tvshow_licenses TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.tvshow_licenses TO catalog_service_gql_role;
 
 
 --
@@ -4717,7 +4717,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.tvshow_licenses_id_seq TO catalog_serv
 -- Name: TABLE tvshow_video_cue_points; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.tvshow_video_cue_points TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.tvshow_video_cue_points TO catalog_service_gql_role;
 
 
 --
@@ -4731,7 +4731,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.tvshow_video_cue_points_id_seq TO cata
 -- Name: TABLE tvshow_video_streams; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.tvshow_video_streams TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.tvshow_video_streams TO catalog_service_gql_role;
 
 
 --
@@ -4745,7 +4745,7 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.tvshow_video_streams_id_seq TO catalog
 -- Name: TABLE tvshow_videos; Type: ACL; Schema: app_public; Owner: -
 --
 
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE app_public.tvshow_videos TO catalog_service_gql_role;
+GRANT SELECT ON TABLE app_public.tvshow_videos TO catalog_service_gql_role;
 
 
 --

--- a/services/catalog/service/src/tests/test-utils/test-context.ts
+++ b/services/catalog/service/src/tests/test-utils/test-context.ts
@@ -114,7 +114,7 @@ export interface ITestContext {
     variables?: Dict<any>,
     requestContext?: TestRequestContext,
   ): Promise<IExecutionResult>;
-  executeGqlSql<T>(
+  executeOwnerSql<T>(
     callback: (client: TxnClient<IsolationLevel>) => Promise<T>,
   ): Promise<T>;
 }
@@ -167,16 +167,16 @@ export const createTestContext = async (
     options,
   );
 
-  const executeGqlSql = async <T>(
+  const executeOwnerSql = async <T>(
     callback: (client: TxnClient<IsolationLevel>) => Promise<T>,
   ): Promise<T> => {
     const pgSettings = buildPgSettings(
       createTestUser(config.serviceId),
-      config.dbGqlRole,
+      config.dbOwner,
       config.serviceId,
     );
     return transactionWithContext(
-      loginPool,
+      ownerPool,
       IsolationLevel.Serializable,
       pgSettings,
       async (dbContext) => callback(dbContext),
@@ -191,7 +191,7 @@ export const createTestContext = async (
     options,
     schema,
     runGqlQuery,
-    executeGqlSql,
+    executeOwnerSql,
     truncate: async function (tableName: Table): Promise<void> {
       try {
         await truncate(tableName, 'CASCADE').run(this.ownerPool);


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [X] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [X] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

For a good separation of concern and security context boundaries, we have the database owner role and the GQL database role. The GQL role is used in the GraphQL API and should have all the required grants. As the Catalog Service GaphQL API only allows query operations, the only required grant is `SELECT` on all the tables in the `app_public` namespace. This PR removes the `INSERT`, `UPDATE`, and `DELETE` grants from the tables in the `app_public` namespace from the GQL role.

## Testing notes

Please test if publishing still works for all the different entities both from the media service (movies, TV shows, seasons, episodes, and collections) as well as for channels.