### PR TITLE
[AB#43432] Allow a custom GEO IP download URL to be configured

### DIFF
--- a/services/entitlement/service/.env.template
+++ b/services/entitlement/service/.env.template
@@ -29,6 +29,8 @@ MOSAIC_TESTING_IP_ENABLED=false
 # You will need a Geolite2 free account, which can also be created using the link above using the signup button.
 # This key is optional during development, but is required when deployed.
 GEOLITE2_LICENSE_KEY=
+# You can define your GEO database cache server/repository in case you run into the Maxmind download limit.
+# GEOLITE2_DOWNLOAD_URL=
 
 # These variables are optional and are only needed for local development
 DEV_USER_SERVICE_MANAGEMENT_BASE_URL=https://user.service.eu.axinom.net

--- a/services/entitlement/service/README.md
+++ b/services/entitlement/service/README.md
@@ -33,7 +33,10 @@ during service runtime. Please have a look at their EULA
       both values.
   - Sign up for a free GeoLite2 account at
     https://dev.maxmind.com/geoip/geolite2-free-geolocation-data, generate a
-    license key and set it as value for GEOLITE2_LICENSE_KEY
+    license key and set it as the value for the GEOLITE2_LICENSE_KEY. If your
+    service(s) run into the Maxmind daily download limit you can set up your own
+    GEO database (proxy) cache or repository. You can set the URL to this
+    service/DB as the `GEOLITE2_DOWNLOAD_URL` in your environment variables.
   - (Optionally) run `yarn setup:webhooks` to generate webhook secrets and set
     related values in `.env` file. This will enable `/entitlement` and
     `/manifest` webhook endpoints to be able to authenticate requests.

--- a/services/entitlement/service/package.json
+++ b/services/entitlement/service/package.json
@@ -61,7 +61,7 @@
     "env-cmd": "^10.1.0",
     "env-var": "^6.3.0",
     "express": "^4.18.1",
-    "geoip-country": "^4.2.76",
+    "geoip-country": "^4.2.78",
     "graphile-build": "4.13.0",
     "graphile-build-pg": "4.13.0",
     "graphile-migrate": "^1.4.0",

--- a/services/entitlement/service/src/common/config/config-definitions.ts
+++ b/services/entitlement/service/src/common/config/config-definitions.ts
@@ -13,6 +13,7 @@ import {
 import { from } from 'env-var';
 
 export const GEOLITE2_LICENSE_KEY = 'GEOLITE2_LICENSE_KEY';
+export const GEOLITE2_DOWNLOAD_URL = 'GEOLITE2_DOWNLOAD_URL';
 
 /**
  * Get an object that contains all the configuration declaration functions to
@@ -53,6 +54,7 @@ export const getConfigDefinitions = (
     geolite2LicenseKey: function () {
       return env.get(GEOLITE2_LICENSE_KEY).required(!this.isDev()).asString();
     },
+    geolite2DownloadUrl: () => env.get(GEOLITE2_DOWNLOAD_URL).asString(),
 
     drmLicenseCommunicationKeyBuffer: function () {
       return Buffer.from(this.drmLicenseCommunicationKey(), 'base64');

--- a/services/entitlement/service/src/update-geo-database.ts
+++ b/services/entitlement/service/src/update-geo-database.ts
@@ -7,7 +7,7 @@ import {
   removeAnsiColorEscapeCodes,
 } from '@axinom/mosaic-service-common';
 import { updateDatabase } from 'geoip-country';
-import { Config, GEOLITE2_LICENSE_KEY } from './common';
+import { Config, GEOLITE2_DOWNLOAD_URL, GEOLITE2_LICENSE_KEY } from './common';
 
 /**
  * Returns an error to be thrown in case initial (startup) geo database update attempt fails.
@@ -74,14 +74,18 @@ const scheduleUpdate = (config: Config, logger: Logger): void => {
 
 /**
  * Performs a geo database update and schedules recurring updates to happen every day.
- * During development, will not require the license key, but will produce reminder warnings on startup to keep geo databases up-to-date
+ * During development, we will not require the license key/download URL, but will produce a warning on startup to keep the GEO databases up-to-date.
  */
 export const updateGeoDatabase = async (config: Config): Promise<void> => {
   const logger = new Logger({ config, context: updateGeoDatabase.name });
   try {
-    if (config.isDev && isNullOrWhitespace(config.geolite2LicenseKey)) {
+    if (
+      config.isDev &&
+      isNullOrWhitespace(config.geolite2LicenseKey) &&
+      isNullOrWhitespace(config.geolite2DownloadUrl)
+    ) {
       logger.warn(
-        `The '${GEOLITE2_LICENSE_KEY}' env variable is not set. Geolocation databases might be outdated! Please make sure to update the 'geoip-country' npm package at least once every 30 days or enable automatic database updates by setting an env variable for the license key.`,
+        `The '${GEOLITE2_LICENSE_KEY}' or '${GEOLITE2_DOWNLOAD_URL}' env variables are not set. The GEO location databases might be outdated! Please make sure to update the 'geoip-country' npm package at least once every 30 days or enable automatic database updates by setting an env variable for the license key.`,
       );
       return;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6959,10 +6959,10 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=
 
-geoip-country@^4.2.76:
-  version "4.2.76"
-  resolved "https://registry.yarnpkg.com/geoip-country/-/geoip-country-4.2.76.tgz#9bab0a4e29c6a7d4e6a2d181dc275833a34a2690"
-  integrity sha512-j+sZFeeTUwchkVIsv5pzV5SN1Gf/7pLhIVeNOS3OQErpiyIuehigKDMSvYVl+yxxDaXa6bTfM9HWoEIwFUkcLQ==
+geoip-country@^4.2.78:
+  version "4.2.78"
+  resolved "https://registry.yarnpkg.com/geoip-country/-/geoip-country-4.2.78.tgz#39a4ce0fc6ecee259855b845c3933f65300ba2ba"
+  integrity sha512-bBXO8saz0N2jIypRZI/pZ/1kefgN88ukqc7BmSXs5i0yIWf3wqGjOYuh36+8xilyzUM8aUhNaI5erVs3CdPxKw==
   dependencies:
     async "^2.6.4"
     iconv-lite "^0.5.2"


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [X] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [X] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Maxmind has a daily download limit for their GEO IP databases (2000 for paid accounts and 30 for free accounts). If your entitlement service is deployed in a scalable way or deployed/restarted often that limit can be exceeded. To avoid this limit Maxmind suggests downloading their database with your license key to some shared repository or setting up a proxy cache from where your services download the database. 

You can set this URL in the environment variable `GEOLITE2_DOWNLOAD_URL` for your Entitlement Service.

The used library (https://github.com/sapics/geoip-country) got upgraded with this functionality so this PR includes no code changes.

## Release Notes

Maxmind has a daily download limit for their GEO IP databases (2000 for paid accounts and 30 for free accounts). If your entitlement service is deployed in a scalable way or deployed/restarted often that limit can be exceeded. To avoid this limit Maxmind suggests downloading their database with your license key to some shared repository or setting up a proxy cache from where your services download the database. 

You can set this URL in the environment variable `GEOLITE2_DOWNLOAD_URL` for your Entitlement Service.
