### PR TITLE
[AB#42991] Use new metrics interface with the logger passed-in

### DIFF
--- a/services/catalog/service/package.json
+++ b/services/catalog/service/package.json
@@ -41,7 +41,7 @@
     "util:define-func-migration": "yarn mosaic generate-define-func-migration"
   },
   "dependencies": {
-    "@axinom/mosaic-db-common": "0.34.0-rc.0",
+    "@axinom/mosaic-db-common": "0.34.0-rc.11",
     "@axinom/mosaic-graphql-common": "0.10.0-rc.0",
     "@axinom/mosaic-id-guard": "0.29.0-rc.0",
     "@axinom/mosaic-messages": "0.40.0-rc.0",

--- a/services/catalog/service/src/index.ts
+++ b/services/catalog/service/src/index.ts
@@ -68,7 +68,11 @@ async function bootstrap(): Promise<void> {
 
   setupMonitoring(config, {
     metrics: [
-      createPostgresPoolConnectivityMetric(getLoginPgPool(app), 'loginPool'),
+      createPostgresPoolConnectivityMetric(
+        logger,
+        getLoginPgPool(app),
+        'loginPool',
+      ),
       createRabbitMQConnectivityMetric(broker),
     ],
   });

--- a/services/entitlement/service/package.json
+++ b/services/entitlement/service/package.json
@@ -46,7 +46,7 @@
     "util:define-func-migration": "yarn mosaic generate-define-func-migration"
   },
   "dependencies": {
-    "@axinom/mosaic-db-common": "0.34.0-rc.0",
+    "@axinom/mosaic-db-common": "0.34.0-rc.11",
     "@axinom/mosaic-graphql-common": "0.10.0-rc.0",
     "@axinom/mosaic-id-guard": "0.29.0-rc.0",
     "@axinom/mosaic-id-utils": "0.15.14-rc.0",

--- a/services/entitlement/service/src/index.ts
+++ b/services/entitlement/service/src/index.ts
@@ -92,7 +92,11 @@ async function bootstrap(): Promise<void> {
 
   setupMonitoring(config, {
     metrics: [
-      createPostgresPoolConnectivityMetric(getLoginPgPool(app), 'loginPool'),
+      createPostgresPoolConnectivityMetric(
+        logger,
+        getLoginPgPool(app),
+        'loginPool',
+      ),
       createRabbitMQConnectivityMetric(broker),
     ],
   });

--- a/services/media/service/package.json
+++ b/services/media/service/package.json
@@ -46,7 +46,7 @@
     "util:define-func-migration": "yarn mosaic generate-define-func-migration"
   },
   "dependencies": {
-    "@axinom/mosaic-db-common": "0.34.0-rc.0",
+    "@axinom/mosaic-db-common": "0.34.0-rc.11",
     "@axinom/mosaic-graphql-common": "0.10.0-rc.0",
     "@axinom/mosaic-id-guard": "0.29.0-rc.0",
     "@axinom/mosaic-id-link-be": "0.18.0-rc.0",

--- a/services/media/service/src/index.ts
+++ b/services/media/service/src/index.ts
@@ -123,7 +123,7 @@ async function bootstrap(): Promise<void> {
   // Configure metrics endpoint for Prometheus.
   setupMonitoring(config, {
     metrics: [
-      createPostgresPoolConnectivityMetric(loginPgPool, 'loginPool'),
+      createPostgresPoolConnectivityMetric(logger, loginPgPool, 'loginPool'),
       createRabbitMQConnectivityMetric(broker),
     ],
   });

--- a/services/vod-to-live/service/package.json
+++ b/services/vod-to-live/service/package.json
@@ -31,7 +31,7 @@
     "@axinom/mosaic-id-guard": "0.29.0-rc.0",
     "@axinom/mosaic-message-bus": "0.24.0-rc.0",
     "@axinom/mosaic-messages": "0.40.0-rc.0",
-    "@axinom/mosaic-service-common": "0.46.0-rc.0",
+    "@axinom/mosaic-service-common": "0.46.0-rc.11",
     "@azure/storage-blob": "^12.14.0",
     "amqplib": "^0.6.0",
     "axios": "^0.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,16 +257,16 @@
   resolved "https://registry.yarnpkg.com/@axinom/mosaic-core/-/mosaic-core-0.4.17-rc.0.tgz#c0b26bb0e7e25d43bd26dff271c63787c4cfd847"
   integrity sha512-1RkvGuAOxOSG/ff2+3GmhI+ypupJ+FQ1QBvi3+WceIqF6XMiwYba6lts3AJ5vO58m0N5+0XM8NpTgabJrmFliA==
 
-"@axinom/mosaic-db-common@0.34.0-rc.0":
-  version "0.34.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@axinom/mosaic-db-common/-/mosaic-db-common-0.34.0-rc.0.tgz#675231605a15c12e18b1fd4ed55166c5a82d01f6"
-  integrity sha512-dDKiLw0EzikQhL0sSrOiuIGMhePZMkwSFv1jhENy1w/ITPkN37iQ8RDPTcp2d0k3GqC3JC4Wi8UcuWoMievLUA==
+"@axinom/mosaic-db-common@0.34.0-rc.11":
+  version "0.34.0-rc.11"
+  resolved "https://registry.yarnpkg.com/@axinom/mosaic-db-common/-/mosaic-db-common-0.34.0-rc.11.tgz#3b993f570fbd0647cadabaa661e076d045cc17d6"
+  integrity sha512-qkqmALz+4jjxia3WH9bhhRgjzUOwzFn4nYdSyuwUpqEI6fG1J+1ZpQOuU5hdFJ39day7d/qem1t1oSy7apixHw==
   dependencies:
     express "^4.17.1"
     graphile-migrate "^1.4.0"
     pg "^8.11.3"
     pg-logical-replication "^2.0.3"
-    prom-client "^13.2.0"
+    prom-client "^15.1.0"
     readdirp "^3.4.0"
     yargs "^16.2.0"
     zapatos "3.6.0"
@@ -389,6 +389,32 @@
     moment "^2.29.1"
     prom-client "^13.2.0"
     serialize-error "^7.0.1"
+    short-hash "^1.0.0"
+    uuid "^8.3.2"
+    uuid-encoder "^1.2.0"
+    verror "^1.10.1"
+
+"@axinom/mosaic-service-common@0.46.0-rc.11":
+  version "0.46.0-rc.11"
+  resolved "https://registry.yarnpkg.com/@axinom/mosaic-service-common/-/mosaic-service-common-0.46.0-rc.11.tgz#98f3f75458486a8ead5885799a45901956ab48bb"
+  integrity sha512-fyxUI7os8uP0sMRB1QLloCCXNqfrUaxls+Zb+UT6zycy2/5d8VYtlxKw4pb1tnvaxGK9an5xYT7QsCxHykRnkw==
+  dependencies:
+    ajv "^7.0.3"
+    ajv-formats "^2.1.1"
+    axios "1.6.3"
+    cockatiel "^3.1.1"
+    endent "^2.1.0"
+    env-var "^6.3.0"
+    express "^4.17.1"
+    express-basic-auth "^1.2.1"
+    fast-stable-stringify "^1.0.0"
+    inflection "^1.12.0"
+    jest "^29"
+    jest-expect-message "^1.1.3"
+    moment "^2.29.1"
+    prom-client "^15.1.0"
+    serialize-error "^7.0.1"
+    serve-favicon "^2.5.0"
     short-hash "^1.0.0"
     uuid "^8.3.2"
     uuid-encoder "^1.2.0"
@@ -2602,6 +2628,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.1.0.tgz#563539048255bbe1a5f4f586a4a10a1bb737f44a"
   integrity sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==
+
+"@opentelemetry/api@^1.4.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.8.0.tgz#5aa7abb48f23f693068ed2999ae627d2f7d902ec"
+  integrity sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==
 
 "@peculiar/asn1-schema@^2.1.6":
   version "2.3.0"
@@ -9587,6 +9618,11 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
+ms@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -10082,7 +10118,7 @@ parse5@^7.0.0:
   dependencies:
     entities "^4.4.0"
 
-parseurl@^1.3.2, parseurl@~1.3.3:
+parseurl@^1.3.2, parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -10917,6 +10953,14 @@ prom-client@^13.2.0:
   dependencies:
     tdigest "^0.1.1"
 
+prom-client@^15.1.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-15.1.0.tgz#816a4a2128da169d0471093baeccc6d2f17a4613"
+  integrity sha512-cCD7jLTqyPdjEPBo/Xk4Iu8jxjuZgZJ3e/oET3L+ZwOuap/7Cw3dH/TJSsZKs1TQLZ2IHpIlRAKw82ef06kmMw==
+  dependencies:
+    "@opentelemetry/api" "^1.4.0"
+    tdigest "^0.1.1"
+
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
@@ -11612,6 +11656,11 @@ rxjs@^7.5.5:
   dependencies:
     tslib "^2.1.0"
 
+safe-buffer@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+  integrity sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1, safe-buffer@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -11800,6 +11849,17 @@ serialize-javascript@^6.0.0:
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
   dependencies:
     randombytes "^2.1.0"
+
+serve-favicon@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/serve-favicon/-/serve-favicon-2.5.0.tgz#935d240cdfe0f5805307fdfe967d88942a2cbcf0"
+  integrity sha512-FMW2RvqNr03x+C0WxTyu6sOv21oOjkq5j8tjquWccwa6ScNyGFOGJVpuS1NmTVGBAHS07xnSKotgf2ehQmf9iA==
+  dependencies:
+    etag "~1.8.1"
+    fresh "0.5.2"
+    ms "2.1.1"
+    parseurl "~1.3.2"
+    safe-buffer "5.1.1"
 
 serve-static@1.15.0:
   version "1.15.0"


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [ ] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [X] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [X] appropriate labels for the PR applied

## Description

We use the latest service-common & db-common libraries that offers a new metric interface. Using this would ensure that any errors caused during metric collection will not disrupt the other successfully collected metrics in the registry. Instead an error will be logged for the errorneous metric collection.

## Release Notes

The media-template services were updated to use the latest service-common library, specifically now we use the updated `setupMonitoring` method of this library that will ensure if there will be any errors of a single metric during its collection, the other successfully collected metrics will be availble in the registry. Instead an error log will be generated to be investigated separately.