### PR TITLE
[AB#43535] Update isLocalizationEnabled if Localization Service is disabled

### DIFF
--- a/services/media/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/media/service/mosaic-hosting-deployment-manifest.yaml
@@ -71,7 +71,7 @@ regularVariables:
   VIDEO_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-video-service.management_base_url}'
   LOCALIZATION_SERVICE_BASE_URL: '${__ax_hosted__.svc.ax-localization-service.management_base_url}'
 
-  IS_LOCALIZATION_ENABLED: false
+  IS_LOCALIZATION_ENABLED: true
 
 secureVariables:
   # Use this section to store any custom environment variables which contain sensitive data.

--- a/services/media/service/src/common/utils/index.ts
+++ b/services/media/service/src/common/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './is-localization-available';
 export * from './token-utils';
 export * from './validation-utils';

--- a/services/media/service/src/common/utils/is-localization-available.spec.ts
+++ b/services/media/service/src/common/utils/is-localization-available.spec.ts
@@ -1,3 +1,4 @@
+import { getAuthenticatedManagementSubject } from '@axinom/mosaic-id-guard';
 import { Logger } from '@axinom/mosaic-service-common';
 import { Config } from '../config';
 import { updateConfigWithActualLocalizationAvailability } from './is-localization-available';
@@ -5,6 +6,10 @@ import { requestServiceAccountToken } from './token-utils';
 
 jest.mock('./token-utils', () => ({
   requestServiceAccountToken: jest.fn(),
+}));
+
+jest.mock('@axinom/mosaic-id-guard', () => ({
+  getAuthenticatedManagementSubject: jest.fn().mockReturnValue({}),
 }));
 
 describe('localizationAvailableCheck', () => {
@@ -35,42 +40,12 @@ describe('localizationAvailableCheck', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('should keep isLocalizationEnabled as true if the service account token has localization permission', async () => {
-    // Arrange - fake signed token contains permissions for the localization service
-    (requestServiceAccountToken as jest.Mock).mockResolvedValue(
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwZXJtaXNzaW9ucyI6eyJheC1sb2NhbGl6YXRpb24tc2VydmljZSI6WyJFTlRJVFlfREVGSU5JVElPTlNfRURJVCJdfSwiaWF0IjoxNzEwNzcyNTk4fQ.z6WfHLgtpsDr_dFQpaULMZGPzSAhvB8g2AUZ-nmqCk8',
-    );
-
-    // Act
-    await updateConfigWithActualLocalizationAvailability(mockConfig, logger);
-
-    // Assert
-    expect(requestServiceAccountToken).toHaveBeenCalledWith(mockConfig);
-    expect(mockConfig.isLocalizationEnabled).toBe(true);
-    expect(logger.warn).not.toHaveBeenCalled();
-  });
-
-  it('should set isLocalizationEnabled to false if the service account token does not have localization permission', async () => {
-    // Arrange - fake signed token does not contain permissions for the localization service
-    const mockToken =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwZXJtaXNzaW9ucyI6e30sImlhdCI6MTcxMDc3MjYzMX0.FUgks4EvGilaqdTUvzo3eyU5NqV5vt9aZP63vo3XJck';
-    (requestServiceAccountToken as jest.Mock).mockResolvedValue(mockToken);
-
-    // Act
-    await updateConfigWithActualLocalizationAvailability(mockConfig, logger);
-
-    // Assert
-    expect(requestServiceAccountToken).toHaveBeenCalledWith(mockConfig);
-    expect(mockConfig.isLocalizationEnabled).toBe(false);
-    expect(logger.warn).not.toHaveBeenCalled();
-  });
-
-  it('should keep isLocalizationEnabled true if an error is thrown', async () => {
+  it('should keep isLocalizationEnabled as true if the service account has localization permission', async () => {
     // Arrange
-    const mockError = new Error('Token parsing error');
-    (requestServiceAccountToken as jest.Mock).mockResolvedValue('in.val.id');
-    jest.spyOn(JSON, 'parse').mockImplementationOnce(() => {
-      throw mockError;
+    (getAuthenticatedManagementSubject as jest.Mock).mockResolvedValue({
+      permissions: {
+        'ax-localization-service': ['ENTITY_DEFINITIONS_EDIT'],
+      },
     });
 
     // Act
@@ -79,6 +54,43 @@ describe('localizationAvailableCheck', () => {
     // Assert
     expect(requestServiceAccountToken).toHaveBeenCalledWith(mockConfig);
     expect(mockConfig.isLocalizationEnabled).toBe(true);
-    expect(logger.warn).toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('should set isLocalizationEnabled to false if the service account does not have localization permission', async () => {
+    // Arrange
+    (getAuthenticatedManagementSubject as jest.Mock).mockResolvedValue({
+      permissions: {
+        'ax-other-service': ['SOME_PERMISSION'],
+      },
+    });
+    // Act
+    await updateConfigWithActualLocalizationAvailability(mockConfig, logger);
+
+    // Assert
+    expect(requestServiceAccountToken).toHaveBeenCalledWith(mockConfig);
+    expect(mockConfig.isLocalizationEnabled).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'The configuration value states that localization should be enabled but the service account does not have permissions for the localization service. Disabling localizations until the Media Service is restarted and the checks are run again.',
+    );
+  });
+
+  it('should keep isLocalizationEnabled true if an error is thrown', async () => {
+    // Arrange
+    const mockError = new Error('Token parsing error');
+    (getAuthenticatedManagementSubject as jest.Mock).mockRejectedValue(
+      mockError,
+    );
+
+    // Act
+    await updateConfigWithActualLocalizationAvailability(mockConfig, logger);
+
+    // Assert
+    expect(requestServiceAccountToken).toHaveBeenCalledWith(mockConfig);
+    expect(mockConfig.isLocalizationEnabled).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      mockError,
+      'Could not get the service account token to check if the localization service is enabled.',
+    );
   });
 });

--- a/services/media/service/src/common/utils/is-localization-available.spec.ts
+++ b/services/media/service/src/common/utils/is-localization-available.spec.ts
@@ -1,0 +1,84 @@
+import { Logger } from '@axinom/mosaic-service-common';
+import { Config } from '../config';
+import { updateConfigWithActualLocalizationAvailability } from './is-localization-available';
+import { requestServiceAccountToken } from './token-utils';
+
+jest.mock('./token-utils', () => ({
+  requestServiceAccountToken: jest.fn(),
+}));
+
+describe('localizationAvailableCheck', () => {
+  let mockConfig: Config;
+  let logger: Logger;
+
+  beforeEach(() => {
+    mockConfig = {
+      isLocalizationEnabled: true,
+    } as unknown as Config;
+
+    logger = { warn: jest.fn() } as unknown as Logger;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keep isLocalizationEnabled as false if isLocalizationEnabled is already false', async () => {
+    // Arrange
+    mockConfig.isLocalizationEnabled = false;
+
+    // Act
+    await updateConfigWithActualLocalizationAvailability(mockConfig, logger);
+
+    // Assert
+    expect(mockConfig.isLocalizationEnabled).toBe(false);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('should keep isLocalizationEnabled as true if the service account token has localization permission', async () => {
+    // Arrange - fake signed token contains permissions for the localization service
+    (requestServiceAccountToken as jest.Mock).mockResolvedValue(
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwZXJtaXNzaW9ucyI6eyJheC1sb2NhbGl6YXRpb24tc2VydmljZSI6WyJFTlRJVFlfREVGSU5JVElPTlNfRURJVCJdfSwiaWF0IjoxNzEwNzcyNTk4fQ.z6WfHLgtpsDr_dFQpaULMZGPzSAhvB8g2AUZ-nmqCk8',
+    );
+
+    // Act
+    await updateConfigWithActualLocalizationAvailability(mockConfig, logger);
+
+    // Assert
+    expect(requestServiceAccountToken).toHaveBeenCalledWith(mockConfig);
+    expect(mockConfig.isLocalizationEnabled).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('should set isLocalizationEnabled to false if the service account token does not have localization permission', async () => {
+    // Arrange - fake signed token does not contain permissions for the localization service
+    const mockToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwZXJtaXNzaW9ucyI6e30sImlhdCI6MTcxMDc3MjYzMX0.FUgks4EvGilaqdTUvzo3eyU5NqV5vt9aZP63vo3XJck';
+    (requestServiceAccountToken as jest.Mock).mockResolvedValue(mockToken);
+
+    // Act
+    await updateConfigWithActualLocalizationAvailability(mockConfig, logger);
+
+    // Assert
+    expect(requestServiceAccountToken).toHaveBeenCalledWith(mockConfig);
+    expect(mockConfig.isLocalizationEnabled).toBe(false);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('should keep isLocalizationEnabled true if an error is thrown', async () => {
+    // Arrange
+    const mockError = new Error('Token parsing error');
+    (requestServiceAccountToken as jest.Mock).mockResolvedValue('in.val.id');
+    jest.spyOn(JSON, 'parse').mockImplementationOnce(() => {
+      throw mockError;
+    });
+
+    // Act
+    await updateConfigWithActualLocalizationAvailability(mockConfig, logger);
+
+    // Assert
+    expect(requestServiceAccountToken).toHaveBeenCalledWith(mockConfig);
+    expect(mockConfig.isLocalizationEnabled).toBe(true);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/services/media/service/src/common/utils/is-localization-available.ts
+++ b/services/media/service/src/common/utils/is-localization-available.ts
@@ -1,0 +1,42 @@
+import { ensureError, Logger } from '@axinom/mosaic-service-common';
+import { Config } from '../config';
+import { requestServiceAccountToken } from './token-utils';
+
+/**
+ * The media service has the `config.isLocalizationEnabled`. If it is true, we
+ * check if the service account has any localization permissions meaning the
+ * service is enabled. If there are no permissions the
+ * `config.isLocalizationEnabled` is set to false.
+ * @param config The service configuration object
+ * @param logger Service setup logger
+ */
+export const updateConfigWithActualLocalizationAvailability = async (
+  config: Config,
+  logger: Logger,
+): Promise<void> => {
+  if (!config.isLocalizationEnabled) {
+    return;
+  }
+
+  const accessToken = await requestServiceAccountToken(config);
+  try {
+    // Check if the token contains the localization service as a permission
+    const parsed = JSON.parse(
+      Buffer.from(accessToken.split('.')[1], 'base64').toString(),
+    );
+    const localizationPermissions: string[] | undefined =
+      parsed.permissions['ax-localization-service'];
+    if (
+      localizationPermissions === undefined ||
+      localizationPermissions.length === 0
+    ) {
+      config.isLocalizationEnabled = false;
+    }
+  } catch (e) {
+    const error = ensureError(e);
+    logger.warn(
+      error,
+      'Could not get the service account token to check if the localization service is enabled.',
+    );
+  }
+};

--- a/services/media/service/src/index.ts
+++ b/services/media/service/src/index.ts
@@ -35,6 +35,7 @@ import {
   applyMigrations,
   getFullConfig,
   setIsLocalizationEnabledDbFunction,
+  updateConfigWithActualLocalizationAvailability,
 } from './common';
 import { syncPermissions } from './domains/permission-definition';
 import { populateSeedData } from './domains/populate-seed-data';
@@ -81,6 +82,9 @@ async function bootstrap(): Promise<void> {
   if (!(await isServiceAvailable(config.idServiceAuthBaseUrl))) {
     throw new MosaicError(IdGuardErrors.IdentityServiceNotAccessible);
   }
+
+  // Check if the Localization Service is enabled and update the config.isLocalizationEnabled value if not
+  await updateConfigWithActualLocalizationAvailability(config, logger);
 
   // Register service health endpoint
   setupServiceHealthEndpoint(app);


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [X] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [X] potential **release notes** to the PR description added
- [X] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

The Media Service has a configuration value `config.isLocalizationEnabled`. If that value is set to true it will send messages to the Localization Service. This PR adjusts the startup logic to request the configured service account token and check if that service account has permissions on the Localization Service (required to send the messaegs). If this is not the case the `config.isLocalizationEnabled` is set to false.

## Release Notes

The Media Service has a configuration value `config.isLocalizationEnabled`. If that value is set to true it will integrate with the Localization Service by sending messages/asking for localizations. The startup logic requests now the configured service account token and checks if that service account has permissions on the Localization Service. If this is not the case the `config.isLocalizationEnabled` is set to false as the localization cannot work if the service account does not have those permissions.

## Testing Notes

Set the `IS_LOCALIZATION_ENABLED` ENV variable value to true. Make sure that the Localization Service is disabled (please test in a fresh environment as you will loose all transaltions when disabling the service). Check the log files that during startup and when changing e.g. the title of a movie that no messages are sent to the Localization Service. And publishing of e.g. movies should still work without some error that Localizations are not available.