### PR TITLE
[AB#43560] Refetch queries after mutations complete

### DIFF
--- a/services/media/workflows/src/Stations/Collections/CollectionDetails/CollectionDetails.tsx
+++ b/services/media/workflows/src/Stations/Collections/CollectionDetails/CollectionDetails.tsx
@@ -22,6 +22,7 @@ import * as Yup from 'yup';
 import { client } from '../../../apolloClient';
 import { ExtensionsContext } from '../../../externals';
 import {
+  CollectionDocument,
   CollectionImageType,
   CollectionQuery,
   Mutation,
@@ -109,6 +110,8 @@ export const CollectionDetails: React.FC = () => {
       await client.mutate<unknown, { input: UpdateCollectionInput }>({
         mutation: GqlMutationDocument,
         variables: { input: { id: collectionId, patch } },
+        refetchQueries: [CollectionDocument],
+        awaitRefetchQueries: true,
       });
     },
     [collectionId],

--- a/services/media/workflows/src/Stations/Episodes/EpisodeDetails/EpisodeDetails.tsx
+++ b/services/media/workflows/src/Stations/Episodes/EpisodeDetails/EpisodeDetails.tsx
@@ -27,6 +27,7 @@ import { InfoPanelParent } from '../../../components';
 import { ExtensionsContext } from '../../../externals';
 import {
   Episode,
+  EpisodeDocument,
   EpisodeImageType,
   Mutation,
   MutationCreateEpisodesCastArgs,
@@ -220,6 +221,8 @@ export const EpisodeDetails: React.FC = () => {
       >({
         mutation: GqlMutationDocument,
         variables: { input: { id: episodeId, patch } },
+        refetchQueries: [EpisodeDocument],
+        awaitRefetchQueries: true,
       });
     },
     [allGenres, episodeId],

--- a/services/media/workflows/src/Stations/Movies/MovieDetails/MovieDetails.tsx
+++ b/services/media/workflows/src/Stations/Movies/MovieDetails/MovieDetails.tsx
@@ -25,6 +25,7 @@ import { client } from '../../../apolloClient';
 import { ExtensionsContext } from '../../../externals';
 import {
   Movie,
+  MovieDocument,
   MovieGenre,
   MovieImageType,
   Mutation,
@@ -210,6 +211,8 @@ export const MovieDetails: React.FC = () => {
       await client.mutate<unknown, { input: UpdateMovieInput }>({
         mutation: GqlMutationDocument,
         variables: { input: { id: movieId, patch } },
+        refetchQueries: [MovieDocument],
+        awaitRefetchQueries: true,
       });
     },
     [allGenres, movieId],

--- a/services/media/workflows/src/Stations/Movies/MovieGenres/MovieGenres.tsx
+++ b/services/media/workflows/src/Stations/Movies/MovieGenres/MovieGenres.tsx
@@ -18,6 +18,7 @@ import React, { useCallback, useMemo } from 'react';
 import { client } from '../../../apolloClient';
 import { Constants } from '../../../constants';
 import {
+  MovieGenresDocument,
   MovieGenresQuery,
   Mutation,
   MutationCreateMovieGenreArgs,
@@ -78,7 +79,11 @@ export const MovieGenres: React.FC = () => {
         ${mutations}
       }`;
 
-      await client.mutate({ mutation: GqlMutationDocument });
+      await client.mutate({
+        mutation: GqlMutationDocument,
+        refetchQueries: [MovieGenresDocument],
+        awaitRefetchQueries: true,
+      });
     },
     [],
   );

--- a/services/media/workflows/src/Stations/Seasons/SeasonDetails/SeasonDetails.tsx
+++ b/services/media/workflows/src/Stations/Seasons/SeasonDetails/SeasonDetails.tsx
@@ -45,6 +45,7 @@ import {
   SearchSeasonTagsQuery,
   SearchSeasonTagsQueryVariables,
   Season,
+  SeasonDocument,
   SeasonImageType,
   TvshowGenre,
   UpdateSeasonInput,
@@ -215,6 +216,8 @@ export const SeasonDetails: React.FC = () => {
       await client.mutate<unknown, { input: UpdateSeasonInput }>({
         mutation: GqlMutationDocument,
         variables: { input: { id: seasonId, patch } },
+        refetchQueries: [SeasonDocument],
+        awaitRefetchQueries: true,
       });
     },
     [allGenres, seasonId],

--- a/services/media/workflows/src/Stations/TvShows/TvShowDetails/TvShowDetails.tsx
+++ b/services/media/workflows/src/Stations/TvShows/TvShowDetails/TvShowDetails.tsx
@@ -44,6 +44,7 @@ import {
   SearchTvShowTagsQuery,
   SearchTvShowTagsQueryVariables,
   Tvshow,
+  TvShowDocument,
   TvshowGenre,
   TvshowImageType,
   UpdateTvshowInput,
@@ -211,6 +212,8 @@ export const TvShowDetails: React.FC = () => {
       await client.mutate<unknown, { input: UpdateTvshowInput }>({
         mutation: GqlMutationDocument,
         variables: { input: { id: tvshowId, patch } },
+        refetchQueries: [TvShowDocument],
+        awaitRefetchQueries: true,
       });
     },
     [allGenres, tvshowId],

--- a/services/media/workflows/src/Stations/TvShows/TvShowGenres/TvShowGenres.tsx
+++ b/services/media/workflows/src/Stations/TvShows/TvShowGenres/TvShowGenres.tsx
@@ -23,6 +23,7 @@ import {
   MutationDeleteTvshowGenreArgs,
   MutationUpdateTvshowGenreArgs,
   SnapshotState,
+  TvShowGenresDocument,
   TvShowGenresQuery,
   useTvShowGenresQuery,
 } from '../../../generated/graphql';
@@ -78,7 +79,11 @@ export const TvShowGenres: React.FC = () => {
         ${mutations}
       }`;
 
-      await client.mutate({ mutation: GqlMutationDocument });
+      await client.mutate({
+        mutation: GqlMutationDocument,
+        refetchQueries: [TvShowGenresDocument],
+        awaitRefetchQueries: true,
+      });
     },
     [],
   );


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [x] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [x] appropriate labels for the PR applied

## Description

Ideally, you do not need to refetch queries after a mutation since saving happens during a navigation event which inherently re-fetches the data from the backend. But on cases where a save is not performed during a mutation (i.e, action which does not navigate), data needs to be re-fetched to ensure that the FormStation current data is up to date. 

This PR adds the refetching logic to all of the mutations which have the potential to be executed without a navigation. 
