### PR TITLE
[AB#43628] Update pg-transactional-outbox version

### DIFF
--- a/services/catalog/service/package.json
+++ b/services/catalog/service/package.json
@@ -63,7 +63,7 @@
     "graphql": "^15.4.0",
     "media-messages": "^0.0.1",
     "pg": "^8.11.0",
-    "pg-transactional-outbox": "0.5.3",
+    "pg-transactional-outbox": "0.5.5",
     "postgraphile": "4.13.0",
     "postgraphile-plugin-connection-filter": "^2.3.0",
     "rascal": "^14.4.5",

--- a/services/entitlement/service/package.json
+++ b/services/entitlement/service/package.json
@@ -73,7 +73,7 @@
     "jsonwebtoken": "^9.0.0",
     "node-fetch": "^2.6.11",
     "pg": "^8.11.0",
-    "pg-transactional-outbox": "0.5.3",
+    "pg-transactional-outbox": "0.5.5",
     "pluralize": "^7.0.0",
     "postgraphile": "4.13.0",
     "postgraphile-plugin-atomic-mutations": "^1.0.4",

--- a/services/media/service/package.json
+++ b/services/media/service/package.json
@@ -80,7 +80,7 @@
     "node-cache": "^5.1.2",
     "node-fetch": "^2.6.11",
     "pg": "^8.11.0",
-    "pg-transactional-outbox": "0.5.3",
+    "pg-transactional-outbox": "0.5.5",
     "pluralize": "^7.0.0",
     "postgraphile": "4.13.0",
     "postgraphile-plugin-atomic-mutations": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10273,7 +10273,18 @@ pg-sql2@4.13.0:
     debug ">=3 <5"
     tslib "^2.0.1"
 
-pg-transactional-outbox@0.5.3, pg-transactional-outbox@^0.5.3:
+pg-transactional-outbox@0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/pg-transactional-outbox/-/pg-transactional-outbox-0.5.5.tgz#8fc6349769e505fea16ee4701f9e87a9ae36e0a2"
+  integrity sha512-1+fVqQoTQShEspTIipC3zND8X7K1mh4WJC7mLcGRnvDJoz2LEl3yrBbSmKIFJb1Heq4AG98OtOGAOjtOy14oJA==
+  dependencies:
+    async-mutex "^0.4.0"
+    pg "^8.11.3"
+    pg-logical-replication "^2.0.3"
+    pino "^8.16.2"
+    uuid "^9.0.1"
+
+pg-transactional-outbox@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/pg-transactional-outbox/-/pg-transactional-outbox-0.5.3.tgz#d16b2b641e2861d401835b14684f640d993c21c0"
   integrity sha512-wbGfQ9YSTFfiE2FvrUyIScKiGfPPpzEpArnWVGHzoS476COpULbbcrW+qiTLS7xbtToIfiH2O0yFpAdqtlQdDQ==


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [ ] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [x] appropriate labels for the PR applied

## Description

Update the pg-transactional-outbox version to 0.5.5