### PR TITLE
[AB#43685] make sure setup script works when service account for media service did not exist before

### DIFF
--- a/scripts/helpers/service-account-setup.ts
+++ b/scripts/helpers/service-account-setup.ts
@@ -2,6 +2,7 @@
 import {
   devSetupServiceAccountWithPermissions,
   getServiceAccountToken,
+  ServiceAccountResult,
 } from '@axinom/mosaic-id-link-be';
 import { PermissionStructure } from '@axinom/mosaic-id-utils';
 import { updateEnvFile } from './update-env-file';
@@ -12,7 +13,8 @@ export const serviceAccountSetup = async (
   devServiceAccountClientSecret: string,
   serviceId: string,
   permissions: PermissionStructure[],
-): Promise<void> => {
+  printLog = true,
+): Promise<ServiceAccountResult> => {
   const tokenResult = await getServiceAccountToken(
     idServiceAuthBaseUrl,
     devServiceAccountClientId,
@@ -32,8 +34,11 @@ export const serviceAccountSetup = async (
     SERVICE_ACCOUNT_CLIENT_SECRET: serviceAccount.clientSecret,
   });
 
-  console.log({
-    message: `Service account "${serviceAccountName}" successfully created and its credentials added to the .env file.`,
-    ...serviceAccount,
-  });
+  if (printLog) {
+    console.log({
+      message: `Service account "${serviceAccountName}" successfully created and its credentials added to the .env file.`,
+      ...serviceAccount,
+    });
+  }
+  return serviceAccount;
 };

--- a/services/media/service/scripts/setup.ts
+++ b/services/media/service/scripts/setup.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { PermissionStructure } from '@axinom/mosaic-id-link-be';
 import {
   getValidatedConfig,
   isNullOrWhitespace,
@@ -32,6 +33,23 @@ async function main(): Promise<void> {
     );
   }
 
+  const idServicePermissions: PermissionStructure = {
+    serviceId: 'ax-id-service',
+    permissions: [
+      'PERMISSIONS_SYNCHRONIZE',
+      'ACCESS_TOKENS_GENERATE_LONG_LIVED_TOKEN',
+    ],
+  };
+  const result = await serviceAccountSetup(
+    config.idServiceAuthBaseUrl,
+    config.devServiceAccountClientId,
+    config.devServiceAccountClientSecret,
+    config.serviceId,
+    [idServicePermissions],
+    false,
+  );
+  config.serviceAccountClientId = result.clientId;
+  config.serviceAccountClientSecret = result.clientSecret;
   await syncPermissions(config);
   await serviceAccountSetup(
     config.idServiceAuthBaseUrl,
@@ -39,13 +57,7 @@ async function main(): Promise<void> {
     config.devServiceAccountClientSecret,
     config.serviceId,
     [
-      {
-        serviceId: 'ax-id-service',
-        permissions: [
-          'PERMISSIONS_SYNCHRONIZE',
-          'ACCESS_TOKENS_GENERATE_LONG_LIVED_TOKEN',
-        ],
-      },
+      idServicePermissions,
       {
         serviceId: 'ax-image-service',
         permissions: ['IMAGE_TYPES_DECLARE'],


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

With the addition of localizations, `setup` dev script for the media service was adjusted to perform the sync of permissions to enable `Ingests: Edit` permission for the media service. But for this to happen - an existing service account is needed.

## Testing notes

These notes are for running media-service on your local machine:

For existing environment/service account:
- Go to the portal admin of an environment that you have configured in your .env files (e.g. local, test, or prod)
- Go to `media-service-account` Permissions station and unassign `Ingests: Edit` permission in the `MEDIA SERVICE` section.
- Run the `yarn setup` script for the media service
- Refresh the Permissions station - `Ingests: Edit` permission should be enabled (as a result of setup script execution)

For new and existing environment
- make sure that `media-service-account` service account does not exist or delete it
- Run the `yarn setup` script for the media service
- `media-service-account` should now exist and have `Ingests: Edit` permission enabled (along with some other ID, Video, Image, and Localization service permissions)