### PR TITLE
[AB#43742] Ingests: Edit permission is no longer required for media service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,9 +287,6 @@ Note that the following pre-requisites are assumed:
      - i.e.
        `yarn util:load-vars mosaic hosting service deploy -i media-service -t 20230927.1 -p media-workflows@1.0.1 -m media-service-manifest-20230927 -n media-service-deployment-20230927.1`
    - Ensure you provide a unique value for the `<deployment-name>`
-7. (Optional) In case Localizations are enabled - `media-service` service
-   account shall be adjusted to include the `INGESTS_EDIT` permission for
-   the`media-service` itself in the Admin Portal.
 
 #### Deploy Catalog Service
 

--- a/scripts/helpers/service-account-setup.ts
+++ b/scripts/helpers/service-account-setup.ts
@@ -13,7 +13,6 @@ export const serviceAccountSetup = async (
   devServiceAccountClientSecret: string,
   serviceId: string,
   permissions: PermissionStructure[],
-  printLog = true,
 ): Promise<ServiceAccountResult> => {
   const tokenResult = await getServiceAccountToken(
     idServiceAuthBaseUrl,
@@ -34,11 +33,9 @@ export const serviceAccountSetup = async (
     SERVICE_ACCOUNT_CLIENT_SECRET: serviceAccount.clientSecret,
   });
 
-  if (printLog) {
-    console.log({
-      message: `Service account "${serviceAccountName}" successfully created and its credentials added to the .env file.`,
-      ...serviceAccount,
-    });
-  }
+  console.log({
+    message: `Service account "${serviceAccountName}" successfully created and its credentials added to the .env file.`,
+    ...serviceAccount,
+  });
   return serviceAccount;
 };

--- a/services/media/service/scripts/setup.ts
+++ b/services/media/service/scripts/setup.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import { PermissionStructure } from '@axinom/mosaic-id-link-be';
 import {
   getValidatedConfig,
   isNullOrWhitespace,
@@ -7,15 +6,12 @@ import {
 } from '@axinom/mosaic-service-common';
 import { serviceAccountSetup } from '../../../../scripts/helpers';
 import { getConfigDefinitions } from '../src/common';
-import { syncPermissions } from '../src/domains/permission-definition';
 
 async function main(): Promise<void> {
   const config = getValidatedConfig(
     pick(
       getConfigDefinitions(),
       'idServiceAuthBaseUrl',
-      'serviceAccountClientId',
-      'serviceAccountClientSecret',
       'serviceId',
       'tenantId',
       'environmentId',
@@ -33,31 +29,19 @@ async function main(): Promise<void> {
     );
   }
 
-  const idServicePermissions: PermissionStructure = {
-    serviceId: 'ax-id-service',
-    permissions: [
-      'PERMISSIONS_SYNCHRONIZE',
-      'ACCESS_TOKENS_GENERATE_LONG_LIVED_TOKEN',
-    ],
-  };
-  const result = await serviceAccountSetup(
-    config.idServiceAuthBaseUrl,
-    config.devServiceAccountClientId,
-    config.devServiceAccountClientSecret,
-    config.serviceId,
-    [idServicePermissions],
-    false,
-  );
-  config.serviceAccountClientId = result.clientId;
-  config.serviceAccountClientSecret = result.clientSecret;
-  await syncPermissions(config);
   await serviceAccountSetup(
     config.idServiceAuthBaseUrl,
     config.devServiceAccountClientId,
     config.devServiceAccountClientSecret,
     config.serviceId,
     [
-      idServicePermissions,
+      {
+        serviceId: 'ax-id-service',
+        permissions: [
+          'PERMISSIONS_SYNCHRONIZE',
+          'ACCESS_TOKENS_GENERATE_LONG_LIVED_TOKEN',
+        ],
+      },
       {
         serviceId: 'ax-image-service',
         permissions: ['IMAGE_TYPES_DECLARE'],
@@ -74,10 +58,6 @@ async function main(): Promise<void> {
           'LOCALIZED_ENTITIES_EDIT',
           'LOCALIZED_ENTITIES_REVIEW',
         ],
-      },
-      {
-        serviceId: config.serviceId,
-        permissions: ['INGESTS_EDIT'],
       },
     ],
   );

--- a/services/media/service/src/ingest/handlers/check-finish-ingest-item-handler.ts
+++ b/services/media/service/src/ingest/handlers/check-finish-ingest-item-handler.ts
@@ -7,13 +7,12 @@ import {
 import { ClientBase } from 'pg';
 import { select, update } from 'zapatos/db';
 import { Config } from '../../common';
-import { MediaGuardedTransactionalInboxMessageHandler } from '../../messaging';
+import { MediaTransactionalInboxMessageHandler } from '../../messaging';
 
-export class CheckFinishIngestItemHandler extends MediaGuardedTransactionalInboxMessageHandler<CheckFinishIngestItemCommand> {
+export class CheckFinishIngestItemHandler extends MediaTransactionalInboxMessageHandler<CheckFinishIngestItemCommand> {
   constructor(config: Config) {
     super(
       MediaServiceMessagingSettings.CheckFinishIngestItem,
-      ['INGESTS_EDIT', 'ADMIN'],
       new Logger({
         config,
         context: CheckFinishIngestItemHandler.name,

--- a/services/media/service/src/ingest/handlers/localize-entity-failed-handler.ts
+++ b/services/media/service/src/ingest/handlers/localize-entity-failed-handler.ts
@@ -14,17 +14,16 @@ import {
 } from 'media-messages';
 import { ClientBase } from 'pg';
 import { Config } from '../../common';
-import { MediaGuardedTransactionalInboxMessageHandler } from '../../messaging';
+import { MediaTransactionalInboxMessageHandler } from '../../messaging';
 import { checkIsIngestEvent } from '../utils/check-is-ingest-event';
 
-export class LocalizeEntityFailedHandler extends MediaGuardedTransactionalInboxMessageHandler<LocalizeEntityFailedEvent> {
+export class LocalizeEntityFailedHandler extends MediaTransactionalInboxMessageHandler<LocalizeEntityFailedEvent> {
   constructor(
     private readonly storeOutboxMessage: StoreOutboxMessage,
     config: Config,
   ) {
     super(
       LocalizationServiceMultiTenantMessagingSettings.LocalizeEntityFailed,
-      ['INGESTS_EDIT', 'ADMIN'],
       new Logger({
         config,
         context: LocalizeEntityFailedHandler.name,
@@ -32,6 +31,7 @@ export class LocalizeEntityFailedHandler extends MediaGuardedTransactionalInboxM
       config,
     );
   }
+
   override async handleMessage(
     {
       payload,

--- a/services/media/service/src/ingest/handlers/localize-entity-finished-handler.ts
+++ b/services/media/service/src/ingest/handlers/localize-entity-finished-handler.ts
@@ -14,17 +14,16 @@ import {
 } from 'media-messages';
 import { ClientBase } from 'pg';
 import { Config } from '../../common';
-import { MediaGuardedTransactionalInboxMessageHandler } from '../../messaging';
+import { MediaTransactionalInboxMessageHandler } from '../../messaging';
 import { checkIsIngestEvent } from '../utils/check-is-ingest-event';
 
-export class LocalizeEntityFinishedHandler extends MediaGuardedTransactionalInboxMessageHandler<LocalizeEntityFinishedEvent> {
+export class LocalizeEntityFinishedHandler extends MediaTransactionalInboxMessageHandler<LocalizeEntityFinishedEvent> {
   constructor(
     private readonly storeOutboxMessage: StoreOutboxMessage,
     config: Config,
   ) {
     super(
       LocalizationServiceMultiTenantMessagingSettings.LocalizeEntityFinished,
-      ['INGESTS_EDIT', 'ADMIN'],
       new Logger({
         config,
         context: LocalizeEntityFinishedHandler.name,
@@ -32,6 +31,7 @@ export class LocalizeEntityFinishedHandler extends MediaGuardedTransactionalInbo
       config,
     );
   }
+
   override async handleMessage(
     {
       payload,

--- a/services/media/service/src/ingest/handlers/upsert-localization-source-entity-failed-handler.ts
+++ b/services/media/service/src/ingest/handlers/upsert-localization-source-entity-failed-handler.ts
@@ -15,16 +15,15 @@ import {
 import { ClientBase } from 'pg';
 import { param, selectOne, self as value, SQL, sql, update } from 'zapatos/db';
 import { CommonErrors, Config, getMediaMappedError } from '../../common';
-import { MediaGuardedTransactionalInboxMessageHandler } from '../../messaging';
+import { MediaTransactionalInboxMessageHandler } from '../../messaging';
 
-export class UpsertLocalizationSourceEntityFailedHandler extends MediaGuardedTransactionalInboxMessageHandler<UpsertLocalizationSourceEntityFailedEvent> {
+export class UpsertLocalizationSourceEntityFailedHandler extends MediaTransactionalInboxMessageHandler<UpsertLocalizationSourceEntityFailedEvent> {
   constructor(
     private readonly storeOutboxMessage: StoreOutboxMessage,
     config: Config,
   ) {
     super(
       LocalizationServiceMultiTenantMessagingSettings.UpsertLocalizationSourceEntityFailed,
-      ['INGESTS_EDIT', 'ADMIN'],
       new Logger({
         config,
         context: UpsertLocalizationSourceEntityFailedHandler.name,
@@ -32,6 +31,7 @@ export class UpsertLocalizationSourceEntityFailedHandler extends MediaGuardedTra
       config,
     );
   }
+
   override async handleMessage(
     {
       payload,

--- a/services/media/service/src/ingest/handlers/upsert-localization-source-entity-finished-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/upsert-localization-source-entity-finished-handler.db.spec.ts
@@ -29,6 +29,10 @@ import {
   UpsertLocalizationSourceEntityFinishedHandler,
 } from './upsert-localization-source-entity-finished-handler';
 
+jest.mock('../../common/utils/token-utils', () => ({
+  requestServiceAccountToken: jest.fn(),
+}));
+
 describe('UpsertLocalizationSourceEntityFinishedHandler', () => {
   let ctx: ITestContext;
   let handler: UpsertLocalizationSourceEntityFinishedHandler;

--- a/services/media/service/src/ingest/handlers/upsert-localization-source-entity-finished-handler.ts
+++ b/services/media/service/src/ingest/handlers/upsert-localization-source-entity-finished-handler.ts
@@ -1,4 +1,3 @@
-import { getServiceAccountToken } from '@axinom/mosaic-id-link-be';
 import {
   EntityLocalization,
   EntityLocalizationFieldState,
@@ -14,7 +13,12 @@ import {
 import { IngestLocalization, IngestMessageContext } from 'media-messages';
 import { ClientBase } from 'pg';
 import { param, selectOne, self as value, SQL, sql, update } from 'zapatos/db';
-import { CommonErrors, Config, getMediaMappedError } from '../../common';
+import {
+  CommonErrors,
+  Config,
+  getMediaMappedError,
+  requestServiceAccountToken,
+} from '../../common';
 import { MediaTransactionalInboxMessageHandler } from '../../messaging';
 
 /**
@@ -108,14 +112,7 @@ export class UpsertLocalizationSourceEntityFinishedHandler extends MediaTransact
       ingestItemStepId: localizationStep.id,
     };
     const token =
-      metadata.authToken ??
-      (
-        await getServiceAccountToken(
-          this.config.idServiceAuthBaseUrl,
-          this.config.serviceAccountClientId,
-          this.config.serviceAccountClientSecret,
-        )
-      ).accessToken;
+      metadata.authToken ?? (await requestServiceAccountToken(this.config));
     await this.storeOutboxMessage<LocalizeEntityCommand>(
       payload.entity_id,
       messageSettings,


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

(Ingest) events are sent in response to commands. The command handlers have the permission checks included. Events that are sent as responses to commands (or any other action) were already checked for correct permissions. Therefor there is no need to check/include permissions validation for events. The CheckIngestItem is designed as a command but could arguably also be an event as the check happens only due to another action being finished.

## Testing notes

- Make sure that media-service service account for your environment does NOT have `Ingests: Edit` permission for `Media Service` section.
- Run ingest with some localizations
- Expected result: ingest passes without errors
   - Previously ingest would fail with `Localizations` step stuck in `IN_PROGRESS` state
