### PR TITLE
[AB#43746] renamed loginClient to ownerClient in media handlers

### DIFF
--- a/services/media/service/src/domains/collections/localization/localizable-collection-image-db-message-handlers.ts
+++ b/services/media/service/src/domains/collections/localization/localizable-collection-image-db-message-handlers.ts
@@ -92,11 +92,11 @@ export class LocalizableCollectionImageDeletedDbMessageHandler extends Localizab
     {
       payload: { image_type, collection_id },
     }: TypedTransactionalMessage<LocalizableCollectionImageDbEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<LocalizationMessageData | undefined> {
     if (
       image_type !== 'COVER' ||
-      (await this.collectionIsDeleted(collection_id, loginClient))
+      (await this.collectionIsDeleted(collection_id, ownerClient))
     ) {
       // Ignore any changes to non-cover image relations
       // If image relation is deleted as part of a cascade delete of collection - no need to upsert
@@ -115,13 +115,13 @@ export class LocalizableCollectionImageDeletedDbMessageHandler extends Localizab
 
   async collectionIsDeleted(
     collectionId: number,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<boolean> {
     const data = await selectOne(
       'collections',
       { id: collectionId },
       { columns: ['id'] },
-    ).run(loginClient);
+    ).run(ownerClient);
     return !data;
   }
 }

--- a/services/media/service/src/domains/common/handlers/delete-entity-handler.db.spec.ts
+++ b/services/media/service/src/domains/common/handlers/delete-entity-handler.db.spec.ts
@@ -78,7 +78,7 @@ describe('Start Ingest Item Handler', () => {
     };
 
     // Act
-    await ctx.executeGqlSql(user, async (dbCtx) =>
+    await ctx.executeOwnerSql(user, async (dbCtx) =>
       handler.handleMessage(createMessage(payload), dbCtx),
     );
 

--- a/services/media/service/src/domains/common/handlers/delete-entity-handler.ts
+++ b/services/media/service/src/domains/common/handlers/delete-entity-handler.ts
@@ -38,11 +38,11 @@ export class DeleteEntityHandler extends MediaGuardedTransactionalInboxMessageHa
 
   override async handleMessage(
     { payload, metadata }: TypedTransactionalMessage<DeleteEntityCommand>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
     const deletedItems = await deletes(payload.table_name as Table, {
       [payload.primary_key_name]: payload.entity_id,
-    }).run(loginClient);
+    }).run(ownerClient);
 
     if (deletedItems.length >= 1) {
       const deletedRow = deletedItems[0];
@@ -57,7 +57,7 @@ export class DeleteEntityHandler extends MediaGuardedTransactionalInboxMessageHa
           primary_key_name: payload.primary_key_name,
           table_name: payload.table_name,
         },
-        loginClient,
+        ownerClient,
         { envelopeOverrides: { auth_token: metadata.authToken } },
       );
     }

--- a/services/media/service/src/domains/common/handlers/localizable-media-transactional-inbox-message-handler.ts
+++ b/services/media/service/src/domains/common/handlers/localizable-media-transactional-inbox-message-handler.ts
@@ -29,14 +29,14 @@ export abstract class LocalizableMediaTransactionalInboxMessageHandler<
 
   abstract getLocalizationCommandData(
     message: TypedTransactionalMessage<T>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<LocalizationMessageData | undefined>;
 
   override async handleMessage(
     message: TypedTransactionalMessage<T>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
-    const data = await this.getLocalizationCommandData(message, loginClient);
+    const data = await this.getLocalizationCommandData(message, ownerClient);
     if (!data) {
       return;
     }
@@ -46,7 +46,7 @@ export abstract class LocalizableMediaTransactionalInboxMessageHandler<
       data.payload.entity_id,
       data.settings,
       data.payload,
-      loginClient,
+      ownerClient,
       {
         envelopeOverrides: {
           auth_token: accessToken,

--- a/services/media/service/src/domains/movies/handlers/ingest-movie-processor-initialize.db.spec.ts
+++ b/services/media/service/src/domains/movies/handlers/ingest-movie-processor-initialize.db.spec.ts
@@ -54,7 +54,7 @@ describe('IngestMovieProcessor', () => {
       };
 
       // Act
-      const result = await ctx.executeGqlSql(user, async (dbCtx) => {
+      const result = await ctx.executeOwnerSql(user, async (dbCtx) => {
         return processor.initializeMedia([item], dbCtx);
       });
 
@@ -102,7 +102,7 @@ describe('IngestMovieProcessor', () => {
         };
 
         // Act
-        const result = await ctx.executeGqlSql(user, async (dbCtx) => {
+        const result = await ctx.executeOwnerSql(user, async (dbCtx) => {
           return processor.initializeMedia([item], dbCtx);
         });
 
@@ -148,7 +148,7 @@ describe('IngestMovieProcessor', () => {
       ];
 
       // Act
-      const result = await ctx.executeGqlSql(user, async (dbCtx) => {
+      const result = await ctx.executeOwnerSql(user, async (dbCtx) => {
         return processor.initializeMedia(items, dbCtx);
       });
 
@@ -211,7 +211,7 @@ describe('IngestMovieProcessor', () => {
 
       // Act
       const error = await rejectionOf(
-        ctx.executeGqlSql(user, async (dbCtx) => {
+        ctx.executeOwnerSql(user, async (dbCtx) => {
           return processor.initializeMedia(items, dbCtx);
         }),
       );

--- a/services/media/service/src/domains/movies/handlers/ingest-movie-processor-process-image.db.spec.ts
+++ b/services/media/service/src/domains/movies/handlers/ingest-movie-processor-process-image.db.spec.ts
@@ -41,7 +41,7 @@ describe('IngestMovieProcessor', () => {
   describe('processImage', () => {
     it('new cover image -> image relation created', async () => {
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) => {
+      await ctx.executeOwnerSql(user, async (dbCtx) => {
         await processor.processImage(movie1.id, imageId, 'COVER', dbCtx);
       });
 
@@ -68,7 +68,7 @@ describe('IngestMovieProcessor', () => {
       }).run(ctx.ownerPool);
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) => {
+      await ctx.executeOwnerSql(user, async (dbCtx) => {
         await processor.processImage(movie1.id, imageId, 'TEASER', dbCtx);
       });
 

--- a/services/media/service/src/domains/movies/handlers/ingest-movie-processor-process-video.db.spec.ts
+++ b/services/media/service/src/domains/movies/handlers/ingest-movie-processor-process-video.db.spec.ts
@@ -132,7 +132,7 @@ describe('IngestMovieProcessor', () => {
         };
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.processVideo(movie1.id, newId, messageContext, dbCtx);
         });
 
@@ -177,7 +177,7 @@ describe('IngestMovieProcessor', () => {
         };
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.processVideo(movie1.id, newId, messageContext, dbCtx);
         });
 

--- a/services/media/service/src/domains/movies/handlers/ingest-movie-processor-update-metadata.db.spec.ts
+++ b/services/media/service/src/domains/movies/handlers/ingest-movie-processor-update-metadata.db.spec.ts
@@ -96,7 +96,7 @@ describe('IngestMovieProcessor', () => {
         ).run(ctx.ownerPool);
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx, ingestItemId);
         });
 
@@ -158,7 +158,7 @@ describe('IngestMovieProcessor', () => {
         ).run(ctx.ownerPool);
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx);
         });
 
@@ -210,7 +210,7 @@ describe('IngestMovieProcessor', () => {
       const body = createMessageBody(movie1, data);
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) => {
+      await ctx.executeOwnerSql(user, async (dbCtx) => {
         await processor.updateMetadata(body, dbCtx);
       });
 
@@ -262,7 +262,7 @@ describe('IngestMovieProcessor', () => {
 
       // Act
       const error = await rejectionOf(
-        ctx.executeGqlSql(user, async (dbCtx) => {
+        ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx);
         }),
       );
@@ -295,7 +295,7 @@ describe('IngestMovieProcessor', () => {
 
       // Act
       const error = await rejectionOf(
-        ctx.executeGqlSql(user, async (dbCtx) => {
+        ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx);
         }),
       );
@@ -348,7 +348,7 @@ describe('IngestMovieProcessor', () => {
         const body = createMessageBody(movie1, data);
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx);
         });
 
@@ -387,7 +387,7 @@ describe('IngestMovieProcessor', () => {
       const body = createMessageBody(movie1, data);
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) => {
+      await ctx.executeOwnerSql(user, async (dbCtx) => {
         await processor.updateMetadata(body, dbCtx);
       });
 
@@ -425,7 +425,7 @@ describe('IngestMovieProcessor', () => {
       const body = createMessageBody(movie1, data);
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) => {
+      await ctx.executeOwnerSql(user, async (dbCtx) => {
         await processor.updateMetadata(body, dbCtx);
       });
 
@@ -486,7 +486,7 @@ describe('IngestMovieProcessor', () => {
         const body = createMessageBody(movie1, data);
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx);
         });
 
@@ -548,7 +548,7 @@ describe('IngestMovieProcessor', () => {
         });
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx);
         });
 
@@ -637,7 +637,7 @@ describe('IngestMovieProcessor', () => {
         });
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx);
         });
 
@@ -698,7 +698,7 @@ describe('IngestMovieProcessor', () => {
         });
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx);
         });
 

--- a/services/media/service/src/domains/movies/localization/localizable-movie-image-db-message-handlers.ts
+++ b/services/media/service/src/domains/movies/localization/localizable-movie-image-db-message-handlers.ts
@@ -92,11 +92,11 @@ export class LocalizableMovieImageDeletedDbMessageHandler extends LocalizableMed
     {
       payload: { image_type, movie_id },
     }: TypedTransactionalMessage<LocalizableMovieImageDbEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<LocalizationMessageData | undefined> {
     if (
       image_type !== 'COVER' ||
-      (await this.movieIsDeleted(movie_id, loginClient))
+      (await this.movieIsDeleted(movie_id, ownerClient))
     ) {
       // Ignore any changes to non-cover image relations
       // If image relation is deleted as part of a cascade delete of movie - no need to upsert
@@ -115,13 +115,13 @@ export class LocalizableMovieImageDeletedDbMessageHandler extends LocalizableMed
 
   async movieIsDeleted(
     movieId: number,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<boolean> {
     const data = await selectOne(
       'movies',
       { id: movieId },
       { columns: ['id'] },
-    ).run(loginClient);
+    ).run(ownerClient);
     return !data;
   }
 }

--- a/services/media/service/src/domains/tvshows/handlers/ingest-episode-processor-initialize.db.spec.ts
+++ b/services/media/service/src/domains/tvshows/handlers/ingest-episode-processor-initialize.db.spec.ts
@@ -66,7 +66,7 @@ describe('IngestEpisodeProcessor', () => {
         };
 
         // Act
-        const result = await ctx.executeGqlSql(user, async (dbCtx) => {
+        const result = await ctx.executeOwnerSql(user, async (dbCtx) => {
           return processor.initializeMedia([item], dbCtx);
         });
 

--- a/services/media/service/src/domains/tvshows/handlers/ingest-episode-processor-update-metadata.db.spec.ts
+++ b/services/media/service/src/domains/tvshows/handlers/ingest-episode-processor-update-metadata.db.spec.ts
@@ -89,7 +89,7 @@ describe('IngestEpisodeProcessor', () => {
         const body = createMessageBody(episode1, data);
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx);
         });
 
@@ -128,7 +128,7 @@ describe('IngestEpisodeProcessor', () => {
       const body = createMessageBody(episode1, data);
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) => {
+      await ctx.executeOwnerSql(user, async (dbCtx) => {
         await processor.updateMetadata(body, dbCtx);
       });
 
@@ -166,7 +166,7 @@ describe('IngestEpisodeProcessor', () => {
       const body = createMessageBody(episode1, data);
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) => {
+      await ctx.executeOwnerSql(user, async (dbCtx) => {
         await processor.updateMetadata(body, dbCtx);
       });
 

--- a/services/media/service/src/domains/tvshows/handlers/ingest-season-processor-initialize.db.spec.ts
+++ b/services/media/service/src/domains/tvshows/handlers/ingest-season-processor-initialize.db.spec.ts
@@ -63,7 +63,7 @@ describe('IngestSeasonProcessor', () => {
         };
 
         // Act
-        const result = await ctx.executeGqlSql(user, async (dbCtx) => {
+        const result = await ctx.executeOwnerSql(user, async (dbCtx) => {
           return processor.initializeMedia([item], dbCtx);
         });
 

--- a/services/media/service/src/domains/tvshows/handlers/ingest-season-processor-update-metadata.db.spec.ts
+++ b/services/media/service/src/domains/tvshows/handlers/ingest-season-processor-update-metadata.db.spec.ts
@@ -77,7 +77,7 @@ describe('IngestSeasonProcessor', () => {
         const body = createMessageBody(season1, data);
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx);
         });
 
@@ -116,7 +116,7 @@ describe('IngestSeasonProcessor', () => {
       const body = createMessageBody(season1, data);
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) => {
+      await ctx.executeOwnerSql(user, async (dbCtx) => {
         await processor.updateMetadata(body, dbCtx);
       });
 

--- a/services/media/service/src/domains/tvshows/handlers/ingest-tvshow-processor-update-metadata.db.spec.ts
+++ b/services/media/service/src/domains/tvshows/handlers/ingest-tvshow-processor-update-metadata.db.spec.ts
@@ -77,7 +77,7 @@ describe('IngestTvshowProcessor', () => {
         const body = createMessageBody(tvshow1, data);
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) => {
+        await ctx.executeOwnerSql(user, async (dbCtx) => {
           await processor.updateMetadata(body, dbCtx);
         });
 
@@ -116,7 +116,7 @@ describe('IngestTvshowProcessor', () => {
       const body = createMessageBody(tvshow1, data);
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) => {
+      await ctx.executeOwnerSql(user, async (dbCtx) => {
         await processor.updateMetadata(body, dbCtx);
       });
 

--- a/services/media/service/src/domains/tvshows/localization/localizable-episode-db-message-handlers.ts
+++ b/services/media/service/src/domains/tvshows/localization/localizable-episode-db-message-handlers.ts
@@ -26,7 +26,7 @@ export interface LocalizableEpisodeDbEvent {
 
 const getEntityTitle = async (
   episode: LocalizableEpisodeDbEvent,
-  loginClient: ClientBase,
+  ownerClient: ClientBase,
 ): Promise<string> => {
   const season = episode.season_id
     ? await selectOne(
@@ -42,7 +42,7 @@ const getEntityTitle = async (
             ),
           },
         },
-      ).run(loginClient)
+      ).run(ownerClient)
     : undefined;
   return buildDisplayTitle('EPISODE', episode, season, season?.tvshow);
 };
@@ -58,9 +58,9 @@ export class LocalizableEpisodeCreatedDbMessageHandler extends LocalizableMediaT
 
   override async getLocalizationCommandData(
     { payload }: TypedTransactionalMessage<LocalizableEpisodeDbEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<LocalizationMessageData | undefined> {
-    const entityTitle = await getEntityTitle(payload, loginClient);
+    const entityTitle = await getEntityTitle(payload, ownerClient);
     const { id, index, season_id, ...fields } = payload;
     return getUpsertMessageData(
       this.config.serviceId,
@@ -84,9 +84,9 @@ export class LocalizableEpisodeUpdatedDbMessageHandler extends LocalizableMediaT
 
   override async getLocalizationCommandData(
     { payload }: TypedTransactionalMessage<LocalizableEpisodeDbEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<LocalizationMessageData | undefined> {
-    const entityTitle = await getEntityTitle(payload, loginClient);
+    const entityTitle = await getEntityTitle(payload, ownerClient);
     const { id, index, season_id, ...fields } = payload;
     return getUpsertMessageData(
       this.config.serviceId,

--- a/services/media/service/src/domains/tvshows/localization/localizable-episode-image-db-message-handlers.ts
+++ b/services/media/service/src/domains/tvshows/localization/localizable-episode-image-db-message-handlers.ts
@@ -92,11 +92,11 @@ export class LocalizableEpisodeImageDeletedDbMessageHandler extends LocalizableM
     {
       payload: { image_type, episode_id },
     }: TypedTransactionalMessage<LocalizableEpisodeImageDbEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<LocalizationMessageData | undefined> {
     if (
       image_type !== 'COVER' ||
-      (await this.episodeIsDeleted(episode_id, loginClient))
+      (await this.episodeIsDeleted(episode_id, ownerClient))
     ) {
       // Ignore any changes to non-cover image relations
       // If image relation is deleted as part of a cascade delete of episode - no need to upsert
@@ -115,13 +115,13 @@ export class LocalizableEpisodeImageDeletedDbMessageHandler extends LocalizableM
 
   async episodeIsDeleted(
     episodeId: number,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<boolean> {
     const data = await selectOne(
       'episodes',
       { id: episodeId },
       { columns: ['id'] },
-    ).run(loginClient);
+    ).run(ownerClient);
     return !data;
   }
 }

--- a/services/media/service/src/domains/tvshows/localization/localizable-season-db-message-handlers.ts
+++ b/services/media/service/src/domains/tvshows/localization/localizable-season-db-message-handlers.ts
@@ -25,14 +25,14 @@ export interface LocalizableSeasonDbEvent {
 
 const getEntityTitle = async (
   season: LocalizableSeasonDbEvent,
-  loginClient: ClientBase,
+  ownerClient: ClientBase,
 ): Promise<string> => {
   const tvshow = season.tvshow_id
     ? await selectOne(
         'tvshows',
         { id: season.tvshow_id },
         { columns: ['title'] },
-      ).run(loginClient)
+      ).run(ownerClient)
     : undefined;
   return buildDisplayTitle('SEASON', season, tvshow);
 };
@@ -48,9 +48,9 @@ export class LocalizableSeasonCreatedDbMessageHandler extends LocalizableMediaTr
 
   override async getLocalizationCommandData(
     { payload }: TypedTransactionalMessage<LocalizableSeasonDbEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<LocalizationMessageData | undefined> {
-    const entityTitle = await getEntityTitle(payload, loginClient);
+    const entityTitle = await getEntityTitle(payload, ownerClient);
     const { id, index, tvshow_id, ...fields } = payload;
     return getUpsertMessageData(
       this.config.serviceId,
@@ -74,9 +74,9 @@ export class LocalizableSeasonUpdatedDbMessageHandler extends LocalizableMediaTr
 
   override async getLocalizationCommandData(
     { payload }: TypedTransactionalMessage<LocalizableSeasonDbEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<LocalizationMessageData | undefined> {
-    const entityTitle = await getEntityTitle(payload, loginClient);
+    const entityTitle = await getEntityTitle(payload, ownerClient);
     const { id, index, tvshow_id, ...fields } = payload;
     return getUpsertMessageData(
       this.config.serviceId,

--- a/services/media/service/src/domains/tvshows/localization/localizable-season-image-db-message-handlers.ts
+++ b/services/media/service/src/domains/tvshows/localization/localizable-season-image-db-message-handlers.ts
@@ -92,11 +92,11 @@ export class LocalizableSeasonImageDeletedDbMessageHandler extends LocalizableMe
     {
       payload: { image_type, season_id },
     }: TypedTransactionalMessage<LocalizableSeasonImageDbEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<LocalizationMessageData | undefined> {
     if (
       image_type !== 'COVER' ||
-      (await this.seasonIsDeleted(season_id, loginClient))
+      (await this.seasonIsDeleted(season_id, ownerClient))
     ) {
       // Ignore any changes to non-cover image relations
       // If image relation is deleted as part of a cascade delete of season - no need to upsert
@@ -115,13 +115,13 @@ export class LocalizableSeasonImageDeletedDbMessageHandler extends LocalizableMe
 
   async seasonIsDeleted(
     seasonId: number,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<boolean> {
     const data = await selectOne(
       'seasons',
       { id: seasonId },
       { columns: ['id'] },
-    ).run(loginClient);
+    ).run(ownerClient);
     return !data;
   }
 }

--- a/services/media/service/src/domains/tvshows/localization/localizable-tvshow-image-db-message-handlers.ts
+++ b/services/media/service/src/domains/tvshows/localization/localizable-tvshow-image-db-message-handlers.ts
@@ -92,11 +92,11 @@ export class LocalizableTvshowImageDeletedDbMessageHandler extends LocalizableMe
     {
       payload: { image_type, tvshow_id },
     }: TypedTransactionalMessage<LocalizableTvshowImageDbEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<LocalizationMessageData | undefined> {
     if (
       image_type !== 'COVER' ||
-      (await this.tvshowIsDeleted(tvshow_id, loginClient))
+      (await this.tvshowIsDeleted(tvshow_id, ownerClient))
     ) {
       // Ignore any changes to non-cover image relations
       // If image relation is deleted as part of a cascade delete of tvshow - no need to upsert
@@ -115,13 +115,13 @@ export class LocalizableTvshowImageDeletedDbMessageHandler extends LocalizableMe
 
   async tvshowIsDeleted(
     tvshowId: number,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<boolean> {
     const data = await selectOne(
       'tvshows',
       { id: tvshowId },
       { columns: ['id'] },
-    ).run(loginClient);
+    ).run(ownerClient);
     return !data;
   }
 }

--- a/services/media/service/src/ingest/handlers/check-finish-ingest-document-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/check-finish-ingest-document-handler.db.spec.ts
@@ -119,7 +119,7 @@ describe('Check Finish Ingest Document Handler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload), dbCtx),
       );
 
@@ -158,7 +158,7 @@ describe('Check Finish Ingest Document Handler', () => {
         };
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) =>
+        await ctx.executeOwnerSql(user, async (dbCtx) =>
           handler.handleMessage(createMessage(payload), dbCtx),
         );
 
@@ -197,7 +197,7 @@ describe('Check Finish Ingest Document Handler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload), dbCtx),
       );
 
@@ -243,7 +243,7 @@ describe('Check Finish Ingest Document Handler', () => {
         };
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) =>
+        await ctx.executeOwnerSql(user, async (dbCtx) =>
           handler.handleMessage(createMessage(payload), dbCtx),
         );
 
@@ -304,7 +304,7 @@ describe('Check Finish Ingest Document Handler', () => {
         };
 
         // Act
-        await ctx.executeGqlSql(user, async (dbCtx) =>
+        await ctx.executeOwnerSql(user, async (dbCtx) =>
           handler.handleMessage(createMessage(payload), dbCtx),
         );
 

--- a/services/media/service/src/ingest/handlers/check-finish-ingest-item-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/check-finish-ingest-item-handler.db.spec.ts
@@ -87,7 +87,7 @@ describe('Check Finish Ingest Item Handler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload), dbCtx),
       );
 
@@ -126,7 +126,7 @@ describe('Check Finish Ingest Item Handler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         Promise.all([
           handler.handleMessage(createMessage(payload), dbCtx),
           handler.handleMessage(createMessage(payload), dbCtx),
@@ -166,7 +166,7 @@ describe('Check Finish Ingest Item Handler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload), dbCtx),
       );
 
@@ -244,7 +244,7 @@ describe('Check Finish Ingest Item Handler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload), dbCtx),
       );
 
@@ -345,7 +345,7 @@ describe('Check Finish Ingest Item Handler', () => {
       ]).run(ctx.ownerPool);
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(
           createMessage({
             ingest_item_id: item.id,
@@ -465,7 +465,7 @@ describe('Check Finish Ingest Item Handler', () => {
       ]).run(ctx.ownerPool);
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) => {
+      await ctx.executeOwnerSql(user, async (dbCtx) => {
         await handler.handleMessage(
           createMessage({
             ingest_item_id: item.id,
@@ -614,7 +614,7 @@ describe('Check Finish Ingest Item Handler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) => {
+      await ctx.executeOwnerSql(user, async (dbCtx) => {
         await handler.handleMessage(createMessage(payload1), dbCtx);
         await handler.handleMessage(createMessage(payload2), dbCtx);
       });

--- a/services/media/service/src/ingest/handlers/check-finish-ingest-item-handler.ts
+++ b/services/media/service/src/ingest/handlers/check-finish-ingest-item-handler.ts
@@ -25,7 +25,7 @@ export class CheckFinishIngestItemHandler extends MediaTransactionalInboxMessage
     {
       payload: { ingest_item_id, ingest_item_step_id, error_message },
     }: TypedTransactionalMessage<CheckFinishIngestItemCommand>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
     const updated = await update(
       'ingest_item_steps',
@@ -34,7 +34,7 @@ export class CheckFinishIngestItemHandler extends MediaTransactionalInboxMessage
         response_message: error_message,
       },
       { id: ingest_item_step_id, status: 'IN_PROGRESS' },
-    ).run(loginClient);
+    ).run(ownerClient);
 
     if (updated.length === 0) {
       this.logger.debug({
@@ -48,7 +48,7 @@ export class CheckFinishIngestItemHandler extends MediaTransactionalInboxMessage
       'ingest_item_steps',
       { ingest_item_id: ingest_item_id },
       { columns: ['status', 'id'] },
-    ).run(loginClient);
+    ).run(ownerClient);
 
     const inProgressSteps = steps.filter((r) => r.status === 'IN_PROGRESS');
     if (inProgressSteps.length > 0) {
@@ -68,6 +68,6 @@ export class CheckFinishIngestItemHandler extends MediaTransactionalInboxMessage
         status: steps.some((r) => r.status === 'ERROR') ? 'ERROR' : 'SUCCESS',
       },
       { id: ingest_item_id },
-    ).run(loginClient);
+    ).run(ownerClient);
   }
 }

--- a/services/media/service/src/ingest/handlers/image-failed-handler.ts
+++ b/services/media/service/src/ingest/handlers/image-failed-handler.ts
@@ -41,7 +41,7 @@ export class ImageFailedHandler extends MediaGuardedTransactionalInboxMessageHan
       payload,
       metadata,
     }: TypedTransactionalMessage<EnsureImageExistsFailedEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
     if (!checkIsIngestEvent(metadata, this.logger, id, aggregateId)) {
       return;
@@ -56,7 +56,7 @@ export class ImageFailedHandler extends MediaGuardedTransactionalInboxMessageHan
         ingest_item_id: messageContext.ingestItemId,
         error_message: payload.message,
       },
-      loginClient,
+      ownerClient,
       {
         envelopeOverrides: { auth_token: metadata.authToken },
         lockedUntil: getFutureIsoDateInMilliseconds(1_000),

--- a/services/media/service/src/ingest/handlers/image-succeeded-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/image-succeeded-handler.db.spec.ts
@@ -123,7 +123,7 @@ describe('ImageSucceededHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload, metadata), dbCtx),
       );
 
@@ -156,7 +156,7 @@ describe('ImageSucceededHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleErrorMessage(
           new Error('test error'),
           createMessage(payload, context),

--- a/services/media/service/src/ingest/handlers/localize-entity-failed-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/localize-entity-failed-handler.db.spec.ts
@@ -67,7 +67,7 @@ describe('LocalizeEntityFailedHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload, context), dbCtx),
       );
 

--- a/services/media/service/src/ingest/handlers/localize-entity-failed-handler.ts
+++ b/services/media/service/src/ingest/handlers/localize-entity-failed-handler.ts
@@ -39,7 +39,7 @@ export class LocalizeEntityFailedHandler extends MediaTransactionalInboxMessageH
       id,
       aggregateId,
     }: TypedTransactionalMessage<LocalizeEntityFailedEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
     if (
       !checkIsIngestEvent(metadata, this.logger, id, aggregateId) ||
@@ -58,7 +58,7 @@ export class LocalizeEntityFailedHandler extends MediaTransactionalInboxMessageH
         ingest_item_id: messageContext.ingestItemId,
         error_message: payload.message,
       },
-      loginClient,
+      ownerClient,
       { envelopeOverrides: { auth_token: metadata.authToken } },
     );
   }

--- a/services/media/service/src/ingest/handlers/localize-entity-finished-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/localize-entity-finished-handler.db.spec.ts
@@ -68,7 +68,7 @@ describe('LocalizeEntityFinishedHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload, context), dbCtx),
       );
 

--- a/services/media/service/src/ingest/handlers/localize-entity-finished-handler.ts
+++ b/services/media/service/src/ingest/handlers/localize-entity-finished-handler.ts
@@ -39,7 +39,7 @@ export class LocalizeEntityFinishedHandler extends MediaTransactionalInboxMessag
       id,
       aggregateId,
     }: TypedTransactionalMessage<LocalizeEntityFinishedEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
     if (
       !checkIsIngestEvent(metadata, this.logger, id, aggregateId) ||
@@ -58,7 +58,7 @@ export class LocalizeEntityFinishedHandler extends MediaTransactionalInboxMessag
         ingest_item_step_id: messageContext.ingestItemStepId,
         ingest_item_id: messageContext.ingestItemId,
       },
-      loginClient,
+      ownerClient,
       { envelopeOverrides: { auth_token: metadata.authToken } },
     );
   }

--- a/services/media/service/src/ingest/handlers/start-ingest-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/start-ingest-handler.db.spec.ts
@@ -103,7 +103,7 @@ describe('Start Ingest Handler', () => {
       const payload: StartIngestCommand = { doc_id: doc.id };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload), dbCtx),
       );
 
@@ -198,7 +198,7 @@ describe('Start Ingest Handler', () => {
       const payload: StartIngestCommand = { doc_id: doc.id };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload), dbCtx),
       );
 
@@ -282,7 +282,7 @@ describe('Start Ingest Handler', () => {
       const payload: StartIngestCommand = { doc_id: doc.id };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleErrorMessage(
           new Error('test error'),
           createMessage(payload),

--- a/services/media/service/src/ingest/handlers/start-ingest-item-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/start-ingest-item-handler.db.spec.ts
@@ -154,7 +154,7 @@ describe('Start Ingest Item Handler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload), dbCtx),
       );
 
@@ -214,7 +214,7 @@ describe('Start Ingest Item Handler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload), dbCtx),
       );
 
@@ -300,7 +300,7 @@ describe('Start Ingest Item Handler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload), dbCtx),
       );
 
@@ -367,7 +367,7 @@ describe('Start Ingest Item Handler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleErrorMessage(
           new Error('test error'),
           createMessage(payload),

--- a/services/media/service/src/ingest/handlers/start-ingest-item-handler.ts
+++ b/services/media/service/src/ingest/handlers/start-ingest-item-handler.ts
@@ -56,7 +56,7 @@ export class StartIngestItemHandler extends MediaGuardedTransactionalInboxMessag
 
   override async handleMessage(
     { payload, metadata }: TypedTransactionalMessage<StartIngestItemCommand>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
     const processor = this.entityProcessors.find(
       (h) => h.type === payload.item.type,
@@ -70,7 +70,7 @@ export class StartIngestItemHandler extends MediaGuardedTransactionalInboxMessag
     }
 
     const data = processor.getOrchestrationData(payload);
-    await this.saveIngestItemSteps(data, loginClient);
+    await this.saveIngestItemSteps(data, ownerClient);
     const orchestrationData = data
       .filter<FullOrchestrationData>(this.isFullOrchestrationData)
       .map((original) => ({
@@ -85,7 +85,7 @@ export class StartIngestItemHandler extends MediaGuardedTransactionalInboxMessag
         data.aggregateId,
         data.messagingSettings,
         data.messagePayload,
-        loginClient,
+        ownerClient,
         {
           envelopeOverrides: {
             auth_token: metadata.authToken,
@@ -100,7 +100,7 @@ export class StartIngestItemHandler extends MediaGuardedTransactionalInboxMessag
   override async handleErrorMessage(
     error: Error,
     { payload }: TypedTransactionalMessage<StartIngestItemCommand>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
     retry: boolean,
   ): Promise<void> {
     if (retry) {
@@ -121,7 +121,7 @@ export class StartIngestItemHandler extends MediaGuardedTransactionalInboxMessag
         errors: sql<SQL>`${value} || ${errorParam}::jsonb`,
       },
       { id: payload.ingest_item_id },
-    ).run(loginClient);
+    ).run(ownerClient);
   }
 
   private getPublicationConfig(

--- a/services/media/service/src/ingest/handlers/update-metadata-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/update-metadata-handler.db.spec.ts
@@ -80,7 +80,7 @@ describe('UpdateMetadataHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload, context), dbCtx),
       );
 
@@ -141,7 +141,7 @@ describe('UpdateMetadataHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload, context), dbCtx),
       );
 
@@ -172,7 +172,7 @@ describe('UpdateMetadataHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleErrorMessage(
           new Error('test error'),
           createMessage(payload, context),
@@ -204,7 +204,7 @@ describe('UpdateMetadataHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleErrorMessage(
           new MosaicError({
             message: errorMessage,

--- a/services/media/service/src/ingest/handlers/update-metadata-handler.ts
+++ b/services/media/service/src/ingest/handlers/update-metadata-handler.ts
@@ -38,7 +38,7 @@ export class UpdateMetadataHandler extends MediaGuardedTransactionalInboxMessage
 
   override async handleMessage(
     { payload, metadata }: TypedTransactionalMessage<UpdateMetadataCommand>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
     const messageContext = metadata.messageContext as IngestMessageContext;
     const processor = this.entityProcessors.find(
@@ -58,11 +58,11 @@ export class UpdateMetadataHandler extends MediaGuardedTransactionalInboxMessage
         type: 'LOCALIZATIONS',
       },
       { columns: ['id'] },
-    ).run(loginClient);
+    ).run(ownerClient);
 
     await processor.updateMetadata(
       payload,
-      loginClient,
+      ownerClient,
       localizationStep ? messageContext.ingestItemId : undefined,
     );
 
@@ -73,7 +73,7 @@ export class UpdateMetadataHandler extends MediaGuardedTransactionalInboxMessage
         ingest_item_step_id: messageContext.ingestItemStepId,
         ingest_item_id: messageContext.ingestItemId,
       },
-      loginClient,
+      ownerClient,
       {
         envelopeOverrides: { auth_token: metadata.authToken },
         lockedUntil: getFutureIsoDateInMilliseconds(1_000),
@@ -84,7 +84,7 @@ export class UpdateMetadataHandler extends MediaGuardedTransactionalInboxMessage
   override async handleErrorMessage(
     error: Error,
     { metadata }: TypedTransactionalMessage<UpdateMetadataCommand>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
     retry: boolean,
   ): Promise<void> {
     if (retry) {
@@ -103,7 +103,7 @@ export class UpdateMetadataHandler extends MediaGuardedTransactionalInboxMessage
           'Unexpected error occurred while updating metadata.',
         ),
       },
-      loginClient,
+      ownerClient,
       { envelopeOverrides: { auth_token: metadata.authToken } },
     );
   }

--- a/services/media/service/src/ingest/handlers/upsert-localization-source-entity-failed-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/upsert-localization-source-entity-failed-handler.db.spec.ts
@@ -118,7 +118,7 @@ describe('UpsertLocalizationSourceEntityFailedHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload, context), dbCtx),
       );
 
@@ -152,7 +152,7 @@ describe('UpsertLocalizationSourceEntityFailedHandler', () => {
       });
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleErrorMessage(
           error,
           createMessage(payload, context),

--- a/services/media/service/src/ingest/handlers/upsert-localization-source-entity-failed-handler.ts
+++ b/services/media/service/src/ingest/handlers/upsert-localization-source-entity-failed-handler.ts
@@ -37,7 +37,7 @@ export class UpsertLocalizationSourceEntityFailedHandler extends MediaTransactio
       payload,
       metadata,
     }: TypedTransactionalMessage<UpsertLocalizationSourceEntityFailedEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
     const messageContext = metadata.messageContext as Pick<
       IngestMessageContext,
@@ -58,7 +58,7 @@ export class UpsertLocalizationSourceEntityFailedHandler extends MediaTransactio
         type: 'LOCALIZATIONS',
       },
       { columns: ['id'] },
-    ).run(loginClient);
+    ).run(ownerClient);
 
     if (!localizationStep?.id) {
       throw new MosaicError({
@@ -75,7 +75,7 @@ export class UpsertLocalizationSourceEntityFailedHandler extends MediaTransactio
         ingest_item_id: messageContext.ingestItemId,
         error_message: payload.message,
       },
-      loginClient,
+      ownerClient,
       { envelopeOverrides: { auth_token: metadata.authToken } },
     );
   }
@@ -93,7 +93,7 @@ export class UpsertLocalizationSourceEntityFailedHandler extends MediaTransactio
     {
       metadata,
     }: TypedTransactionalMessage<UpsertLocalizationSourceEntityFailedEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
     retry: boolean,
   ): Promise<void> {
     if (retry) {
@@ -114,6 +114,6 @@ export class UpsertLocalizationSourceEntityFailedHandler extends MediaTransactio
         errors: sql<SQL>`${value} || ${err}::jsonb`,
       },
       { id: messageContext.ingestItemId },
-    ).run(loginClient);
+    ).run(ownerClient);
   }
 }

--- a/services/media/service/src/ingest/handlers/upsert-localization-source-entity-finished-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/upsert-localization-source-entity-finished-handler.db.spec.ts
@@ -145,7 +145,7 @@ describe('UpsertLocalizationSourceEntityFinishedHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload, context), dbCtx),
       );
 
@@ -225,7 +225,7 @@ describe('UpsertLocalizationSourceEntityFinishedHandler', () => {
       });
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleErrorMessage(
           error,
           createMessage(payload, context),

--- a/services/media/service/src/ingest/handlers/upsert-localization-source-entity-finished-handler.ts
+++ b/services/media/service/src/ingest/handlers/upsert-localization-source-entity-finished-handler.ts
@@ -50,7 +50,7 @@ export class UpsertLocalizationSourceEntityFinishedHandler extends MediaTransact
       payload,
       metadata,
     }: TypedTransactionalMessage<UpsertLocalizationSourceEntityFinishedEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
     const messageContext = metadata.messageContext as Pick<
       IngestMessageContext,
@@ -68,7 +68,7 @@ export class UpsertLocalizationSourceEntityFinishedHandler extends MediaTransact
       'ingest_items',
       { id: messageContext.ingestItemId },
       { columns: ['item'] },
-    ).run(loginClient);
+    ).run(ownerClient);
     const localizationStep = await selectOne(
       'ingest_item_steps',
       {
@@ -76,7 +76,7 @@ export class UpsertLocalizationSourceEntityFinishedHandler extends MediaTransact
         type: 'LOCALIZATIONS',
       },
       { columns: ['id'] },
-    ).run(loginClient);
+    ).run(ownerClient);
 
     if (!ingestItem || !localizationStep) {
       throw new MosaicError({
@@ -117,7 +117,7 @@ export class UpsertLocalizationSourceEntityFinishedHandler extends MediaTransact
       payload.entity_id,
       messageSettings,
       messagePayload,
-      loginClient,
+      ownerClient,
       {
         envelopeOverrides: {
           auth_token: token,
@@ -146,7 +146,7 @@ export class UpsertLocalizationSourceEntityFinishedHandler extends MediaTransact
     {
       metadata,
     }: TypedTransactionalMessage<UpsertLocalizationSourceEntityFinishedEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
     retry: boolean,
   ): Promise<void> {
     if (retry) {
@@ -167,6 +167,6 @@ export class UpsertLocalizationSourceEntityFinishedHandler extends MediaTransact
         errors: sql<SQL>`${value} || ${err}::jsonb`,
       },
       { id: messageContext.ingestItemId },
-    ).run(loginClient);
+    ).run(ownerClient);
   }
 }

--- a/services/media/service/src/ingest/handlers/video-failed-handler.ts
+++ b/services/media/service/src/ingest/handlers/video-failed-handler.ts
@@ -40,7 +40,7 @@ export class VideoFailedHandler extends MediaGuardedTransactionalInboxMessageHan
       id,
       aggregateId,
     }: TypedTransactionalMessage<EnsureVideoExistsFailedEvent>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
     if (!checkIsIngestEvent(metadata, this.logger, id, aggregateId)) {
       return;
@@ -56,7 +56,7 @@ export class VideoFailedHandler extends MediaGuardedTransactionalInboxMessageHan
         ingest_item_id: messageContext.ingestItemId,
         error_message: payload.message,
       },
-      loginClient,
+      ownerClient,
       { envelopeOverrides: { auth_token: metadata.authToken } },
     );
   }

--- a/services/media/service/src/ingest/handlers/video-succeeded-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/video-succeeded-handler.db.spec.ts
@@ -117,7 +117,7 @@ describe('VideoSucceededHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(createMessage(payload, context), dbCtx),
       );
 
@@ -151,7 +151,7 @@ describe('VideoSucceededHandler', () => {
       };
 
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleErrorMessage(
           new Error('test error'),
           createMessage(payload, context),

--- a/services/media/service/src/publishing/handlers/publish-entity-handler.db.spec.ts
+++ b/services/media/service/src/publishing/handlers/publish-entity-handler.db.spec.ts
@@ -84,7 +84,7 @@ describe('PublishEntityCommandHandler', () => {
   describe('onMessage', () => {
     it('message to publish a movie -> snapshot with relation created with correct metadata and publish message sent', async () => {
       // Act
-      await ctx.executeGqlSql(user, async (txn) => {
+      await ctx.executeOwnerSql(user, async (txn) => {
         await handler.handleMessage(
           createMessage({
             table_name: mockPublishingProcessor.type,
@@ -159,7 +159,7 @@ describe('PublishEntityCommandHandler', () => {
       );
 
       // Act
-      await ctx.executeGqlSql(user, async (txn) => {
+      await ctx.executeOwnerSql(user, async (txn) => {
         await handler.handleMessage(
           createMessage({
             table_name: 'snapshots',
@@ -237,7 +237,7 @@ describe('PublishEntityCommandHandler', () => {
       ).run(ctx.ownerPool);
 
       // Act
-      await ctx.executeGqlSql(user, async (txn) => {
+      await ctx.executeOwnerSql(user, async (txn) => {
         await handler.handleMessage(
           createMessage({
             table_name: 'snapshots',
@@ -298,7 +298,7 @@ describe('PublishEntityCommandHandler', () => {
 
       // Act
       const error = await rejectionOf(
-        ctx.executeGqlSql(user, async (txn) => {
+        ctx.executeOwnerSql(user, async (txn) => {
           await handler.handleMessage(
             createMessage({
               table_name: mockPublishingProcessor.type,
@@ -335,7 +335,7 @@ describe('PublishEntityCommandHandler', () => {
       handler = new PublishEntityHandler([], storeOutboxMessage, ctx.config);
 
       // Act
-      await ctx.executeGqlSql(user, async (txn) => {
+      await ctx.executeOwnerSql(user, async (txn) => {
         await handler.handleMessage(
           createMessage({
             table_name: 'movies',
@@ -381,7 +381,7 @@ describe('PublishEntityCommandHandler', () => {
   describe('onMessageFailure', () => {
     it('message to publish a movie failed after 10 tries -> snapshot with ERROR state created', async () => {
       // Act
-      await ctx.executeGqlSql(user, async (txn) => {
+      await ctx.executeOwnerSql(user, async (txn) => {
         await handler.handleMessage(
           createMessage({
             table_name: 'movies',
@@ -438,7 +438,7 @@ describe('PublishEntityCommandHandler', () => {
       );
 
       // Act
-      await ctx.executeGqlSql(user, async (txn) => {
+      await ctx.executeOwnerSql(user, async (txn) => {
         await handler.handleMessage(
           createMessage({
             table_name: 'snapshots',

--- a/services/media/service/src/publishing/handlers/unpublish-entity-handler.db.spec.ts
+++ b/services/media/service/src/publishing/handlers/unpublish-entity-handler.db.spec.ts
@@ -93,7 +93,7 @@ describe('UnpublishEntityHandler', () => {
   describe('onMessage', () => {
     it('message to publish a movie -> snapshot with relation created with correct metadata and publish message sent', async () => {
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(
           createMessage({
             table_name: mockPublishingProcessor.type,
@@ -143,7 +143,7 @@ describe('UnpublishEntityHandler', () => {
 
     it('message to publish a snapshot -> existing snapshot is updated with correct metadata and publish message sent', async () => {
       // Act
-      await ctx.executeGqlSql(user, async (dbCtx) =>
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
         handler.handleMessage(
           createMessage({
             table_name: 'snapshots',

--- a/services/media/service/src/publishing/handlers/unpublish-entity-handler.ts
+++ b/services/media/service/src/publishing/handlers/unpublish-entity-handler.ts
@@ -39,19 +39,19 @@ export class UnpublishEntityHandler extends MediaGuardedTransactionalInboxMessag
 
   async handleMessage(
     { payload, metadata }: TypedTransactionalMessage<UnpublishEntityCommand>,
-    loginClient: ClientBase,
+    ownerClient: ClientBase,
   ): Promise<void> {
     const payloadTable = payload.table_name as Table;
     let snapshot: snapshots.Selectable | snapshots.JSONSelectable | undefined;
     if (payloadTable === 'snapshots') {
       snapshot = await selectOne('snapshots', {
         id: payload.entity_id,
-      }).run(loginClient);
+      }).run(ownerClient);
     } else {
       snapshot = await getPublishedSnapshot(
         payloadTable,
         payload.entity_id,
-        loginClient,
+        ownerClient,
       );
     }
 
@@ -65,7 +65,7 @@ export class UnpublishEntityHandler extends MediaGuardedTransactionalInboxMessag
 
     const wrapper = new SnapshotWrapper(
       snapshot.id,
-      loginClient,
+      ownerClient,
       this.storeOutboxMessage,
       this.config,
     );

--- a/services/media/service/src/tests/ingest/upload.db.spec.ts
+++ b/services/media/service/src/tests/ingest/upload.db.spec.ts
@@ -515,7 +515,7 @@ describe('Movies GraphQL endpoints', () => {
         defaultRequestContext,
       );
 
-      await ctx.executeGqlSql(user, async (txn) => {
+      await ctx.executeOwnerSql(user, async (txn) => {
         let videoId = 1;
         let imageId = 1;
         while (messages.length) {


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [x] appropriate labels for the PR applied

## Description

Media message handles had db clients named `loginClient`, and renamed to `ownerClient` to match the db connection that actually produces the client (in `dbHandlerConfig` of `services\video\service\src\messaging\register-messaging.ts`). Adjusted the tests to pass appropriate matching clients.
