### PR TITLE
[AB#43767] entity titles are now fully generated for localized seasons and episodes

### DIFF
--- a/services/media/service/migrations/committed/000024-update-localization-required-fields.sql
+++ b/services/media/service/migrations/committed/000024-update-localization-required-fields.sql
@@ -1,0 +1,8 @@
+--! Previous: sha1:50966f45912651069b92071e3c73262b023ad48e
+--! Hash: sha1:d7c481931580f6acf907cf543994742775ae710c
+--! Message: update-localization-required-fields
+
+SELECT app_hidden.create_localizable_entity_triggers(
+  'id', 'episodes', 'EPISODE', ':EPISODE_LOCALIZABLE_FIELDS',':EPISODE_LOCALIZATION_REQUIRED_FIELDS');
+SELECT app_hidden.create_localizable_entity_triggers(
+  'id', 'seasons', 'SEASON', ':SEASON_LOCALIZABLE_FIELDS',':SEASON_LOCALIZATION_REQUIRED_FIELDS');

--- a/services/media/service/src/domains/tvshows/localization/localizable-episode-db-migration-placeholders.ts
+++ b/services/media/service/src/domains/tvshows/localization/localizable-episode-db-migration-placeholders.ts
@@ -16,7 +16,9 @@ export const localizableEpisodeDbMigrationPlaceholders = {
   // update computed entityTitle
   ':EPISODE_LOCALIZABLE_FIELDS':
     EpisodeFieldDefinitions.map((d) => d.field_name).join(',') + ',season_id',
-  ':EPISODE_LOCALIZATION_REQUIRED_FIELDS': 'id,index',
+  // season_id is always included to make sure entityTitle is generated
+  // fully on metadata updates
+  ':EPISODE_LOCALIZATION_REQUIRED_FIELDS': 'id,index,season_id',
   ':EPISODE_IMAGE_LOCALIZABLE_FIELDS': 'image_id',
   ':EPISODE_IMAGE_LOCALIZATION_REQUIRED_FIELDS':
     'episode_id,image_id,image_type',

--- a/services/media/service/src/domains/tvshows/localization/localizable-season-db-migration-placeholders.ts
+++ b/services/media/service/src/domains/tvshows/localization/localizable-season-db-migration-placeholders.ts
@@ -16,7 +16,9 @@ export const localizableSeasonDbMigrationPlaceholders = {
   // update computed entityTitle
   ':SEASON_LOCALIZABLE_FIELDS':
     SeasonFieldDefinitions.map((d) => d.field_name).join(',') + ',tvshow_id',
-  ':SEASON_LOCALIZATION_REQUIRED_FIELDS': 'id,index',
+  // tvshow_id is always included to make sure entityTitle is generated
+  // fully on metadata updates
+  ':SEASON_LOCALIZATION_REQUIRED_FIELDS': 'id,index,tvshow_id',
   ':SEASON_IMAGE_LOCALIZABLE_FIELDS': 'image_id',
   ':SEASON_IMAGE_LOCALIZATION_REQUIRED_FIELDS': 'season_id,image_id,image_type',
 };

--- a/services/media/service/src/generated/db/schema.sql
+++ b/services/media/service/src/generated/db/schema.sql
@@ -652,7 +652,7 @@ CREATE FUNCTION app_hidden.localizable_episode_delete() RETURNS trigger
     AS $$
 DECLARE
 	_jsonb_old jsonb := row_to_json(OLD.*);
-	_fields text[] := string_to_array('id,index', ',');
+	_fields text[] := string_to_array('id,index,season_id', ',');
 	_payload jsonb := '{}'::jsonb;
 BEGIN
 	SELECT jsonb_object_agg(f.field, _jsonb_old -> f.field)
@@ -758,7 +758,7 @@ CREATE FUNCTION app_hidden.localizable_episode_insert() RETURNS trigger
     AS $$
 DECLARE
 	_jsonb_new jsonb := row_to_json(NEW.*);
-	_fields text[] := string_to_array('title,synopsis,description,season_id', ',') || string_to_array('id,index', ',');
+	_fields text[] := string_to_array('title,synopsis,description,season_id', ',') || string_to_array('id,index,season_id', ',');
 	_payload jsonb := '{}'::jsonb;
 	_field text;
 BEGIN
@@ -785,7 +785,7 @@ CREATE FUNCTION app_hidden.localizable_episode_update() RETURNS trigger
 DECLARE
 	_jsonb_old jsonb := row_to_json(OLD.*);
 	_jsonb_new jsonb := row_to_json(NEW.*);
-	_required_fields text[] := string_to_array('id,index', ',');
+	_required_fields text[] := string_to_array('id,index,season_id', ',');
 	_localizable_fields text[] := string_to_array('title,synopsis,description,season_id', ',');
 	_payload jsonb := '{}'::jsonb;
 	_metadata jsonb;
@@ -1077,7 +1077,7 @@ CREATE FUNCTION app_hidden.localizable_season_delete() RETURNS trigger
     AS $$
 DECLARE
 	_jsonb_old jsonb := row_to_json(OLD.*);
-	_fields text[] := string_to_array('id,index', ',');
+	_fields text[] := string_to_array('id,index,tvshow_id', ',');
 	_payload jsonb := '{}'::jsonb;
 BEGIN
 	SELECT jsonb_object_agg(f.field, _jsonb_old -> f.field)
@@ -1183,7 +1183,7 @@ CREATE FUNCTION app_hidden.localizable_season_insert() RETURNS trigger
     AS $$
 DECLARE
 	_jsonb_new jsonb := row_to_json(NEW.*);
-	_fields text[] := string_to_array('synopsis,description,tvshow_id', ',') || string_to_array('id,index', ',');
+	_fields text[] := string_to_array('synopsis,description,tvshow_id', ',') || string_to_array('id,index,tvshow_id', ',');
 	_payload jsonb := '{}'::jsonb;
 	_field text;
 BEGIN
@@ -1210,7 +1210,7 @@ CREATE FUNCTION app_hidden.localizable_season_update() RETURNS trigger
 DECLARE
 	_jsonb_old jsonb := row_to_json(OLD.*);
 	_jsonb_new jsonb := row_to_json(NEW.*);
-	_required_fields text[] := string_to_array('id,index', ',');
+	_required_fields text[] := string_to_array('id,index,tvshow_id', ',');
 	_localizable_fields text[] := string_to_array('synopsis,description,tvshow_id', ',');
 	_payload jsonb := '{}'::jsonb;
 	_metadata jsonb;

--- a/services/media/service/src/tests/localization/localizable-episode-triggers.db.spec.ts
+++ b/services/media/service/src/tests/localization/localizable-episode-triggers.db.spec.ts
@@ -68,9 +68,14 @@ describe('Episode localizable triggers', () => {
       ]);
     });
 
-    it('Episode inserted with title, description, synopsis -> inbox entry added', async () => {
+    it('Episode inserted with title, description, synopsis, and season relation -> inbox entry added', async () => {
       // Arrange
       await ctx.truncate('episodes');
+      const season = await insert('seasons', {
+        id: 1,
+        index: 2,
+      }).run(ctx.ownerPool);
+      await ctx.truncateInbox();
 
       // Act
       episode = await insert('episodes', {
@@ -79,6 +84,7 @@ describe('Episode localizable triggers', () => {
         title: 'My Episode',
         synopsis: 'My Synopsis',
         description: 'My Description',
+        season_id: season.id,
       }).run(ctx.ownerPool);
 
       // Assert
@@ -100,6 +106,7 @@ describe('Episode localizable triggers', () => {
             title: episode.title,
             synopsis: episode.synopsis,
             description: episode.description,
+            season_id: season.id,
           },
         },
       ]);
@@ -130,12 +137,20 @@ describe('Episode localizable triggers', () => {
             id: episode.id,
             index: episode.index,
             title: updatedEpisode.title,
+            season_id: null,
           },
         },
       ]);
     });
 
-    it('Episode updated with title, description, synopsis -> inbox entry added', async () => {
+    it('Episode updated with title, description, synopsis, and season relation -> inbox entry added', async () => {
+      // Arrange
+      const season = await insert('seasons', {
+        id: 1,
+        index: 2,
+      }).run(ctx.ownerPool);
+      await ctx.truncateInbox();
+
       // Act
       const [updatedEpisode] = await update(
         'episodes',
@@ -143,6 +158,7 @@ describe('Episode localizable triggers', () => {
           title: 'My Edited Episode',
           synopsis: 'My Edited Synopsis',
           description: 'My Edited Description',
+          season_id: season.id,
         },
         { id: episode.id },
       ).run(ctx.ownerPool);
@@ -166,6 +182,7 @@ describe('Episode localizable triggers', () => {
             title: updatedEpisode.title,
             synopsis: updatedEpisode.synopsis,
             description: updatedEpisode.description,
+            season_id: season.id,
           },
         },
       ]);
@@ -285,7 +302,7 @@ describe('Episode localizable triggers', () => {
           // even if no localizable fields are updated - we want to trigger the
           // message to receive the response from Mosaic localization service if
           // this is an update in context of ingest.
-          payload: { id: episode.id, index: episode.index },
+          payload: { id: episode.id, index: episode.index, season_id: null },
         },
       ]);
     });
@@ -318,7 +335,7 @@ describe('Episode localizable triggers', () => {
           // even if no localizable fields are updated - we want to trigger the
           // message to receive the response from Mosaic localization service if
           // this is an update in context of ingest.
-          payload: { id: episode.id, index: episode.index },
+          payload: { id: episode.id, index: episode.index, season_id: null },
         },
       ]);
     });
@@ -343,6 +360,7 @@ describe('Episode localizable triggers', () => {
           payload: {
             id: episode.id,
             index: episode.index,
+            season_id: null,
           },
         },
       ]);
@@ -489,6 +507,7 @@ describe('Episode localizable triggers', () => {
           payload: {
             id: episode.id,
             index: episode.index,
+            season_id: null,
           },
         },
         {

--- a/services/media/service/src/tests/localization/localizable-season-triggers.db.spec.ts
+++ b/services/media/service/src/tests/localization/localizable-season-triggers.db.spec.ts
@@ -65,9 +65,14 @@ describe('Season localizable triggers', () => {
       ]);
     });
 
-    it('Season inserted with index, description, synopsis -> inbox entry added', async () => {
+    it('Season inserted with index, description, synopsis, and parent tvshow -> inbox entry added', async () => {
       // Arrange
       await ctx.truncate('seasons');
+      const tvshow = await insert('tvshows', {
+        id: 1,
+        title: 'My Tvshow',
+      }).run(ctx.ownerPool);
+      await ctx.truncateInbox();
 
       // Act
       season = await insert('seasons', {
@@ -75,6 +80,7 @@ describe('Season localizable triggers', () => {
         index: 1,
         synopsis: 'My Synopsis',
         description: 'My Description',
+        tvshow_id: tvshow.id,
       }).run(ctx.ownerPool);
 
       // Assert
@@ -95,6 +101,7 @@ describe('Season localizable triggers', () => {
             index: season.index,
             synopsis: season.synopsis,
             description: season.description,
+            tvshow_id: tvshow.id,
           },
         },
       ]);
@@ -111,13 +118,20 @@ describe('Season localizable triggers', () => {
       expect(inbox).toHaveLength(0);
     });
 
-    it('Season updated with description, synopsis -> inbox entry added', async () => {
+    it('Season updated with description, synopsis, and tvshow relation -> inbox entry added', async () => {
+      // Arrange
+      const tvshow = await insert('tvshows', {
+        id: 1,
+        title: 'My Tvshow',
+      }).run(ctx.ownerPool);
+      await ctx.truncateInbox();
       // Act
       const [updatedSeason] = await update(
         'seasons',
         {
           synopsis: 'My Edited Synopsis',
           description: 'My Edited Description',
+          tvshow_id: tvshow.id,
         },
         { id: season.id },
       ).run(ctx.ownerPool);
@@ -140,6 +154,7 @@ describe('Season localizable triggers', () => {
             index: season.index,
             synopsis: updatedSeason.synopsis,
             description: updatedSeason.description,
+            tvshow_id: tvshow.id,
           },
         },
       ]);
@@ -256,7 +271,7 @@ describe('Season localizable triggers', () => {
           // even if no localizable fields are updated - we want to trigger the
           // message to receive the response from Mosaic localization service if
           // this is an update in context of ingest.
-          payload: { id: season.id, index: season.index },
+          payload: { id: season.id, index: season.index, tvshow_id: null },
         },
       ]);
     });
@@ -289,7 +304,7 @@ describe('Season localizable triggers', () => {
           // even if no localizable fields are updated - we want to trigger the
           // message to receive the response from Mosaic localization service if
           // this is an update in context of ingest.
-          payload: { id: season.id, index: season.index },
+          payload: { id: season.id, index: season.index, tvshow_id: null },
         },
       ]);
     });
@@ -314,6 +329,7 @@ describe('Season localizable triggers', () => {
           payload: {
             id: season.id,
             index: season.index,
+            tvshow_id: null,
           },
         },
       ]);
@@ -457,6 +473,7 @@ describe('Season localizable triggers', () => {
           payload: {
             id: season.id,
             index: season.index,
+            tvshow_id: null,
           },
         },
         {


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Testing Notes
- ingest a file with tvshow, season, and episode (all related to each other, each must have at least title/index and description)
- ingest succeeds
- check Localizations for some locale
    - Expected result: titles that indicate relations e.g. `Season 1 (The Last of Us)` or `Episode 9 (Season 1, The Last of Us)`
    - Previous result: simplified titles, e.g. `Season 1` or `Episode 9`
