### PR TITLE
[AB#43408] deprecated assertError calls replaced by ensureError

### DIFF
--- a/scripts/helpers/db-test-helpers.ts
+++ b/scripts/helpers/db-test-helpers.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import {
-  assertError,
   createTestDbIdentifier,
+  ensureError,
   getBasicDbConfigDefinitions,
   ValueObject,
 } from '@axinom/mosaic-service-common';
@@ -211,9 +211,9 @@ const resetTemplate1Connections = async (rootPgPool: Pool): Promise<void> => {
     console.log(`Running Query: '${query}'`);
     await rootPgPool.query(query);
   } catch (e) {
-    assertError(e);
+    const error = ensureError(e);
     console.warn(
-      `Could not drop connections on the "template1" database: ${e.message}`,
+      `Could not drop connections on the "template1" database: ${error.message}`,
     );
   }
 };

--- a/services/catalog/service/src/tests/test-utils/test-context.ts
+++ b/services/catalog/service/src/tests/test-utils/test-context.ts
@@ -9,10 +9,10 @@ import {
 } from '@axinom/mosaic-db-common';
 import { enhanceGraphqlErrors } from '@axinom/mosaic-graphql-common';
 import {
-  assertError,
   customizeGraphQlErrorFields,
   defaultPgErrorMapper,
   Dict,
+  ensureError,
   GraphQLErrorEnhanced,
   Logger,
   logGraphQlError,
@@ -196,9 +196,9 @@ export const createTestContext = async (
       try {
         await truncate(tableName, 'CASCADE').run(this.ownerPool);
       } catch (e) {
-        assertError(e);
+        const error = ensureError(e);
         this.logger.error(
-          e,
+          error,
           'An error occurred while trying to truncate a table using TestContext.',
         );
       }
@@ -208,9 +208,9 @@ export const createTestContext = async (
         await this.ownerPool.end();
         await this.loginPool.end();
       } catch (e) {
-        assertError(e);
+        const error = ensureError(e);
         this.logger.error(
-          e,
+          error,
           'An error occurred while trying to dispose pg pools using TestContext.',
         );
       }

--- a/services/entitlement/service/src/tests/test-utils/test-context.ts
+++ b/services/entitlement/service/src/tests/test-utils/test-context.ts
@@ -13,10 +13,10 @@ import {
   EndUserAuthenticationContext,
 } from '@axinom/mosaic-id-guard';
 import {
-  assertError,
   customizeGraphQlErrorFields,
   defaultPgErrorMapper,
   Dict,
+  ensureError,
   GraphQLErrorEnhanced,
   Logger,
   logGraphQlError,
@@ -200,9 +200,9 @@ export const createTestContext = async (
       try {
         await truncate(tableName, 'CASCADE').run(this.ownerPool);
       } catch (e) {
-        assertError(e);
+        const error = ensureError(e);
         this.logger.error(
-          e,
+          error,
           'An error occurred while trying to truncate a table using TestContext.',
         );
       }
@@ -212,9 +212,9 @@ export const createTestContext = async (
         await this.ownerPool.end();
         await this.loginPool.end();
       } catch (e) {
-        assertError(e);
+        const error = ensureError(e);
         this.logger.error(
-          e,
+          error,
           'An error occurred while trying to dispose pg pools using TestContext.',
         );
       }

--- a/services/media/service/scripts/ingest-gen.ts
+++ b/services/media/service/scripts/ingest-gen.ts
@@ -2,8 +2,8 @@
 /* eslint-disable no-console */
 import { optional } from '@axinom/mosaic-db-common';
 import {
-  assertError,
   Dict,
+  ensureError,
   getValidatedConfig,
   isNullOrWhitespace,
   MosaicError,
@@ -489,8 +489,8 @@ const makeVideoCopy = async (
       conditions: { ifNoneMatch: '*' },
     });
     console.log(getTimestamp(), `Copying video: ${videoPath}`);
-  } catch (err) {
-    assertError(err);
+  } catch (e) {
+    const err = ensureError(e);
     const error = err as Error & { code: string };
     if (error.code === 'BlobAlreadyExists') {
       console.log(getTimestamp(), `Video already exists: ${videoPath}`);
@@ -586,8 +586,8 @@ const generateAndUploadImage = async (
   try {
     await blob.uploadData(buffer, { conditions: { ifNoneMatch: '*' } });
     console.log(getTimestamp(), `Image uploaded: ${imagePath}`);
-  } catch (err) {
-    assertError(err);
+  } catch (e) {
+    const err = ensureError(e);
     const error = err as Error & { code: string };
     if (error.code === 'BlobAlreadyExists') {
       console.log(getTimestamp(), `Image already exists: ${imagePath}`);
@@ -723,8 +723,8 @@ const getProcessingProfiles = async (
     }
 
     return profiles;
-  } catch (error) {
-    assertError(error);
+  } catch (e) {
+    const error = ensureError(e);
     throw new MosaicError({
       message: `An error occurred trying to retrieve encoding processing profiles`,
       code: 'INGEST_GEN_PROFILES_ERROR',
@@ -778,8 +778,8 @@ const getLanguageTags = async (
       ) ?? [];
 
     return languageTags;
-  } catch (error) {
-    assertError(error);
+  } catch (e) {
+    const error = ensureError(e);
     throw new MosaicError({
       message: `An error occurred trying to retrieve localization language tags`,
       code: 'INGEST_GEN_LOCALIZATIONS_ERROR',

--- a/services/media/service/src/domains/collections/plugins/populate-endpoint-plugin.ts
+++ b/services/media/service/src/domains/collections/plugins/populate-endpoint-plugin.ts
@@ -1,5 +1,5 @@
 import {
-  assertError,
+  ensureError,
   Logger,
   randomArray,
 } from '@axinom/mosaic-service-common';
@@ -148,8 +148,8 @@ export const PopulateEndpointPlugin = makeExtendSchemaPlugin((build) => {
                 },
               );
               count += elements.length;
-            } catch (error) {
-              assertError(error);
+            } catch (e) {
+              const error = ensureError(e);
               logger.warn(
                 error,
                 `An error occurred trying to insert a batch of ${batch} sample collections.`,

--- a/services/media/service/src/domains/movies/plugins/populate-endpoint-plugin.ts
+++ b/services/media/service/src/domains/movies/plugins/populate-endpoint-plugin.ts
@@ -1,4 +1,4 @@
-import { assertError, Logger } from '@axinom/mosaic-service-common';
+import { ensureError, Logger } from '@axinom/mosaic-service-common';
 import { faker } from '@faker-js/faker';
 import { gql as gqlExtended, makeExtendSchemaPlugin } from 'graphile-utils';
 import { PublishStatusEnum } from 'zapatos/custom';
@@ -107,8 +107,8 @@ export const PopulateEndpointPlugin = makeExtendSchemaPlugin((build) => {
                 },
               );
               count += elements.length;
-            } catch (error) {
-              assertError(error);
+            } catch (e) {
+              const error = ensureError(e);
               logger.warn(
                 error,
                 `An error occurred trying to insert a batch of ${batch} sample movies.`,

--- a/services/media/service/src/domains/tvshows/plugins/populate-endpoint-plugin.ts
+++ b/services/media/service/src/domains/tvshows/plugins/populate-endpoint-plugin.ts
@@ -1,4 +1,4 @@
-import { assertError, Logger } from '@axinom/mosaic-service-common';
+import { ensureError, Logger } from '@axinom/mosaic-service-common';
 import { faker } from '@faker-js/faker';
 import { gql as gqlExtended, makeExtendSchemaPlugin } from 'graphile-utils';
 import { PublishStatusEnum } from 'zapatos/custom';
@@ -213,8 +213,8 @@ export const PopulateEndpointPlugin = makeExtendSchemaPlugin((build) => {
                   count += tvshows.length;
                 },
               );
-            } catch (error) {
-              assertError(error);
+            } catch (e) {
+              const error = ensureError(e);
               logger.warn(
                 error,
                 `An error occurred trying to insert a batch of ${batch} sample TV shows.`,

--- a/services/media/service/src/tests/test-utils/test-context.ts
+++ b/services/media/service/src/tests/test-utils/test-context.ts
@@ -13,10 +13,10 @@ import {
   ManagementAuthenticationContext,
 } from '@axinom/mosaic-id-guard';
 import {
-  assertError,
   customizeGraphQlErrorFields,
   defaultWriteLogMapper,
   Dict,
+  ensureError,
   GraphQLErrorEnhanced,
   Logger,
   logGraphQlError,
@@ -251,9 +251,9 @@ export const createTestContext = async (
       try {
         await truncate(tableName, 'CASCADE').run(this.ownerPool);
       } catch (e) {
-        assertError(e);
+        const error = ensureError(e);
         this.logger.error(
-          e,
+          error,
           'An error occurred while trying to truncate a table using TestContext.',
         );
       }
@@ -263,9 +263,9 @@ export const createTestContext = async (
         await this.ownerPool.end();
         await this.loginPool.end();
       } catch (e) {
-        assertError(e);
+        const error = ensureError(e);
         this.logger.error(
-          e,
+          error,
           'An error occurred while trying to dispose pg pools using TestContext.',
         );
       }


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [x] appropriate labels for the PR applied

## Description

Dropped the usage of deprecated `assertError` function in favor of `ensureError`. This reduces the chances of errors being rethrown in try/catch blocks. No testing notes, as all affected files are dev-related.
