### PR TITLE
[AB#44239] Seed data postponed when localizations are enabled

### DIFF
--- a/services/media/service/src/domains/common/handlers/entity-definition-declare-finished-handler.ts
+++ b/services/media/service/src/domains/common/handlers/entity-definition-declare-finished-handler.ts
@@ -13,7 +13,10 @@ export class EntityDefinitionDeclareFinishedHandler extends TransactionalInboxMe
   EntityDefinitionDeclareFinishedEvent,
   Config
 > {
-  constructor(config: Config) {
+  constructor(
+    config: Config,
+    private readonly callback: (entityType: string) => Promise<void>,
+  ) {
     super(
       LocalizationServiceMultiTenantMessagingSettings.EntityDefinitionDeclareFinished,
       new Logger({
@@ -33,5 +36,10 @@ export class EntityDefinitionDeclareFinishedHandler extends TransactionalInboxMe
         details: { ...payload },
       });
     }
+
+    // Performs a callback to do post-processing, e.g. populate seed data only
+    // after definitions are fully synced.
+    // Done in this way to avoid circular dependencies between imports.
+    await this.callback(payload.entity_type);
   }
 }

--- a/services/media/service/src/domains/populate-seed-data.ts
+++ b/services/media/service/src/domains/populate-seed-data.ts
@@ -1,17 +1,45 @@
 import { OwnerPgPool } from '@axinom/mosaic-db-common';
 import { Logger } from '@axinom/mosaic-service-common';
-import { MovieGenresSeedDataHandler } from './movies';
-import { TvshowGenresSeedDataHandler } from './tvshows';
+import { Config } from '../common';
+import {
+  LOCALIZATION_MOVIE_GENRE_TYPE,
+  MovieGenresSeedDataHandler,
+} from './movies';
+import {
+  LOCALIZATION_TVSHOW_GENRE_TYPE,
+  TvshowGenresSeedDataHandler,
+} from './tvshows';
 
 export const populateSeedData = async (
   pgPool: OwnerPgPool,
+  config: Config,
   logger: Logger = new Logger({ context: `populateSeedData` }),
 ): Promise<void> => {
-  const handlers = [
-    new MovieGenresSeedDataHandler(pgPool, logger),
-    new TvshowGenresSeedDataHandler(pgPool, logger),
-  ];
-  for (const handler of handlers) {
-    await handler.seed();
+  if (config.isLocalizationEnabled) {
+    logger.debug(
+      'Seed data population postponed until localization entity definitions are fully synchronized.',
+    );
+    return;
+  }
+  const populate = getPopulateSeedDataCallback(pgPool, logger);
+  const types = [LOCALIZATION_MOVIE_GENRE_TYPE, LOCALIZATION_TVSHOW_GENRE_TYPE];
+  for (const type of types) {
+    await populate(type);
   }
 };
+
+export const getPopulateSeedDataCallback =
+  (
+    pgPool: OwnerPgPool,
+    logger: Logger = new Logger({ context: `getPopulateSeedDataCallback` }),
+  ) =>
+  async (entityType: string): Promise<void> => {
+    switch (entityType) {
+      case LOCALIZATION_MOVIE_GENRE_TYPE:
+        await new MovieGenresSeedDataHandler(pgPool, logger).seed();
+        break;
+      case LOCALIZATION_TVSHOW_GENRE_TYPE:
+        await new TvshowGenresSeedDataHandler(pgPool, logger).seed();
+        break;
+    }
+  };

--- a/services/media/service/src/index.ts
+++ b/services/media/service/src/index.ts
@@ -135,7 +135,7 @@ async function bootstrap(): Promise<void> {
   await registerTypes(storeOutboxMessage, loginPgPool, config);
 
   // Populate the DB with some initial seed data
-  await populateSeedData(ownerPgPool, logger);
+  await populateSeedData(ownerPgPool, config, logger);
 
   // Enable authentication middleware for all requests to /graphql.
   setupManagementAuthentication(app, ['/graphql'], authConfig);

--- a/services/media/service/src/messaging/register-messaging.ts
+++ b/services/media/service/src/messaging/register-messaging.ts
@@ -65,6 +65,7 @@ import {
   LocalizableMovieImageUpdatedDbMessageHandler,
   LocalizableMovieUpdatedDbMessageHandler,
 } from '../domains/movies';
+import { getPopulateSeedDataCallback } from '../domains/populate-seed-data';
 import {
   entityPublishEventSettings,
   publishingProcessors,
@@ -343,7 +344,10 @@ const registerTransactionalInboxHandlers = (
     new ImageTypesDeclaredHandler(config),
     new ImageTypesDeclareFailedHandler(config),
     new EntityDefinitionDeclareFailedHandler(config),
-    new EntityDefinitionDeclareFinishedHandler(config),
+    new EntityDefinitionDeclareFinishedHandler(
+      config,
+      getPopulateSeedDataCallback(ownerPool),
+    ),
     new EntityDefinitionDeleteFailedHandler(config),
     new EntityDefinitionDeleteFinishedHandler(config),
   ];


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Previously, it was possible when a new instance of media service is deployed (e.g. using hosting v2) - seed data would be populated for genres, but, e.g. for tv show genres, localizations would not be synchronized.

This happens because registration of localization entity definitions with localization service and insertion of genres was happening at almost the same time. Sometimes this resulted in cases when source entities were processed (and failed) before entity definitions were processed.

Now, if localizations are enabled for the media service - seed data will not be immediately inserted, but only when receiving corresponding  `EntityDefinitionDeclareFinished` events.

## Testing notes

With localizations enabled:
- Create a new environment in admin-portal,
- Define some locales in the Localization service configuration station
- Deploy media service via Hosting v2
- Observe `Media Management` -> `Movie Genres` and `Media Management` -> `TV Show Genres`  stations - they should have default genres created
- Observe the localizations for created locale - it might be delayed, but both movie and tvshow genres should be visible there.

With localizations disabled:
- Create a new environment in admin-portal,
- Make sure localization service is disabled (disable it if it was enabled by default)
- Deploy media service via Hosting v2
- Observe `Media Management` -> `Movie Genres` and `Media Management` -> `TV Show Genres`  stations - they should have default genres created