### PR TITLE
[AB#41605] localizations view optimized in catalog service

### DIFF
--- a/.vscode/mosaic-sql-migrations.code-snippets
+++ b/.vscode/mosaic-sql-migrations.code-snippets
@@ -165,7 +165,8 @@
     "description": [
       "Defines ASC/DESC indexes based on id and one other column.",
       "Use these indexes if there is a plan to perform sorting by this column.\n",
-      "Fourth & fifth (optional) parameters: unique names for the indexes. If either value is NULL then a name will be generated from the table & field name."
+      "Fourth & fifth (optional) parameters: unique names for the indexes. If either value is NULL then a name will be generated from the table & field name.\n",
+      "Sixth (optional) parameter: name for the ID column to be used, default is 'id'"
     ],
     "scope": "sql"
   },
@@ -362,9 +363,21 @@
   },
   "Create Messaging Counter Table (Ax Define)": {
     "prefix": "ax-create-messaging-counter-table",
-    "body": ["SELECT ax_define.create_messaging_counter_table();"],
+    "body": [
+      "SELECT ax_define.create_messaging_counter_table();"
+    ],
     "description": [
       "Creates a table that will count how often a message was already processed via Mosaic-based messaging e.g. multiple retries due to server crashes."
+    ],
+    "scope": "sql"
+  },
+  "Create Messaging Health Monitoring (Ax Define)": {
+    "prefix": "ax-create-messaging-health-monitoring",
+    "body": [
+      "SELECT ax_define.create_messaging_health_monitorying();"
+    ],
+    "description": [
+      "Creates a table that will store a key when a health check is conducted and triggers to notify the application about updates in that table."
     ],
     "scope": "sql"
   },
@@ -437,12 +450,41 @@
   },
   "Pgmemento Delete Old Logs (Ax Define)": {
     "prefix": "ax-pgmemento-delete-old-logs",
-    "body": ["SELECT ax_define.pgmemento_delete_old_logs(${age:'30 days'})"],
+    "body": [
+      "SELECT ax_define.pgmemento_delete_old_logs(${age:'30 days'})"
+    ],
     "description": [
       "Deletes all audit logs (for all registered tables) older than specified age.\n",
       "Returns number of table events deleted.\n",
       "NOTE: This requires pgmemento extension to be installed in the database.\n",
       "For additional info, see https://github.com/pgMemento/pgMemento/wiki/Delete-logs .\n"
+    ],
+    "scope": "sql"
+  },
+  "Create Trx Table  (Ax Define)": {
+    "prefix": "ax-create-trx-table ",
+    "body": [
+      "SELECT ax_define.create_trx_table(",
+      "  '${1:app_hidden}',",
+      "  '${2|inbox,outbox|}',",
+      "  '{${3::DATABASE_ENV_OWNER},${4::DATABASE_GQL_ROLE}}',",
+      "  '${5|sequential,parallel|}');"
+    ],
+    "description": [
+      "Create a new table for transaction inbox/outbox handling. \n"
+    ],
+    "scope": "sql"
+  },
+  "Create Trx Next Messages Function (Ax Define)": {
+    "prefix": "ax-create-trx-next-messages-function",
+    "body": [
+      "SELECT ax_define.create_trx_next_messages_function(",
+      "  '${1:app_hidden}',",
+      "  '${2:app_hidden}',",
+      "  '${3|inbox,outbox|}');"
+    ],
+    "description": [
+      "Create next_messages function that is used to poll the inbox/outbox tables. \n"
     ],
     "scope": "sql"
   },
@@ -467,7 +509,9 @@
   },
   "Validate Identifier Length (Ax Utils)": {
     "prefix": "ax-validate-identifier-length",
-    "body": ["PERFORM ax_utils.validate_identifier_length('${1:identifier}');"],
+    "body": [
+      "PERFORM ax_utils.validate_identifier_length('${1:identifier}');"
+    ],
     "description": [
       "Raises an exception if the provided identifer exceeds the PostgreSQL max length (63 bytes).",
       "This can be useful to prevent name truncation, identifier collisions and silently dropped constraints.",
@@ -677,7 +721,9 @@
   },
   "Validation Not Empty (Ax Utils)": {
     "prefix": "ax-validation-not-empty",
-    "body": ["ax_utils.validation_not_empty(${1:column_or_variable})"],
+    "body": [
+      "ax_utils.validation_not_empty(${1:column_or_variable})"
+    ],
     "description": [
       "Returns true if the value is not null, not an empty string, and not a whitespace string. Returns false otherwise."
     ],
@@ -685,7 +731,9 @@
   },
   "Validation Is Trimmed (Ax Utils)": {
     "prefix": "ax-validation-is-trimmed",
-    "body": ["ax_utils.validation_is_trimmed(${1:column_or_variable})"],
+    "body": [
+      "ax_utils.validation_is_trimmed(${1:column_or_variable})"
+    ],
     "description": [
       "Returns false if the value starts or ends with a whitespace character. Returns true otherwise."
     ],
@@ -693,7 +741,9 @@
   },
   "Validation Is Base64 (Ax Utils)": {
     "prefix": "ax-validation-is-base64",
-    "body": ["ax_utils.validation_is_base64(${1:column_or_variable})"],
+    "body": [
+      "ax_utils.validation_is_base64(${1:column_or_variable})"
+    ],
     "description": [
       "Returns true if the value is a base64 encoded string. Returns false otherwise."
     ],
@@ -701,7 +751,9 @@
   },
   "Validation Is Identifier Key (Ax Utils)": {
     "prefix": "ax-validation-is-identifier-key",
-    "body": ["ax_utils.validation_is_identifier_key(${1:column_or_variable})"],
+    "body": [
+      "ax_utils.validation_is_identifier_key(${1:column_or_variable})"
+    ],
     "description": [
       "Returns true if the value only contains letters, numbers, underscores, and dashes.",
       "Returns false otherwise."
@@ -710,7 +762,9 @@
   },
   "Validation Is Url (Ax Utils)": {
     "prefix": "ax-validation-is-url",
-    "body": ["ax_utils.validation_is_url(${1:column_or_variable})"],
+    "body": [
+      "ax_utils.validation_is_url(${1:column_or_variable})"
+    ],
     "description": [
       "Returns true if the value is a valid URL. Returns false otherwise, including in cases when value is an empty string."
     ],
@@ -718,7 +772,9 @@
   },
   "Validation Is Optional Url (Ax Utils)": {
     "prefix": "ax-validation-is-optional-url",
-    "body": ["ax_utils.validation_is_optional_url(${1:column_or_variable})"],
+    "body": [
+      "ax_utils.validation_is_optional_url(${1:column_or_variable})"
+    ],
     "description": [
       "Returns true if the value is a valid URL or an empty string. Returns false otherwise."
     ],
@@ -736,7 +792,9 @@
   },
   "Validation Not Empty Array (Ax Utils)": {
     "prefix": "ax-validation-not-empty-array",
-    "body": ["ax_utils.validation_not_empty_array(${1:column_or_variable})"],
+    "body": [
+      "ax_utils.validation_not_empty_array(${1:column_or_variable})"
+    ],
     "description": [
       "Returns false if the value is an empty array or an array containing empty elements. Returns true otherwise."
     ],
@@ -744,7 +802,9 @@
   },
   "Validation Valid Url Array (Ax Utils)": {
     "prefix": "ax-validation-valid-url-array",
-    "body": ["ax_utils.validation_valid_url_array(${1:column_or_variable})"],
+    "body": [
+      "ax_utils.validation_valid_url_array(${1:column_or_variable})"
+    ],
     "description": [
       "Returns false if at least one element of an array is not a valid URL or an empty string. Returns true otherwise."
     ],
@@ -776,7 +836,9 @@
   },
   "User Has Tag (Ax Utils)": {
     "prefix": "ax-user-has-tag",
-    "body": ["SELECT ax_utils.user_has_tag(${1:'tag1,tag2'});"],
+    "body": [
+      "SELECT ax_utils.user_has_tag(${1:'tag1,tag2'});"
+    ],
     "description": [
       "Checks if a user has one of the specified tags.\n",
       "Returns true if the user has at least one of the tags from provided comma-separated string. Returns false otherwise."
@@ -798,7 +860,9 @@
   },
   "Current Tenant Id (Ax Utils)": {
     "prefix": "ax-current-tenant-id",
-    "body": ["SELECT ax_utils.current_tenant_id();"],
+    "body": [
+      "SELECT ax_utils.current_tenant_id();"
+    ],
     "description": [
       "Gets the tenant ID from the context of the current user.",
       "This is needed for multitenancy systems."
@@ -807,7 +871,9 @@
   },
   "Current Environment Id (Ax Utils)": {
     "prefix": "ax-current-environment-id",
-    "body": ["SELECT ax_utils.current_environment_id();"],
+    "body": [
+      "SELECT ax_utils.current_environment_id();"
+    ],
     "description": [
       "Gets the environment ID from the context of the current user.",
       "This is needed for multitenancy systems."
@@ -816,7 +882,9 @@
   },
   "Current User Id (Ax Utils)": {
     "prefix": "ax-current-user-id",
-    "body": ["SELECT ax_utils.current_user_id();"],
+    "body": [
+      "SELECT ax_utils.current_user_id();"
+    ],
     "description": [
       "Gets the User ID from the context of the current user.",
       "This is needed when end-user RLS is needed."
@@ -1030,7 +1098,9 @@
   "Drop Table (Ax Custom)": {
     "scope": "sql",
     "prefix": "ax-drop-table",
-    "body": ["DROP TABLE IF EXISTS ${8:app_public}.${1:table_name} CASCADE;"],
+    "body": [
+      "DROP TABLE IF EXISTS ${8:app_public}.${1:table_name} CASCADE;"
+    ],
     "description": "Drops a table."
   },
   "Add Enum and Column (Ax Custom)": {
@@ -1069,6 +1139,42 @@
     "body": [
       "UPDATE ${5:app_public}.${4:entity_table_name} SET ${6:colum_name} = '${7:DEFAULT_VALUE}' WHERE ${6:colum_name} = '${3:ENUM_VALUE_TO_DROP}';",
       "DELETE FROM ${2:app_public}.${1:enum_table_name} WHERE value = '${3:ENUM_VALUE_TO_DROP}';"
+    ],
+    "description": [
+      "Drops a value from the enum table.\n",
+      "Make sure the dropped value is not used in other tables.\n",
+      "This snippet has a simplified migration sample that might require adjustments."
+    ]
+  },
+  "Create Transaction Inbox Outbox Tables and Functions (Ax Custom)": {
+    "scope": "sql",
+    "prefix": "ax-add-trx-inbox-outbox-tables-and-functions",
+    "body": [
+      "-- Create Transaction Inbox Table",
+      "SELECT ax_define.create_trx_table(",
+      "'${1:app_hidden}',",
+      "'${2:inbox}',",
+      "'{${3::DATABASE_ENV_OWNER},${4::DATABASE_GQL_ROLE}}',",
+      "'${5|sequential,parallel|}');",
+      "",
+      "-- Create Transaction Outbox Table",
+      "SELECT ax_define.create_trx_table(",
+      "'${1:app_hidden}',",
+      "'${6:outbox}',",
+      "'{${3::DATABASE_ENV_OWNER},${4::DATABASE_GQL_ROLE}}',",
+      "'${7|sequential,parallel|}');",
+      "",
+      "-- Create Transaction Inbox Next Message function",
+      "SELECT ax_define.create_trx_next_messages_function(",
+      "'${8:app_hidden}',",
+      "'${1:app_hidden}',",
+      "'${2:inbox}');",
+      "",
+      "-- Create Transaction Outbox Next Message function",
+      "SELECT ax_define.create_trx_next_messages_function(",
+      "'${8:app_hidden}',",
+      "'${1:app_hidden}',",
+      "'${6:outbox}');"
     ],
     "description": [
       "Drops a value from the enum table.\n",

--- a/services/catalog/service/migrations/committed/000015-upgrade-sql-define-functions.sql
+++ b/services/catalog/service/migrations/committed/000015-upgrade-sql-define-functions.sql
@@ -1,0 +1,1327 @@
+--! Previous: sha1:a6c702858a035cb36f13575f70a7bc19528e7500
+--! Hash: sha1:ed200bb5de90a7d4d7ab04cc493b5e8c3da35189
+--! Message: upgrade SQL define functions
+
+-- first, clean up and delete all now obsolete define functions
+DO $$
+DECLARE
+  func RECORD;
+BEGIN
+  FOR func IN (
+    SELECT ns.nspname as schema, p.proname as name, oidvectortypes(p.proargtypes) as parameters
+    FROM pg_proc p INNER JOIN pg_namespace ns ON (p.pronamespace = ns.oid)
+    WHERE ns.nspname = 'ax_define'  order by p.proname
+  )
+  LOOP
+    execute 'DROP FUNCTION ' || func.schema || '.' || func.name || '(' || func.parameters || ');';
+  END LOOP;
+END$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_subscription_triggers('id', '${1:table_name}', '${3:app_public}', '${1:table_name}', '${2:SINGULAR_TABLE_NAME_IN_SCREAMING_SNAKE_CASE}');",
+    "-- TODO: To enable subscriptions:",
+    "-- - Use `setupHttpServerWithWebsockets` with `setupManagementGQLSubscriptionAuthentication` as 3rd parameter to enable authentication.",
+    "-- - Create the plugin via SubscriptionsPluginFactory('${1:table_name}', '${5:SingularTableNameInPascalCase}', '${4|UUID,Int|}')",
+    "-- - Use `enableSubscriptions` on the `PostgraphileOptionsBuilder`.",
+    "-- - Enhance your HTTP server with websocket support with `enhanceHttpServerWithSubscriptions`."
+  ],
+  "description": [
+    "Defines PostgreSQL triggers for the specified table to enable GraphQL subscriptions functionality.\n",
+    "Adds a comment to the main or relation table with a comma-separated list of possible events that is used by SubscriptionsPluginFactory.\n",
+    "3rd parameter of SubscriptionsPluginFactory must be either 'Int' or `UUID' depending on the type of 'id' column."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_subscription_triggers(idColumn text, tableName text, schemaName text, mainTableName text, eventType text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  createEvent text = eventType || '_CREATED';
+  changeEvent text = eventType || '_CHANGED';
+  deleteEvent text = eventType || '_DELETED';
+BEGIN
+  EXECUTE 'COMMENT ON TABLE ' || schemaName || '.' || tableName || '  IS E''@subscription_events_' || mainTableName || ' ' || createEvent || ',' || changeEvent || ',' || deleteEvent || ''';';
+  
+  EXECUTE 'DROP TRIGGER IF EXISTS _500_gql_' || tableName || '_inserted ON ' || schemaName || '.' || tableName;
+  EXECUTE 'CREATE TRIGGER _500_gql_' || tableName || '_inserted after insert on ' || schemaName || '.' || tableName || ' ' ||
+          'for each row execute procedure ax_utils.tg__graphql_subscription(''' || createEvent || ''',''graphql:' || mainTableName || ''',''' || idColumn || ''');';
+
+  EXECUTE 'DROP TRIGGER IF EXISTS _500_gql_' || tableName || '_updated ON ' || schemaName || '.' || tableName;
+  EXECUTE 'CREATE TRIGGER _500_gql_' || tableName || '_updated after update on ' || schemaName || '.' || tableName || ' ' ||
+          'for each row execute procedure ax_utils.tg__graphql_subscription(''' || changeEvent || ''',''graphql:' || mainTableName || ''',''' || idColumn || ''');';
+
+  EXECUTE 'DROP TRIGGER IF EXISTS _500_gql_' || tableName || '_deleted ON ' || schemaName || '.' || tableName;
+  EXECUTE 'CREATE TRIGGER _500_gql_' || tableName || '_deleted before delete on ' || schemaName || '.' || tableName || ' ' ||
+          'for each row execute procedure ax_utils.tg__graphql_subscription(''' || deleteEvent || ''',''graphql:' || mainTableName || ''',''' || idColumn || ''');';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.drop_timestamps_trigger('${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Drops previously defined timestamp trigger which automatically populated 'created_date' and 'updated_date' columns."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.drop_timestamps_trigger(tableName text, schemaName text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  EXECUTE 'DROP trigger IF EXISTS _100_timestamps on ' || schemaName || '.' || tableName || ';';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_timestamps_trigger('${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Defines timestamp trigger which automatically populates 'created_date' and 'updated_date' columns.",
+    "It is recommended to use 'ax_define.define_audit_date_fields_on_table' to define both columns and triggers in one go.",
+    "Use this one if you really need to define triggers separately.\n",
+    "N.B! The trigger function is not compatible with JSON columns. Use JSONB instead."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_timestamps_trigger(tableName text, schemaName text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  PERFORM ax_define.drop_timestamps_trigger(tableName, schemaName);
+  -- Full row comparison is not compatible with column type JSON. Expect error: "could not identify an equality operator for type json"
+  EXECUTE 'CREATE trigger _100_timestamps BEFORE UPDATE ON ' || schemaName || '.' || tableName ||
+          ' for each ROW when (old.* is distinct from new.*) EXECUTE PROCEDURE ax_utils.tg__timestamps();';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.drop_users_trigger('${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Drops previously defined users trigger which automatically populated 'created_user' and 'updated_user' columns."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.drop_users_trigger(tableName text, schemaName text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  EXECUTE 'DROP trigger IF EXISTS _200_username on ' || schemaName || '.' || tableName || ';';
+  EXECUTE 'DROP trigger IF EXISTS _200_username_before_insert on ' || schemaName || '.' || tableName || ';';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_users_trigger('${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Defines users trigger which automatically populates 'created_user' and 'updated_user' columns.",
+    "It is recommended to use 'ax_define.define_audit_user_fields_on_table' to define both columns and triggers in one go.",
+    "Use this one if you really need to define triggers separately.\n",
+    "N.B! The trigger function is not compatible with JSON columns. Use JSONB instead."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_users_trigger(tableName text, schemaName text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  PERFORM ax_define.drop_users_trigger(tableName, schemaName);
+  -- Full row comparison is not compatible with column type JSON. Expect error: "could not identify an equality operator for type json"
+  EXECUTE 'CREATE trigger _200_username BEFORE UPDATE ON ' || schemaName || '.' || tableName ||
+          ' for each ROW when (old.* is distinct from new.*) EXECUTE PROCEDURE ax_utils.tg__username();';
+  -- INSERT trigger's WHEN condition cannot reference OLD values
+  EXECUTE 'CREATE trigger _200_username_before_insert BEFORE INSERT ON ' || schemaName || '.' || tableName ||
+          ' for each ROW EXECUTE PROCEDURE ax_utils.tg__username();';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.drop_tenant_environment_trigger('${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Drops previously defined tenant/environment trigger which automatically populated 'tenant_id' and 'environment_id' columns."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.drop_tenant_environment_trigger(tableName text, schemaName text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  EXECUTE 'DROP trigger IF EXISTS _200_tenant_environment on ' || schemaName || '.' || tableName || ';';
+  EXECUTE 'DROP trigger IF EXISTS _200_tenant_environment_on_delete on ' || schemaName || '.' || tableName || ';';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_tenant_environment_trigger('${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Defines tenant/environment trigger which automatically populates 'tenant_id' and 'environment_id' columns."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_tenant_environment_trigger(tableName text, schemaName text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  PERFORM ax_define.drop_tenant_environment_trigger(tableName, schemaName);
+  EXECUTE 'CREATE trigger _200_tenant_environment BEFORE INSERT OR UPDATE ON ' || schemaName || '.' || tableName ||
+          ' for each ROW EXECUTE PROCEDURE ax_utils.tg__tenant_environment();';
+  EXECUTE 'CREATE trigger _200_tenant_environment_on_delete BEFORE DELETE ON ' || schemaName || '.' || tableName ||
+          ' for each ROW EXECUTE PROCEDURE ax_utils.tg__tenant_environment_on_delete();';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.drop_user_id_trigger('${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Drops previously defined user id trigger which automatically populated 'user_id' column."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.drop_user_id_trigger(tablename text, schemaname text)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $$
+BEGIN
+  EXECUTE 'DROP trigger IF EXISTS _200_user_id on ' || schemaName || '.' || tableName || ';';
+END;
+$$
+;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_user_id_trigger('${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Defines user id trigger which automatically populates 'user_id' column."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_user_id_trigger(tablename text, schemaname text)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM ax_define.drop_user_id_trigger(tableName, schemaName);
+  EXECUTE 'CREATE trigger _200_user_id BEFORE INSERT OR UPDATE ON ' || schemaName || '.' || tableName ||
+          ' for each ROW EXECUTE PROCEDURE ax_utils.tg__user_id();';
+END;
+$$
+;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.drop_index('${1:column_name}', '${2:table_name}');"
+  ],
+  "description": [
+    "Drops previously defined index. Applies to both regular and unique indexes.\n",
+    "Third (optional) parameter: the unique name for this index. If the value is NULL then the name will be generated from the table & field name."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.drop_index(fieldName text, tableName text, indexName text default NULL) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  SELECT COALESCE(indexName, 'idx_' || tableName || '_' || fieldName) INTO indexName;
+  PERFORM ax_utils.validate_identifier_length(indexName, 'If the auto-generated name is too long then an "indexName" argument must be provided.');
+  EXECUTE 'DROP INDEX IF EXISTS ' || indexName || ' cascade;';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_index('${1:column_name}', '${2:table_name}', '${3:app_public}');"
+  ],
+  "description": [
+    "Defines a regular index on a column.\n",
+    "Fourth (optional) parameter: a unique name for this index. If the value is NULL then a name will be generated from the table & field name."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_index(fieldName text, tableName text, schemaName text, indexName text default NULL) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  SELECT COALESCE(indexName, 'idx_' || tableName || '_' || fieldName) INTO indexName;
+  PERFORM ax_utils.validate_identifier_length(indexName, 'If the auto-generated name is too long then an "indexName" argument must be provided.');
+  PERFORM ax_define.drop_index(fieldName, tableName, indexName);
+  EXECUTE 'CREATE INDEX ' || indexName || ' ON ' || schemaName || '.' || tableName || ' (' || fieldName || ');';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.drop_multiple_field_index('{\"${1:column_name_one}\", \"${2:column_name_two}\"}','${3:table_name}');"
+  ],
+  "description": [
+    "Drops previously defined multi-field index.\n",
+    "Third (optional) parameter: the unique name for this index. If the value is NULL then the name will be generated from the table & field names."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.drop_multiple_field_index(fieldNames text[], tableName text, indexName text default NULL) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  fieldNamesConcat text = array_to_string(array_agg(fieldNames), '_');
+BEGIN
+  SELECT COALESCE(indexName, 'idx_' || tableName || '_' || fieldNamesConcat) INTO indexName;
+  PERFORM ax_utils.validate_identifier_length(indexName, 'If the auto-generated name is too long then an "indexName" argument must be provided.');
+  EXECUTE 'DROP INDEX IF EXISTS ' || indexName || ' cascade;';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_multiple_field_index('{\"${1:column_name_one}\", \"${2:column_name_two}\"}', '${3:table_name}', '${4:app_public}');"
+  ],
+  "description": [
+    "Defines a regular index on multiple columns.\n",
+    "Fourth (optional) parameter: a unique name for this index. If the value is NULL then a name will be generated from the table & field names."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_multiple_field_index(fieldNames text[], tableName text, schemaName text, indexName text default NULL) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  fieldNamesConcat text = array_to_string(array_agg(fieldNames), '_');
+  fieldList text = array_to_string(array_agg(fieldNames), ', ');
+BEGIN
+  SELECT COALESCE(indexName, 'idx_' || tableName || '_' || fieldNamesConcat) INTO indexName;
+  PERFORM ax_utils.validate_identifier_length(indexName, 'If the auto-generated name is too long then an "indexName" argument must be provided.');
+  PERFORM ax_define.drop_multiple_field_index(fieldNames, tableName, indexName);
+  EXECUTE 'CREATE INDEX ' || indexName || ' ON ' || schemaName || '.' || tableName || ' (' || fieldList || ');';
+END;
+$$;
+
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.drop_indexes_with_id('${1:column_name}', '${2:table_name}');"
+  ],
+  "description": [
+    "Drops previously defined ASC/DESC indexes based on id and one other column.\n",
+    "Third & fourth (optional) parameters: unique names for the indexes. If either value is NULL then the name will be generated from the table & field name."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.drop_indexes_with_id(fieldName text, tableName text, indexNameAsc text default NULL, indexNameDesc text default NULL) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  SELECT COALESCE(indexNameAsc, 'idx_' || tableName || '_' || fieldName || '_asc_with_id') INTO indexNameAsc;
+  SELECT COALESCE(indexNameDesc, 'idx_' || tableName || '_' || fieldName || '_desc_with_id') INTO indexNameDesc;
+  PERFORM ax_utils.validate_identifier_length(indexNameAsc, 'If the auto-generated name is too long then an "indexNameAsc" argument must be provided.');
+  PERFORM ax_utils.validate_identifier_length(indexNameDesc, 'If the auto-generated name is too long then an "indexNameDesc" argument must be provided.');
+  EXECUTE 'DROP INDEX IF EXISTS ' || indexNameAsc || ' cascade;';
+  EXECUTE 'DROP INDEX IF EXISTS ' || indexNameDesc || ' cascade;';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_indexes_with_id('${1:column_name}', '${2:table_name}', '${3:app_public}');"
+  ],
+  "description": [
+    "Defines ASC/DESC indexes based on id and one other column.",
+    "Use these indexes if there is a plan to perform sorting by this column.\n",
+    "Fourth & fifth (optional) parameters: unique names for the indexes. If either value is NULL then a name will be generated from the table & field name.\n",
+    "Sixth (optional) parameter: name for the ID column to be used, default is 'id'"
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_indexes_with_id(fieldName text, tableName text, schemaName text, indexNameAsc text default NULL, indexNameDesc text default NULL, idFieldName text default 'id') RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  SELECT COALESCE(indexNameAsc, 'idx_' || tableName || '_' || fieldName || '_asc_with_id') INTO indexNameAsc;
+  SELECT COALESCE(indexNameDesc, 'idx_' || tableName || '_' || fieldName || '_desc_with_id') INTO indexNameDesc;
+  PERFORM ax_utils.validate_identifier_length(indexNameAsc, 'If the auto-generated name is too long then an "indexNameAsc" argument must be provided.');
+  PERFORM ax_utils.validate_identifier_length(indexNameDesc, 'If the auto-generated name is too long then an "indexNameDesc" argument must be provided.');
+  PERFORM ax_define.drop_indexes_with_id(fieldName, tableName, indexNameAsc, indexNameDesc);
+  EXECUTE 'CREATE INDEX idx_' || tableName || '_' || fieldName || '_asc_with_id ON ' || schemaName || '.' || tableName || ' (' || fieldName || ' ASC, ' || idFieldName || ' ASC);';
+  EXECUTE 'CREATE INDEX idx_' || tableName || '_' || fieldName || '_desc_with_id ON ' || schemaName || '.' || tableName || ' (' || fieldName || ' DESC, ' || idFieldName || ' ASC);';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_unique_index('${1:column_name}', '${2:table_name}', '${3:app_public}');"
+  ],
+  "description": [
+    "Defines a UNIQUE index on a column.",
+    "You can drop a unique index by using the normal 'ax_define.drop_index' function.\n",
+    "Fourth (optional) parameter: a unique name for the index. If the value is NULL then a name will be generated from the table & field name."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_unique_index(fieldName text, tableName text, schemaName text, indexName text default NULL) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  SELECT COALESCE(indexName, 'idx_' || tableName || '_' || fieldName) INTO indexName;
+  PERFORM ax_utils.validate_identifier_length(indexName, 'If the auto-generated name is too long then an "indexName" argument must be provided.');
+  PERFORM ax_define.drop_index(fieldName, tableName, indexName);
+  EXECUTE 'CREATE UNIQUE INDEX ' || indexName || ' ON ' || schemaName || '.' || tableName || ' (' || fieldName || ');';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.drop_unique_constraint('${1:column_name}', '${2:table_name}', '${3:app_public}');"
+  ],
+  "description": [
+    "Drops a UNIQUE constraint based on a column.\n",
+    "Fourth (optional) parameter: the unique name for the contraint. If the value is NULL then the name will be generated from the table & field name."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.drop_unique_constraint(fieldName text, tableName text, schemaName text, constraintName text default NULL) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  SELECT COALESCE(constraintName, tableName || '_' || fieldName || '_is_unique') INTO constraintName;
+  PERFORM ax_utils.validate_identifier_length(constraintName, 'If the auto-generated name is too long then a "constraintName" argument must be provided.');
+  EXECUTE 'ALTER TABLE ' || schemaName || '.' || tableName || ' DROP CONSTRAINT IF EXISTS ' || constraintName || ';';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_unique_constraint('${1:column_name}', '${2:table_name}', '${3:app_public}');"
+  ],
+  "description": [
+    "Defines a UNIQUE constraint on a column.\n",
+    "Fourth (optional) parameter: a unique name for the contraint. If the value is NULL then a name will be generated from the table & field name."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_unique_constraint(fieldName text, tableName text, schemaName text, constraintName text default NULL) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  SELECT COALESCE(constraintName, tableName || '_' || fieldName || '_is_unique') INTO constraintName;
+  PERFORM ax_utils.validate_identifier_length(constraintName, 'If the auto-generated name is too long then a "constraintName" argument must be provided.');
+  PERFORM ax_define.drop_unique_constraint(fieldName, tableName, schemaName, constraintName);
+  EXECUTE 'ALTER TABLE ' || schemaName || '.' || tableName || ' ADD CONSTRAINT ' ||constraintName || ' UNIQUE (' || fieldName || ');';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_deferred_unique_constraint('${1:column_name}', '${2:table_name}', '${3:app_public}');"
+  ],
+  "description": [
+    "Defines a deferred UNIQUE constraint on a column.\n",
+    "Uniqueness is only checked when the transaction is committed.",
+    "If you want to drop it - use 'ax_define.drop_unique_constraint'.\n",
+    "Fourth (optional) parameter: a unique name for the contraint. If the value is NULL then a name will be generated from the table & field name."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_deferred_unique_constraint(fieldName text, tableName text, schemaName text, constraintName text default NULL) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+SELECT COALESCE(constraintName, tableName || '_' || fieldName || '_is_unique') INTO constraintName;
+  PERFORM ax_utils.validate_identifier_length(constraintName, 'If the auto-generated name is too long then a "constraintName" argument must be provided.');
+  PERFORM ax_define.drop_unique_constraint(fieldName, tableName, schemaName, constraintName);
+  EXECUTE 'ALTER TABLE ' || schemaName || '.' || tableName || ' ADD CONSTRAINT ' || constraintName || ' UNIQUE (' || fieldName || ') DEFERRABLE INITIALLY DEFERRED;';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.drop_like_index('${1:column_name}', '${2:table_name}');"
+  ],
+  "description": [
+    "Drops a gin_trgm_ops index (for LIKE/ILIKE searches) based on a column.\n",
+    "Third (optional) parameter: the unique name for the index. If the value is NULL then the name will be generated from the table & field name."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.drop_like_index(fieldName text, tableName text, indexName text default NULL) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  SELECT COALESCE(indexName, 'idx_trgm_' || tableName || '_' || fieldName) INTO indexName;
+  PERFORM ax_utils.validate_identifier_length(indexName, 'If the auto-generated name is too long then an "indexName" argument must be provided.');
+  EXECUTE 'DROP INDEX IF EXISTS ' || indexName || ' cascade;';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_like_index('${1:column_name}', '${2:table_name}', '${3:app_public}');"
+  ],
+  "description": [
+    "Defines a gin_trgm_ops index (for LIKE/ILIKE searches) on a column.",
+    "Read more here: https://niallburkley.com/blog/index-columns-for-like-in-postgres/\n",
+    "Fourth (optional) parameter: a unique name for the index. If the value is NULL then a name will be generated from the table & field name."
+  ]
+}
+snippet-*/
+
+CREATE OR REPLACE FUNCTION ax_define.define_like_index(fieldName text, tableName text, schemaName text, indexName text default NULL) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  SELECT COALESCE(indexName, 'idx_trgm_' || tableName || '_' || fieldName) INTO indexName;
+  PERFORM ax_utils.validate_identifier_length(indexName, 'If the auto-generated name is too long then an "indexName" argument must be provided.');
+  PERFORM ax_define.drop_like_index(fieldName, tableName, indexName);
+  EXECUTE 'CREATE INDEX ' || indexName || ' ON ' || schemaName || '.' || tableName || ' USING gin (' || fieldName || ' gin_trgm_ops);';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_authentication('${1/(.*)/${1:/upcase}/}_VIEW,${1/(.*)/${1:/upcase}/}_EDIT,ADMIN', '${1/(.*)/${1:/upcase}/}_EDIT,ADMIN', '${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Defines authentication for a table via row level security based on permissions.\n",
+    "First parameter: comma-separated list of permission names to grant read permissions.",
+    "Second parameter: comma-separated list of permission names to grant write permissions.",
+    " - If the second parameter is an empty string, only read permissions are granted.",
+    "Third parameter: the name of the table to protect.",
+    "Fourth parameter: the database schema name of the table to protect.",
+    "Fifth (optional) parameter: an additional RLS check to add to the policies."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_authentication(readPermissions text, modifyPermissions text, tableName text, schemaName text, additionalRls text default '1=1') RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  EXECUTE 'ALTER TABLE ' || schemaName || '.' || tableName || ' ENABLE ROW LEVEL SECURITY;';
+  EXECUTE 'DROP POLICY IF EXISTS ' || tableName || '_authorization ON ' || schemaName || '.' || tableName || ';';
+
+  if (readPermissions <> '' and modifyPermissions <> '') then
+    EXECUTE 'CREATE POLICY ' || tableName || '_authorization ON ' || schemaName || '.' || tableName || ' FOR ALL
+      USING ((SELECT ax_utils.user_has_permission(''' || readPermissions || ''')) AND ' || additionalRls || ')
+      WITH CHECK ((SELECT ax_utils.user_has_permission(''' || modifyPermissions || ''')) AND ' || additionalRls || ');';
+    EXECUTE 'DROP POLICY IF EXISTS ' || tableName || '_authorization_delete ON ' || schemaName || '.' || tableName || ';';
+    EXECUTE 'CREATE POLICY ' || tableName || '_authorization_delete ON ' || schemaName || '.' || tableName || ' AS restrictive FOR DELETE
+    USING ((SELECT ax_utils.user_has_permission(''' || modifyPermissions || ''')));';
+  elsif (readPermissions <> '') then
+    EXECUTE 'CREATE POLICY ' || tableName || '_authorization ON ' || schemaName || '.' || tableName || ' FOR SELECT
+      USING ((SELECT ax_utils.user_has_permission(''' || readPermissions || ''')) AND ' || additionalRls || ');';
+  elsif (additionalRls <> '') then
+    EXECUTE 'CREATE POLICY ' || tableName || '_authorization ON ' || schemaName || '.' || tableName || ' FOR ALL
+      USING (' || additionalRls || ');';
+  else
+    perform ax_utils.raise_error('Invalid parameters provided to "define_authentication". At least the "readPermissions" or "additionalRls" must be provided.', 'SETUP');
+  end if;
+
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_readonly_authentication('${1/(.*)/${1:/upcase}/}_VIEW,${1/(.*)/${1:/upcase}/}_EDIT,ADMIN', '${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Defines read-only authentication for a table via row level security based on permissions.\n",
+    "First parameter: comma-separated list of permission names to grant read permissions.",
+    "Second parameter: the name of the table to protect.",
+    "Third parameter: the database schema name of the table to protect."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_readonly_authentication(readPermissions text, tableName text, schemaName text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  perform ax_define.define_authentication(readPermissions, '', tableName, schemaName);
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.live_suggestions_endpoint('${1:text_column_name}','${2:table_name}', '${3:app_public}');"
+  ],
+  "description": [
+    "Creates custom GraphQL query endpoint to request values of a single column from the table.\n",
+    "Endpoint selects a single text column, performs a DISTINCT, and orders by ASC."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.live_suggestions_endpoint(
+  propertyName text,
+  typeName text,
+  schemaName text
+  ) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  EXECUTE 'CREATE OR REPLACE FUNCTION ' || schemaName || '.get_' || typeName || '_values() ' ||
+    'RETURNS SETOF text AS $get$ ' ||
+      'SELECT DISTINCT ' || propertyName || ' FROM '|| schemaName || '.' || typeName || ' ' ||
+      'ORDER BY ' || propertyName || ' ASC' ||
+    '$get$ LANGUAGE SQL STABLE;';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_audit_user_fields_on_table('${1:table_name}', '${2:app_public}', ':DEFAULT_USERNAME');"
+  ],
+  "description": [
+    "Defines 'created_user' and 'updated_user' columns for specified table.",
+    "Also defines triggers that populate these columns on row create/update.\n",
+    "The third parameter is a placeholder for the default username value.",
+    "Please make sure that this placeholder is defined in the 'graphile-migrate' settings object,",
+    "in the placeholders property with the same name e.g. ':DEFAULT_USERNAME'.\n",
+    "N.B! The trigger functions are not compatible with JSON columns. Use JSONB instead."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_audit_user_fields_on_table(
+  tableName text,
+  schemaName text,
+  defaultUserName text
+  ) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  EXECUTE '
+    DO $do$ BEGIN
+      BEGIN
+          ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN created_user text NOT NULL DEFAULT ''' || defaultUserName || ''';
+          ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN updated_user text NOT NULL DEFAULT ''' || defaultUserName || ''';
+      EXCEPTION
+          WHEN duplicate_column THEN RAISE NOTICE ''The column created_user already exists in the ' || schemaName || '.' || tableName || ' table.'';
+      END;
+    END $do$;
+  ';
+  PERFORM ax_define.define_users_trigger(tableName, schemaName);
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_audit_date_fields_on_table('${1:table_name}', '${3:app_public}');"
+  ],
+  "description": [
+    "Defines 'created_date' and 'updated_date' columns for the specified table.",
+    "Also defines triggers that populate these columns on row create/update."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_audit_date_fields_on_table(
+  tableName text,
+  schemaName text
+  ) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  EXECUTE '
+    DO $do$ BEGIN
+      BEGIN
+          ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN created_date timestamptz NOT NULL DEFAULT (now() at time zone ''utc'');
+          ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN updated_date timestamptz NOT NULL DEFAULT (now() at time zone ''utc'');
+      EXCEPTION
+          WHEN duplicate_column THEN RAISE NOTICE ''The column created_date already exists in the ' || schemaName || '.' || tableName || ' table.'';
+      END;
+    END $do$;
+  ';
+  PERFORM ax_define.define_timestamps_trigger(tableName, schemaName);
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.column_exists('${1:column_name}', '${2:table_name}', '${3:app_public}');"
+  ],
+  "description": [
+    "Checks if the column exists in a specific table and schema."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.column_exists(
+  columnName text,
+  tableName text,
+  schemaName text
+) RETURNS boolean
+  LANGUAGE plpgsql
+  AS $$
+DECLARE
+  found_column text;
+begin
+  EXECUTE '
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema='''||schemaName||''' and table_name='''||tableName||''' and column_name='''||columnName||''';
+  ' INTO found_column;
+
+    IF found_column IS NULL THEN
+      RETURN false;
+    END IF;
+    RETURN true;
+end;
+$$;
+
+/*-snippet
+{
+  "body": [
+      "SELECT ax_define.create_enum_table(",
+      "  '${1:enum_table_name}',",
+      "  '${2:app_public}',",
+      "  ':${6:DATABASE_LOGIN}',",
+      "  '{\"${3:DEFAULT_VALUE}\",\"${4:OTHER_VALUE}\",\"${5:ANOTHER_VALUE}\"}',",
+      "  '{\"${3/(?:([A-Z])([A-Z]+))*(_)?([A-Z]+)/${1:/capitalize}${2:/downcase}${3:+ }${4:/downcase}/g}\",\"${4/(?:([A-Z])([A-Z]+))*(_)?([A-Z]+)/${1:/capitalize}${2:/downcase}${3:+ }${4:/downcase}/g}\",\"${5/(?:([A-Z])([A-Z]+))*(_)?([A-Z]+)/${1:/capitalize}${2:/downcase}${3:+ }${4:/downcase}/g}\"}');"
+  ],
+  "description": [
+    "Creates the enum table and initializes it with the possible enum values.\n",
+    "To support the enum table approach, Postgraphile requires the login role to have a SELECT grant on the enum table.\n",
+    "This is one of the functions that is needed to create an enum table and bind it to a column.",
+    "Use 'ax-add-enum-and-column' for a full code example."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.create_enum_table(
+  enumName text,
+  schemaName text,
+  loginRolePlaceholder text,
+  enumValues text,
+  enumDesriptions text default NULL
+  ) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+
+  EXECUTE 'DROP TABLE IF EXISTS ' || schemaName || '.' || enumName || ' CASCADE;';
+
+  -- Define an enum table. The value field is the enum key and the description will be used for GraphQL type annotations.
+  EXECUTE '
+  CREATE TABLE ' || schemaName || '.' || enumName || ' (
+    value text primary key,
+    description text
+  );
+  ';
+
+  -- Insert the enum values. This needs to be done here - otherwise migrating existing tables will throw FK errors.
+  IF enumDesriptions IS NULL THEN
+    EXECUTE '
+      INSERT INTO ' || schemaName || '.' || enumName || ' (value)
+      SELECT * FROM unnest(''' || enumValues || '''::text[]);
+    ';
+  ELSE
+    EXECUTE '
+      INSERT INTO ' || schemaName || '.' || enumName || ' (value, description)
+      SELECT * FROM unnest(''' || enumValues || '''::text[], ''' || enumDesriptions || '''::text[]);
+    ';
+  END IF;
+
+  -- This is needed for Postgraphile introspection to retrieve the values from enum table and use those values to construct a GraphQL enum type
+  EXECUTE 'GRANT SELECT ON ' || schemaName || '.' || enumName || ' TO ' || loginRolePlaceholder || ';';
+
+  -- Put a smart comment on an enum table so that Postgraphile introspection is able to find it
+  EXECUTE 'COMMENT ON TABLE ' || schemaName || '.' || enumName || '  IS E''@enum'';';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+      "SELECT ax_define.set_enum_as_column_type('${3:column_name}', '${4:entity_table_name}', '${5:app_public}', '${1:enum_table_name}', '${2:app_public}', '${6:DEFAULT_VALUE}');"
+  ],
+  "description": [
+    "Adds a foreign key to the enum table for a specific column that can reside in a different schema.",
+    "If the column does not exist - it is created with type text.\n",
+    "The sixth parameter is optional. Do not define if the column already exists or if the new column should not have a default value.",
+    "The seventh parameter is optional and decides if the column should be required or optional.",
+    "The default value is 'NOT NULL'. Use 'NULL' if the new column should be optional.",
+    "The eighth parameter is optional: a unique name for the generated constraint. If the value is NULL then a name will be generated from the table & column name."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.set_enum_as_column_type(
+  columnName text, -- 'status'
+  tableName text, -- 'example_table'
+  schemaName text, -- 'app_public'
+  enumName text, -- 'example_status'
+  enumSchemaName text, -- 'app_public'
+  defaultEnumValue text default '', -- 'Success'
+  notNullOptions text default 'NOT NULL', -- 'NOT NULL'
+  constraintName text default NULL
+  ) RETURNS void LANGUAGE plpgsql AS $$
+DECLARE
+  default_setting TEXT = '';
+BEGIN
+  SELECT COALESCE(constraintName, tableName || '_' || columnName || '_fkey') INTO constraintName;
+  PERFORM ax_utils.validate_identifier_length(constraintName, 'If the auto-generated name is too long then a "constraintName" argument must be provided.');
+  IF NOT coalesce(defaultEnumValue, '') = '' THEN
+    default_setting = 'DEFAULT ''' || defaultEnumValue || '''::text';
+  END IF;
+  IF NOT ax_define.column_exists(columnName, tableName, schemaName) THEN
+    EXECUTE 'ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN ' || columnName ||' text ' || default_setting || ' ' || notNullOptions || ';';
+  END IF;
+
+  -- Set the column that uses enum value as a foreign key
+  EXECUTE 'ALTER TABLE ' || schemaName || '.' || tableName || ' ADD CONSTRAINT ' || constraintName || ' FOREIGN KEY ('|| columnName ||') REFERENCES ' || enumSchemaName || '.' || enumName || '(value);';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.set_enum_domain('${3:column_name}', '${4:entity_table_name}', '${5:app_public}', '${1:enum_table_name}_enum', '${2:app_public}');"
+  ],
+  "description": [
+    "Create a domain for an enum table based property.",
+    "Enables strong typing when working with 'zapatos' npm package by defining custom types for enums.",
+    "Read more about custom types here: https://jawj.github.io/zapatos/#custom-types-and-domains"
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.set_enum_domain(
+  columnName text,
+  tableName text,
+  schemaName text,
+  enumName text,
+  enumSchemaName text
+  ) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  EXECUTE '
+    DO $do$ BEGIN
+      BEGIN
+        CREATE DOMAIN ' || enumSchemaName || '.' || enumName || ' AS text;
+      EXCEPTION
+        WHEN duplicate_object THEN RAISE NOTICE ''Domain already existed.'';
+      END;
+    END $do$;
+    ALTER TABLE ' || schemaName || '.' || tableName || ' ALTER COLUMN ' || columnName || ' TYPE ' || enumSchemaName || '.' || enumName || ';
+  ';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.create_messaging_counter_table();"
+  ],
+  "description": [
+    "Creates a table that will count how often a message was already processed via Mosaic-based messaging e.g. multiple retries due to server crashes."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.create_messaging_counter_table()
+  RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+
+  EXECUTE 'DROP TABLE IF EXISTS app_private.messaging_counter CASCADE;';
+  EXECUTE '
+  CREATE TABLE app_private.messaging_counter (
+    key text primary key,
+    counter INT DEFAULT 1,
+    expiration_date timestamptz NOT NULL DEFAULT ((now() + INTERVAL ''1 days'') at time zone ''utc'')
+  );
+  ';
+
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.create_messaging_health_monitorying();"
+  ],
+  "description": [
+    "Creates a table that will store a key when a health check is conducted and triggers to notify the application about updates in that table."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.create_messaging_health_monitoring()
+  RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+
+  EXECUTE 'DROP TABLE IF EXISTS app_private.messaging_health CASCADE;';
+  EXECUTE '
+  CREATE TABLE app_private.messaging_health (
+    key TEXT PRIMARY KEY,
+    success BOOLEAN
+  );';
+  
+  EXECUTE 'CREATE OR REPLACE FUNCTION app_private.messaging_health_notify()
+    RETURNS trigger
+    LANGUAGE plpgsql
+  AS $function$
+  BEGIN
+    PERFORM pg_notify(''messaging_health_handled'', row_to_json(NEW)::text);
+    RETURN NULL;
+  END;
+  $function$ ';
+
+  EXECUTE  'DROP TRIGGER IF EXISTS _500_messaging_health_trigger ON app_private.messaging_health;';
+  EXECUTE  'CREATE trigger _500_messaging_health_trigger
+              AFTER UPDATE ON app_private.messaging_health
+              FOR EACH ROW EXECUTE PROCEDURE app_private.messaging_health_notify();';
+
+END;
+$$;
+
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_user_id_on_table('${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Defines 'user_id' column for the specified table.",
+    "Also defines a trigger that populates this column on row create/update."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_user_id_on_table(tablename text, schemaname text)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $$
+BEGIN
+  EXECUTE '
+    DO $do$ BEGIN
+      BEGIN
+          ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN user_id UUID NOT NULL DEFAULT ''00000000-0000-0000-0000-000000000000'';
+      EXCEPTION
+          WHEN duplicate_column THEN RAISE NOTICE ''The column user_id already exists in the ' || schemaName || '.' || tableName || ' table.'';
+      END;
+    END $do$;
+
+    ALTER TABLE ' || schemaName || '.' || tableName || ' DROP CONSTRAINT IF EXISTS user_id_not_default;
+    ALTER TABLE ' || schemaName || '.' || tableName || ' ADD CONSTRAINT user_id_not_default CHECK (ax_utils.constraint_not_default_uuid(user_id, uuid_nil()));
+
+    SELECT ax_define.define_user_id_trigger(''' || tableName || ''', ''' || schemaName || ''');
+  ';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_end_user_authentication('${1:table_name}', '${2:app_public}');"
+  ],
+  "description": [
+    "Defines RLS policy for user_id column in a given table",
+    "This is a RESTRICTIVE policy."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_end_user_authentication(tablename text, schemaname text)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  end_user_rls_string TEXT := '((user_id = (SELECT ax_utils.current_user_id()) OR (SELECT ax_utils.current_user_id()) = uuid_nil()))';
+BEGIN
+  EXECUTE 'ALTER TABLE ' || schemaName || '.' || tableName || ' ENABLE ROW LEVEL SECURITY;';
+  EXECUTE 'DROP POLICY IF EXISTS ' || tableName || '_end_user_authorization ON ' || schemaName || '.' || tableName || ';';
+
+
+  EXECUTE 'CREATE POLICY ' || tableName || '_end_user_authorization ON ' || schemaName || '.' || tableName || ' AS RESTRICTIVE FOR ALL
+    USING (' || end_user_rls_string || ');';
+
+
+END;
+$function$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.drop_timestamp_propagation('${1:fk_column}', '${2:table_name}', '${3:app_public}', '${4:id}', '${5:parent_table}', '${6:app_public}');"
+  ],
+  "description": [
+    "Removes a function and trigger created by 'ax_define.define_timestamp_propagation' in an idempotent way.\n",
+    "The call signature mirrors 'ax_define.define_timestamp_propagation' and should be applied with the same arguments.\n",
+    "Seventh (optional) parameter: the unique name for the generated function. If the value is NULL then the name will be generated from the table names."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.drop_timestamp_propagation(
+  idColumnName text,
+  tableName text,
+  schemaName text,
+  foreignIdColumnName text,
+  foreignTableName text,
+  foreignSchemaName text,
+  functionName text default NULL
+  ) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  SELECT COALESCE(functionName, 'tg_' || tableName || '__' || foreignTableName || '_ts_propagation') INTO functionName;
+  PERFORM ax_utils.validate_identifier_length(functionName, 'If the auto-generated name is too long then a "functionName" argument must be provided.');
+  EXECUTE  'DROP TRIGGER IF EXISTS _200_propogate_timestamps on ' || schemaName || '.' || tableName;
+  EXECUTE  'DROP FUNCTION IF EXISTS ' || schemaName || '.' || functionName || '()';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.define_timestamp_propagation('${1:fk_column}', '${2:table_name}', '${3:app_public}', '${4:id}', '${5:parent_table}', '${6:app_public}');"
+  ],
+  "description": [
+    "Defines a function and trigger to propagate 'updated_date' changes to related entities.\n",
+    "Propagation can trigger 'UPDATED' triggers on the target entity including chained timestamp propagation.\n",
+    "First parameter: a column name from the \"table_name\" table that the trigger should be associated with.",
+    "Fourth parameter: a column name from the \"parent_table\" that 'updated_date' should be propagated to.",
+    "Seventh (optional) parameter: a unique name for the generated function. If the value is NULL then a name will be generated from the table names.\n",
+    "NB!. This function uses SECURITY DEFINER permission. It will always be executed as DB_OWNER."
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.define_timestamp_propagation(
+  idColumnName text,
+  tableName text,
+  schemaName text,
+  foreignIdColumnName text,
+  foreignTableName text,
+  foreignSchemaName text,
+  functionName text default NULL
+  ) RETURNS void
+    LANGUAGE plpgsql
+    AS $a$
+BEGIN
+  SELECT COALESCE(functionName, 'tg_' || tableName || '__' || foreignTableName || '_ts_propagation') INTO functionName;
+  PERFORM ax_utils.validate_identifier_length(functionName, 'If the auto-generated name is too long then a "functionName" argument must be provided.');
+  -- Set updated_date=now() on the foreign table. This will propogate UPDATE triggers.
+  --
+  -- A new function is created for each table to do this.
+  --     It *may* be possible to use a stock function with trigger arguments but its not easy as NEW and OLD cannot be accessed with dynamic column names. A possible
+  --     solution to that is described here: https://itectec.com/database/postgresql-assignment-of-a-column-with-dynamic-column-name/. But even there the advise is
+  --     to: "Just write a new trigger function for each table. Less hassle, better performance. Byte the bullet on code duplication:"
+  --
+  -- WARNING: This function uses "SECURITY DEFINER". This is required to ensure that update to the target table is allowed. This means that the function is
+  --          executed with role "DB_OWNER". Any propogated trigger functions will also execute with role "DB_OWNER".
+  EXECUTE  '
+            CREATE OR REPLACE FUNCTION ' || schemaName || '.' || functionName || '() RETURNS TRIGGER
+            LANGUAGE plpgsql
+            SECURITY DEFINER
+            SET search_path = pg_temp
+            AS $b$
+            BEGIN
+                -- if updated_date exists on source and its not changed, then exit here
+                -- this prevents multiple propogation from different children in one transaction
+                if (to_jsonb(NEW) ? ''updated_date'') THEN
+                    -- must be a seperate condition to prevent exception if column does not exist
+                    IF (OLD.updated_date = NEW.updated_date) THEN
+                        RETURN NULL;
+                    END IF;
+                END IF;
+
+                -- UPDATE (where relationship is unchanged, or changed to another entity in which case a change is triggered on both the old and new relation)
+                IF (OLD.' || idColumnName || ' IS NOT NULL AND NEW.' || idColumnName || ' IS NOT NULL) THEN
+                    UPDATE ' || foreignSchemaName || '.' || foreignTableName || ' SET updated_date=now()
+                    WHERE (' || foreignIdColumnName || ' = OLD.' || idColumnName || ') OR (' || foreignIdColumnName || ' = NEW.' || idColumnName || ');
+
+                -- INSERT (or UPDATE which sets nullable relationship)
+                ELSIF (NEW.' || idColumnName || ' IS NOT NULL) THEN
+                    UPDATE ' || foreignSchemaName || '.' || foreignTableName || ' SET updated_date=now()
+                    WHERE ' || foreignIdColumnName || ' = NEW.' || idColumnName || ';
+
+                -- DELETE (or UPDATE which removes nullable relationship)
+                ELSIF (OLD.' || idColumnName || ' IS NOT NULL) THEN
+                    UPDATE ' || foreignSchemaName || '.' || foreignTableName || ' SET updated_date=now()
+                    WHERE ' || foreignIdColumnName || ' = OLD.' || idColumnName || ';
+
+                END IF;
+                RETURN NULL;
+            END $b$;
+            REVOKE EXECUTE ON FUNCTION ' || schemaName || '.' || functionName || '() FROM public;
+            ';
+
+  -- Function runs *AFTER* INSERT, UPDATE, DELETE. Propogated queries can still raise an error and rollback the transaction
+  EXECUTE  'DROP TRIGGER IF EXISTS _200_propogate_timestamps on ' || schemaName || '.' || tableName;
+  EXECUTE  'CREATE trigger _200_propogate_timestamps
+            AFTER INSERT OR UPDATE OR DELETE ON ' || schemaName || '.' || tableName || '
+            FOR EACH ROW EXECUTE PROCEDURE ' || schemaName || '.' || functionName || '();';
+END;
+$a$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.pgmemento_create_table_audit(",
+    "  table_name:='${1:table_name}',",
+    "  schema_name:='${2:app_public}',",
+    "  log_old_data:='${3|TRUE,FALSE|}',",
+    "  log_new_data:='${4|TRUE,FALSE|}',",
+    "  log_state:='${5|TRUE,FALSE|}');"
+  ],
+  "description": [
+    "Activates audit logging for a table.\n",
+    "It's a simple wrapper around pgmemento.create_table_audit that wraps it with a try/catch to work with our idempotent migrations.\n",
+    "NOTE: This requires pgmemento extension to be installed in the database.\n",
+    "For additional info, see https://github.com/pgMemento/pgMemento/wiki/Initialize-auditing#start-auditing-for-single-tables .\n"
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.pgmemento_create_table_audit(
+  table_name TEXT,
+  schema_name TEXT DEFAULT 'app_public'::text,
+  audit_id_column_name TEXT DEFAULT 'pgmemento_audit_id'::text,
+  log_old_data BOOLEAN DEFAULT TRUE,
+  log_new_data BOOLEAN DEFAULT FALSE,
+  log_state BOOLEAN DEFAULT FALSE
+) RETURNS VOID
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+    PERFORM pgmemento.create_table_audit($1, $2, $3, $4, $5, $6, TRUE);
+EXCEPTION
+    -- If this has been run before the table will already have the pgmemento_audit_id column and an error will be thrown.
+    WHEN duplicate_column THEN
+        RAISE INFO 'Column % already exists on %.%', $3, $2, $1 ;
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.pgmemento_delete_old_logs(${age:'30 days'})"
+  ],
+  "description": [
+    "Deletes all audit logs (for all registered tables) older than specified age.\n",
+    "Returns number of table events deleted.\n",
+    "NOTE: This requires pgmemento extension to be installed in the database.\n",
+    "For additional info, see https://github.com/pgMemento/pgMemento/wiki/Delete-logs .\n"
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.pgmemento_delete_old_logs(age INTERVAL)
+  RETURNS INTEGER
+  LANGUAGE plpgsql
+  AS $$
+DECLARE
+    counter INTEGER;
+    transaction_id INTEGER;
+    tablename TEXT;
+    schemaname TEXT;
+BEGIN
+    counter := 0;
+    FOR transaction_id, tablename, schemaname IN (
+        -- 1. Get all transaction metadata and associated table event metadata older than specified age.
+        SELECT DISTINCT
+            tl.id, el.table_name, el.schema_name
+        FROM
+            pgmemento.transaction_log tl
+            JOIN pgmemento.table_event_log el ON tl.id = el.transaction_id
+        WHERE
+            tl.txid_time  < NOW() - age)
+    LOOP
+        -- 2. Delete all table event metadata and row log entries associated with the transaction.
+        PERFORM  pgmemento.delete_table_event_log(transaction_id, tablename, schemaname);
+        -- 3. Delete the transaction metadata itself.
+        PERFORM pgmemento.delete_txid_log(transaction_id);
+        counter := counter + 1;
+    END LOOP;
+
+    RETURN counter;
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.create_trx_table(",
+    "  '${1:app_hidden}',",
+    "  '${2|inbox,outbox|}',",
+    "  '{${3::DATABASE_ENV_OWNER},${4::DATABASE_GQL_ROLE}}',",
+    "  '${5|sequential,parallel|}');"
+  ],
+  "description": [
+   "Create a new table for transaction inbox/outbox handling. \n"
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.create_trx_table (
+  trx_schema TEXT,
+  trx_table_name TEXT,
+  additional_roles_to_grant TEXT[],
+  concurrency TEXT
+) RETURNS VOID
+  LANGUAGE plpgsql
+  AS $$
+DECLARE 
+  role_ TEXT;
+BEGIN
+  EXECUTE 'DROP TABLE IF EXISTS ' || trx_schema || '.'|| trx_table_name ||' CASCADE;';
+  EXECUTE 'CREATE TABLE ' || trx_schema || '.'|| trx_table_name ||' (
+            id uuid PRIMARY KEY,
+            aggregate_type TEXT NOT NULL,
+            aggregate_id TEXT NOT NULL, 
+            message_type TEXT NOT NULL,
+            payload JSONB NOT NULL,
+            metadata JSONB,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+            processed_at TIMESTAMPTZ,
+            started_attempts smallint NOT NULL DEFAULT 0,
+            finished_attempts smallint NOT NULL DEFAULT 0,
+            segment TEXT,
+            locked_until TIMESTAMPTZ NOT NULL DEFAULT to_timestamp(0),
+            concurrency TEXT NOT NULL DEFAULT ''' || concurrency || ''',
+            abandoned_at TIMESTAMPTZ
+          );';
+  EXECUTE 'ALTER TABLE ' || trx_schema || '.'|| trx_table_name ||' ADD CONSTRAINT '|| trx_table_name ||'_concurrency_check
+            CHECK (concurrency IN (''sequential'', ''parallel''));';
+  
+  -- The owner role has full access - no grants needed
+  -- Grants for additional roles are given here
+  FOREACH role_ IN ARRAY additional_roles_to_grant LOOP
+    EXECUTE 'GRANT SELECT, INSERT, DELETE ON ' || trx_schema || '.'|| trx_table_name ||' TO ' || role_ || ';';
+    EXECUTE 'GRANT UPDATE (locked_until, processed_at, abandoned_at, started_attempts, finished_attempts) ON ' || trx_schema || '.'|| trx_table_name ||' TO ' || role_ || ';';
+  END LOOP;  
+
+  EXECUTE 'SELECT ax_define.define_index(''segment'', '''|| trx_table_name ||''', '''||trx_schema||''');';
+  EXECUTE 'SELECT ax_define.define_index(''created_at'', '''|| trx_table_name ||''', ''' || trx_schema || ''');';
+  EXECUTE 'SELECT ax_define.define_index(''processed_at'', '''|| trx_table_name ||''', ''' || trx_schema || ''');';
+  EXECUTE 'SELECT ax_define.define_index(''abandoned_at'', '''|| trx_table_name ||''', ''' || trx_schema || ''');';
+  EXECUTE 'SELECT ax_define.define_index(''locked_until'', '''|| trx_table_name ||''', ''' || trx_schema || ''');';
+END;
+$$;
+
+/*-snippet
+{
+  "body": [
+    "SELECT ax_define.create_trx_next_messages_function(",
+    "  '${1:app_hidden}',",
+    "  '${2:app_hidden}',",
+    "  '${3|inbox,outbox|}');"
+  ],
+  "description": [
+   "Create next_messages function that is used to poll the inbox/outbox tables. \n"
+  ]
+}
+snippet-*/
+CREATE OR REPLACE FUNCTION ax_define.create_trx_next_messages_function(
+  trx_next_message_function_schema TEXT,
+  trx_table_schema TEXT,
+  trx_table_name TEXT
+) RETURNS VOID
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  EXECUTE 'DROP FUNCTION IF EXISTS ' || trx_next_message_function_schema || '.next_'|| trx_table_name ||'_messages(integer, integer);';
+  EXECUTE 'CREATE OR REPLACE FUNCTION ' || trx_next_message_function_schema || '.next_'|| trx_table_name ||'_messages(
+  max_size integer, lock_ms integer)
+    RETURNS SETOF ' || trx_table_schema || '.'|| trx_table_name ||' 
+    LANGUAGE ''plpgsql''
+
+AS $BODY$
+DECLARE 
+  loop_row ' || trx_table_schema || '.'|| trx_table_name ||'%ROWTYPE;
+  message_row ' || trx_table_schema || '.'|| trx_table_name ||'%ROWTYPE;
+  ids uuid[] := ''{}'';
+BEGIN
+
+  IF max_size < 1 THEN
+    RAISE EXCEPTION ''The max_size for the next messages batch must be at least one.'' using errcode = ''MAXNR'';
+  END IF;
+
+  -- get (only) the oldest message of every segment but only return it if it is not locked
+  FOR loop_row IN
+    SELECT * FROM ' || trx_table_schema || '.'|| trx_table_name ||' m WHERE m.id in (SELECT DISTINCT ON (segment) id
+      FROM ' || trx_table_schema || '.'|| trx_table_name ||'
+      WHERE processed_at IS NULL AND abandoned_at IS NULL
+      ORDER BY segment, created_at) order by created_at
+  LOOP
+    BEGIN
+      EXIT WHEN cardinality(ids) >= max_size;
+    
+      SELECT *
+        INTO message_row
+        FROM ' || trx_table_schema || '.'|| trx_table_name ||'
+        WHERE id = loop_row.id
+        FOR NO KEY UPDATE NOWAIT; -- throw/catch error when locked
+      
+      IF message_row.locked_until > NOW() THEN
+        CONTINUE;
+      END IF;
+      
+      ids := array_append(ids, message_row.id);
+    EXCEPTION 
+      WHEN lock_not_available THEN
+        CONTINUE;
+      WHEN serialization_failure THEN
+        CONTINUE;
+    END;
+  END LOOP;
+  
+  -- if max_size not reached: get the oldest parallelizable message independent of segment
+  IF cardinality(ids) < max_size THEN
+    FOR loop_row IN
+      SELECT * FROM ' || trx_table_schema || '.'|| trx_table_name ||'
+        WHERE concurrency = ''parallel'' AND processed_at IS NULL AND abandoned_at IS NULL AND locked_until < NOW() 
+          AND id NOT IN (SELECT UNNEST(ids))
+        order by created_at
+    LOOP
+      BEGIN
+        EXIT WHEN cardinality(ids) >= max_size;
+
+        SELECT *
+          INTO message_row
+          FROM ' || trx_table_schema || '.'|| trx_table_name ||'
+          WHERE id = loop_row.id
+          FOR NO KEY UPDATE NOWAIT; -- throw/catch error when locked
+
+        ids := array_append(ids, message_row.id);
+      EXCEPTION 
+        WHEN lock_not_available THEN
+          CONTINUE;
+        WHEN serialization_failure THEN
+          CONTINUE;
+      END;
+    END LOOP;
+  END IF;
+  
+  -- set a short lock value so the the workers can each process a message
+  IF cardinality(ids) > 0 THEN
+
+    RETURN QUERY 
+      UPDATE ' || trx_table_schema || '.'|| trx_table_name ||'
+        SET locked_until = clock_timestamp() + (lock_ms || '' milliseconds'')::INTERVAL, started_attempts = started_attempts + 1
+        WHERE ID = ANY(ids)
+        RETURNING *;
+
+  END IF;
+END;
+$BODY$;';
+END;
+$$;

--- a/services/catalog/service/migrations/committed/000016-localizations-view-approach-adjusted.sql
+++ b/services/catalog/service/migrations/committed/000016-localizations-view-approach-adjusted.sql
@@ -1,0 +1,237 @@
+--! Previous: sha1:ed200bb5de90a7d4d7ab04cc493b5e8c3da35189
+--! Hash: sha1:2bf6facfe4d784a9d5e284749eb7987fe27c9cf2
+--! Message: localizations-view-approach-adjusted
+
+-- Update the localization views
+
+/*
+  Defines a view that joins the parent table and localization table, returning a
+  combined set of properties. The view is exposed to the GraphQL API, replacing
+  the underlying table. Naming conflicts are avoided using Postgraphile smart
+  comments.
+  It is recommended to use smart tags to fine-tune the resulting GraphQL schema,
+  such as adding virtual constraints, adding comments, and marking fields as not-null.
+*/
+CREATE OR REPLACE FUNCTION app_private.define_localization_view(localizableFields text[], tableName text, localizationsTableName text, fkColumn text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  localizableFieldsSelect text = 'l.' || array_to_string(localizableFields, ', l.');
+BEGIN
+  EXECUTE 'DROP VIEW IF EXISTS app_public.' || tableName || '_view CASCADE;';
+  EXECUTE 'CREATE VIEW app_public.' || tableName || '_view AS ' ||
+          'SELECT p.*, ' || localizableFieldsSelect || ' FROM app_public.' || localizationsTableName || ' as l ' ||
+          'JOIN app_public.' || tableName || ' AS p ON l.' || fkColumn || ' = p.id ' ||
+          'WHERE l.locale = (SELECT pg_catalog.current_setting('':MOSAIC_LOCALE'', true));';
+
+  EXECUTE 'GRANT SELECT ON app_public.' || tableName || '_view TO ":DATABASE_GQL_ROLE";';
+
+  EXECUTE 'COMMENT ON TABLE app_public.' || tableName || ' IS E''@omit\n@name ' || tableName || '_data'';';
+  EXECUTE 'COMMENT ON TABLE app_public.' || localizationsTableName || ' IS E''@omit'';';
+  EXECUTE 'COMMENT ON VIEW app_public.' || tableName || '_view IS E''@name ' || tableName || '\n@primaryKey id'';';
+END;
+$$;
+
+SELECT app_private.define_localization_view(
+  ARRAY['title', 'description', 'synopsis'],
+  'movie',
+  'movie_localizations',
+  'movie_id');
+
+SELECT app_private.define_localization_view(
+  ARRAY['title'],
+  'movie_genre',
+  'movie_genre_localizations',
+  'movie_genre_id');
+
+SELECT app_private.define_localization_view(
+  ARRAY['title', 'description', 'synopsis'],
+  'tvshow',
+  'tvshow_localizations',
+  'tvshow_id');
+
+SELECT app_private.define_localization_view(
+  ARRAY['title'],
+  'tvshow_genre',
+  'tvshow_genre_localizations',
+  'tvshow_genre_id');
+
+SELECT app_private.define_localization_view(
+  ARRAY['description', 'synopsis'],
+  'season',
+  'season_localizations',
+  'season_id');
+
+SELECT app_private.define_localization_view(
+  ARRAY['title', 'description', 'synopsis'],
+  'episode',
+  'episode_localizations',
+  'episode_id');
+
+SELECT app_private.define_localization_view(
+  ARRAY['title', 'description', 'synopsis'],
+  'collection',
+  'collection_localizations',
+  'collection_id');
+
+-- Add a table to store a list of available locales
+DROP TABLE IF EXISTS app_public.locales CASCADE;
+CREATE TABLE app_public.locales (
+  locale TEXT NOT NULL PRIMARY KEY,
+  is_default BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+GRANT SELECT ON app_public.locales TO ":DATABASE_GQL_ROLE";
+
+/*
+* A function to be called only when `app_public.locales` table has no entries to 
+* populate it using the contents of *_localizations tables. Expectation for each
+* table to have the same locales, so only the first non-empty table would be
+* used to populate the locales.
+*/
+CREATE OR REPLACE FUNCTION app_private.set_initial_locales()
+RETURNS text[] AS $$
+DECLARE
+    tableName text;
+    localeRecord RECORD;
+    localesFound text[] := '{}';
+    query text;
+BEGIN
+    FOR tableName IN
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'app_public' AND table_name LIKE '%_localizations'
+    LOOP
+        IF localesFound != '{}' THEN
+            -- If locales have been found in a previous iteration, exit the loop
+            EXIT;
+        END IF;
+
+        query := 'SELECT DISTINCT locale, is_default_locale FROM app_public.' || tableName || ';';
+        FOR localeRecord IN EXECUTE query
+        LOOP
+          IF localesFound = '{}' THEN
+            -- If something is found and this is the first locale to be
+            -- processed - drop existing locales
+            DELETE FROM app_public.locales;
+          END IF;
+
+          INSERT INTO app_public.locales (locale, is_default)
+          VALUES (localeRecord.locale, localeRecord.is_default_locale)
+          ON CONFLICT (locale) DO NOTHING;
+
+          localesFound := array_append(localesFound, localeRecord.locale);
+        END LOOP;
+    END LOOP;
+
+    RETURN localesFound;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Add indexes for localizable titles
+SELECT ax_define.define_like_index('title', 'movie_localizations', 'app_public');
+SELECT ax_define.define_indexes_with_id(
+  fieldName => 'title', 
+  tableName => 'movie_localizations', 
+  schemaName => 'app_public', 
+  idFieldName => 'movie_id');
+
+SELECT ax_define.define_like_index('title', 'movie_genre_localizations', 'app_public');
+SELECT ax_define.define_indexes_with_id(
+  fieldName => 'title', 
+  tableName => 'movie_genre_localizations', 
+  schemaName => 'app_public', 
+  idFieldName => 'movie_genre_id');
+
+SELECT ax_define.define_like_index('title', 'tvshow_localizations', 'app_public');
+SELECT ax_define.define_indexes_with_id(
+  fieldName => 'title', 
+  tableName => 'tvshow_localizations', 
+  schemaName => 'app_public', 
+  idFieldName => 'tvshow_id');
+
+SELECT ax_define.define_like_index('title', 'tvshow_genre_localizations', 'app_public');
+SELECT ax_define.define_indexes_with_id(
+  fieldName => 'title', 
+  tableName => 'tvshow_genre_localizations', 
+  schemaName => 'app_public', 
+  idFieldName => 'tvshow_genre_id');
+
+SELECT ax_define.define_like_index('title', 'episode_localizations', 'app_public');
+SELECT ax_define.define_indexes_with_id(
+  fieldName => 'title', 
+  tableName => 'episode_localizations', 
+  schemaName => 'app_public', 
+  idFieldName => 'episode_id');
+
+SELECT ax_define.define_like_index('title', 'collection_localizations', 'app_public');
+SELECT ax_define.define_indexes_with_id(
+  fieldName => 'title', 
+  tableName => 'collection_localizations', 
+  schemaName => 'app_public', 
+  idFieldName => 'collection_id');
+
+-- Make sure only one row can be added for each combination of locale and FK
+ALTER TABLE app_public.movie_localizations DROP CONSTRAINT IF EXISTS unique_by_movie_id_and_locale;
+ALTER TABLE app_public.movie_localizations ADD CONSTRAINT unique_by_movie_id_and_locale UNIQUE(movie_id, locale);
+
+ALTER TABLE app_public.movie_genre_localizations DROP CONSTRAINT IF EXISTS unique_by_movie_genre_id_and_locale;
+ALTER TABLE app_public.movie_genre_localizations ADD CONSTRAINT unique_by_movie_genre_id_and_locale UNIQUE(movie_genre_id, locale);
+
+ALTER TABLE app_public.tvshow_localizations DROP CONSTRAINT IF EXISTS unique_by_tvshow_id_and_locale;
+ALTER TABLE app_public.tvshow_localizations ADD CONSTRAINT unique_by_tvshow_id_and_locale UNIQUE(tvshow_id, locale);
+
+ALTER TABLE app_public.tvshow_genre_localizations DROP CONSTRAINT IF EXISTS unique_by_tvshow_genre_id_and_locale;
+ALTER TABLE app_public.tvshow_genre_localizations ADD CONSTRAINT unique_by_tvshow_genre_id_and_locale UNIQUE(tvshow_genre_id, locale);
+
+ALTER TABLE app_public.season_localizations DROP CONSTRAINT IF EXISTS unique_by_season_id_and_locale;
+ALTER TABLE app_public.season_localizations ADD CONSTRAINT unique_by_season_id_and_locale UNIQUE(season_id, locale);
+
+ALTER TABLE app_public.episode_localizations DROP CONSTRAINT IF EXISTS unique_by_episode_id_and_locale;
+ALTER TABLE app_public.episode_localizations ADD CONSTRAINT unique_by_episode_id_and_locale UNIQUE(episode_id, locale);
+
+ALTER TABLE app_public.collection_localizations DROP CONSTRAINT IF EXISTS unique_by_collection_id_and_locale;
+ALTER TABLE app_public.collection_localizations ADD CONSTRAINT unique_by_collection_id_and_locale UNIQUE(collection_id, locale);
+
+-- Add migration function to call whenever a new locale is added.
+
+/*
+* Migration function to add default fallback entries for new locales, in case
+* not all entities are published while including the new locale values.
+* Finds names of all existing tables in `app_public` schema that end with
+* `_localizations`, iterates through each name. For each found table, gets all
+* rows where is_default_locale is true, and re-inserts them with new UUID and
+* new locale. Skips already existing rows.
+*/
+CREATE OR REPLACE FUNCTION app_private.add_default_placeholder_localizations(newLocale text)
+RETURNS void AS $$
+DECLARE
+    tableName text;
+    columnNames text[];
+    columnNamesStr text;
+    foreignKey text;
+BEGIN
+    FOR tableName IN
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'app_public' AND table_name LIKE '%_localizations'
+    LOOP
+        SELECT array_agg(column_name)
+        INTO columnNames
+        FROM information_schema.columns
+        WHERE table_schema = 'app_public' AND table_name = tableName AND column_name != 'locale' AND column_name != 'id' AND column_name != 'is_default_locale';
+        
+        SELECT columnName
+        INTO foreignKey
+        FROM UNNEST(columnNames) AS columnName
+        WHERE columnName ILIKE '%_id';
+
+        columnNamesStr := array_to_string(columnNames, ', ');
+        EXECUTE 'INSERT INTO app_public.' || tableName || ' (' || columnNamesStr || ', locale, is_default_locale) ' ||
+            'SELECT ' || columnNamesStr || ', ''' || newLocale || ''', FALSE ' ||
+            'FROM app_public.' || tableName || ' ' ||
+            'WHERE is_default_locale = TRUE ' ||
+            'ON CONFLICT (' || foreignKey || ', locale) DO NOTHING;';
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;

--- a/services/catalog/service/src/common/constants.ts
+++ b/services/catalog/service/src/common/constants.ts
@@ -8,3 +8,7 @@ export const MOSAIC_LOCALE_HEADER_KEY = 'mosaic-locale';
  * database migrations that are using this key must be re-applied.
  */
 export const MOSAIC_LOCALE_PG_KEY = 'mosaic.locale';
+/**
+ * A PG notification to keep in-memory array up-to-date in multi-instance scenarios.
+ */
+export const MOSAIC_LOCALE_NOTIFY = 'notify_locale_inserted';

--- a/services/catalog/service/src/common/db/get-mosaic-locale-setting.spec.ts
+++ b/services/catalog/service/src/common/db/get-mosaic-locale-setting.spec.ts
@@ -26,11 +26,11 @@ describe('getMosaicLocaleSetting', () => {
 
   it.each([null, undefined, '', ' ', 'my-locale', 'de-DE', ['asd']])(
     'No supported locales and any header %p specified --> setting with default locale returned',
-    async (emptyValue) => {
+    async (value) => {
       // Arrange
       const req = mockRequest({
         headers: {
-          [MOSAIC_LOCALE_HEADER_KEY]: emptyValue,
+          [MOSAIC_LOCALE_HEADER_KEY]: value,
         },
       });
 

--- a/services/catalog/service/src/common/db/get-mosaic-locale-setting.spec.ts
+++ b/services/catalog/service/src/common/db/get-mosaic-locale-setting.spec.ts
@@ -1,0 +1,109 @@
+import { mockRequest } from 'mock-req-res';
+import {
+  DEFAULT_LOCALE_TAG,
+  MOSAIC_LOCALE_HEADER_KEY,
+  MOSAIC_LOCALE_PG_KEY,
+} from '../constants';
+import { getMosaicLocaleSetting } from './get-mosaic-locale-setting';
+import * as m from './in-memory-locales';
+
+describe('getMosaicLocaleSetting', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it('No supported locales and no header specified -> setting with selected default returned', async () => {
+    // Arrange
+    const req = mockRequest({ headers: {} });
+
+    // Act
+    const setting = getMosaicLocaleSetting(req);
+
+    // Assert
+    expect(setting).toEqual({
+      [MOSAIC_LOCALE_PG_KEY]: DEFAULT_LOCALE_TAG,
+    });
+  });
+
+  it.each([null, undefined, '', ' ', 'my-locale', 'de-DE', ['asd']])(
+    'No supported locales and any header %p specified --> setting with default locale returned',
+    async (emptyValue) => {
+      // Arrange
+      const req = mockRequest({
+        headers: {
+          [MOSAIC_LOCALE_HEADER_KEY]: emptyValue,
+        },
+      });
+
+      // Act
+      const setting = getMosaicLocaleSetting(req);
+
+      // Assert
+      expect(setting).toEqual({
+        [MOSAIC_LOCALE_PG_KEY]: DEFAULT_LOCALE_TAG,
+      });
+    },
+  );
+
+  it.each(['de-DE', 'de-de', 'DE-DE', 'DE-de'])(
+    'Supported locale exists and matching header %p specified --> setting with selected locale returned',
+    async (header) => {
+      // Arrange
+      const locale = 'de-DE';
+      jest.spyOn(m, 'getInMemoryLocales').mockImplementation(() => [locale]);
+      const req = mockRequest({
+        headers: {
+          [MOSAIC_LOCALE_HEADER_KEY]: header,
+        },
+      });
+
+      // Act
+      const setting = getMosaicLocaleSetting(req);
+
+      // Assert
+      expect(setting).toEqual({
+        [MOSAIC_LOCALE_PG_KEY]: locale,
+      });
+    },
+  );
+
+  it('Multiple supported locales and matching header %p specified -> setting with selected locale returned', async () => {
+    // Arrange
+    const selectedLocale = 'zh-CN';
+    jest
+      .spyOn(m, 'getInMemoryLocales')
+      .mockImplementation(() => ['de-DE', 'bg-BG', selectedLocale]);
+    const req = mockRequest({
+      headers: {
+        [MOSAIC_LOCALE_HEADER_KEY]: selectedLocale,
+      },
+    });
+
+    // Act
+    const setting = getMosaicLocaleSetting(req);
+
+    // Assert
+    expect(setting).toEqual({
+      [MOSAIC_LOCALE_PG_KEY]: selectedLocale,
+    });
+  });
+
+  it('Multiple supported locales and non-matching header specified -> setting with default locale returned', async () => {
+    // Arrange
+    jest
+      .spyOn(m, 'getInMemoryLocales')
+      .mockImplementation(() => ['de-DE', 'bg-BG', 'zh-CN']);
+    const req = mockRequest({
+      headers: {
+        [MOSAIC_LOCALE_HEADER_KEY]: 'zh-TW',
+      },
+    });
+
+    // Act
+    const setting = getMosaicLocaleSetting(req);
+
+    // Assert
+    expect(setting).toEqual({
+      [MOSAIC_LOCALE_PG_KEY]: DEFAULT_LOCALE_TAG,
+    });
+  });
+});

--- a/services/catalog/service/src/common/db/get-mosaic-locale-setting.ts
+++ b/services/catalog/service/src/common/db/get-mosaic-locale-setting.ts
@@ -1,0 +1,18 @@
+import { Dict } from '@axinom/mosaic-db-common';
+import { Request } from 'express';
+import {
+  DEFAULT_LOCALE_TAG,
+  MOSAIC_LOCALE_HEADER_KEY,
+  MOSAIC_LOCALE_PG_KEY,
+} from '../constants';
+import { getInMemoryLocales } from './in-memory-locales';
+
+export const getMosaicLocaleSetting = (req: Request): Dict<string> => {
+  const header = String(req.headers[MOSAIC_LOCALE_HEADER_KEY]);
+  return {
+    [MOSAIC_LOCALE_PG_KEY]:
+      getInMemoryLocales().find(
+        (locale) => locale.toLowerCase() === header.toLowerCase(),
+      ) ?? DEFAULT_LOCALE_TAG,
+  };
+};

--- a/services/catalog/service/src/common/db/in-memory-locales.db.spec.ts
+++ b/services/catalog/service/src/common/db/in-memory-locales.db.spec.ts
@@ -1,0 +1,286 @@
+import 'jest-extended';
+import { all, insert, select } from 'zapatos/db';
+import { createTestContext, ITestContext } from '../../tests/test-utils';
+import { DEFAULT_LOCALE_TAG } from '../constants';
+import {
+  exportedForTesting,
+  getInMemoryLocales,
+  loadInMemoryLocales,
+  syncInMemoryLocales,
+} from './in-memory-locales';
+
+describe('inMemoryLocales', () => {
+  let ctx: ITestContext;
+  const movieId = 'movie-1';
+  const episodeId = 'episode-1';
+
+  const populateLocales = async () => {
+    return (
+      await insert('locales', [
+        { locale: DEFAULT_LOCALE_TAG, is_default: true },
+        { locale: 'de-DE', is_default: false },
+        { locale: 'et-EE', is_default: false },
+      ]).run(ctx.ownerPool)
+    ).map((l) => l.locale);
+  };
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    await insert('movie', { id: movieId }).run(ctx.ownerPool);
+    await insert('episode', { id: episodeId }).run(ctx.ownerPool);
+  });
+
+  afterEach(async () => {
+    await ctx?.truncate('locales');
+    await ctx?.truncate('movie_localizations');
+    await ctx?.truncate('episode_localizations');
+    exportedForTesting.clearInMemoryLocales();
+  });
+
+  afterAll(async () => {
+    await ctx?.truncate('movie');
+    await ctx?.truncate('episode');
+    await ctx?.dispose();
+  });
+
+  describe('loadInMemoryLocales', () => {
+    it('Load without any db entries -> empty in-memory locales array', async () => {
+      // Act
+      await loadInMemoryLocales(ctx.ownerPool);
+
+      // Assert
+      const locales = getInMemoryLocales();
+      expect(locales).toEqual([]);
+    });
+
+    it('Load with existing locales -> matching in-memory locales array', async () => {
+      // Arrange
+      await populateLocales();
+
+      // Act
+      await loadInMemoryLocales(ctx.ownerPool);
+
+      // Assert
+      const locales = getInMemoryLocales();
+      expect(locales).toIncludeSameMembers([
+        DEFAULT_LOCALE_TAG,
+        'de-DE',
+        'et-EE',
+      ]);
+    });
+
+    it('Load without existing locales, but with existing localizations -> matching in-memory locales array', async () => {
+      // Arrange
+      await insert('movie_localizations', [
+        {
+          locale: DEFAULT_LOCALE_TAG,
+          is_default_locale: true,
+          title: 'test',
+          movie_id: movieId,
+        },
+        {
+          locale: 'de-DE',
+          is_default_locale: false,
+          title: 'test',
+          movie_id: movieId,
+        },
+        {
+          locale: 'et-EE',
+          is_default_locale: false,
+          title: 'test',
+          movie_id: movieId,
+        },
+      ]).run(ctx.ownerPool);
+
+      // Act
+      await loadInMemoryLocales(ctx.ownerPool);
+
+      // Assert
+      const locales = getInMemoryLocales();
+      expect(locales).toIncludeSameMembers([
+        DEFAULT_LOCALE_TAG,
+        'de-DE',
+        'et-EE',
+      ]);
+
+      const dbEntries = await select('locales', all).run(ctx.ownerPool);
+      expect(dbEntries).toIncludeSameMembers([
+        { locale: DEFAULT_LOCALE_TAG, is_default: true },
+        { locale: 'de-DE', is_default: false },
+        { locale: 'et-EE', is_default: false },
+      ]);
+    });
+
+    it('Load without existing locales, but with multiple existing localizations -> matching in-memory locales array', async () => {
+      // Arrange
+      await insert('movie_localizations', [
+        {
+          locale: DEFAULT_LOCALE_TAG,
+          is_default_locale: true,
+          title: 'test',
+          movie_id: movieId,
+        },
+        {
+          locale: 'de-DE',
+          is_default_locale: false,
+          title: 'test',
+          movie_id: movieId,
+        },
+        {
+          locale: 'et-EE',
+          is_default_locale: false,
+          title: 'test',
+          movie_id: movieId,
+        },
+      ]).run(ctx.ownerPool);
+      await insert('episode_localizations', [
+        {
+          locale: DEFAULT_LOCALE_TAG,
+          is_default_locale: true,
+          title: 'test',
+          episode_id: episodeId,
+        },
+        {
+          locale: 'de-DE',
+          is_default_locale: false,
+          title: 'test',
+          episode_id: episodeId,
+        },
+        {
+          locale: 'et-EE',
+          is_default_locale: false,
+          title: 'test',
+          episode_id: episodeId,
+        },
+      ]).run(ctx.ownerPool);
+
+      // Act
+      await loadInMemoryLocales(ctx.ownerPool);
+
+      // Assert
+      const locales = getInMemoryLocales();
+      expect(locales).toIncludeSameMembers([
+        DEFAULT_LOCALE_TAG,
+        'de-DE',
+        'et-EE',
+      ]);
+
+      const dbEntries = await select('locales', all).run(ctx.ownerPool);
+      expect(dbEntries).toIncludeSameMembers([
+        { locale: DEFAULT_LOCALE_TAG, is_default: true },
+        { locale: 'de-DE', is_default: false },
+        { locale: 'et-EE', is_default: false },
+      ]);
+    });
+  });
+
+  describe('syncInMemoryLocales', () => {
+    it('Sync with empty array and empty in-memory locales array -> empty in-memory locales array', async () => {
+      // Act
+      const localesChanged = await syncInMemoryLocales([], ctx.ownerPool);
+
+      // Assert
+      const locales = getInMemoryLocales();
+      expect(locales).toEqual([]);
+      expect(localesChanged).toEqual(false);
+    });
+
+    it('Sync with empty array and filled in-memory locales array -> unchanged in-memory locales array', async () => {
+      // Array
+      const expectedLocales = await populateLocales();
+      await loadInMemoryLocales(ctx.ownerPool);
+
+      // Act
+      const localesChanged = await syncInMemoryLocales([], ctx.ownerPool);
+
+      // Assert
+      const locales = getInMemoryLocales();
+      expect(locales).toIncludeSameMembers(expectedLocales);
+      expect(localesChanged).toEqual(false);
+    });
+
+    it('Sync with single default element and filled in-memory locales array -> updated in-memory locales array and locales row', async () => {
+      // Array
+      await populateLocales();
+      await loadInMemoryLocales(ctx.ownerPool);
+
+      // Act
+      const localesChanged = await syncInMemoryLocales(
+        [{ language_tag: 'en-US', is_default_locale: true }],
+        ctx.ownerPool,
+      );
+
+      // Assert
+      const locales = getInMemoryLocales();
+      expect(locales).toEqual(['en-US']);
+      const dbEntries = await select('locales', all).run(ctx.ownerPool);
+      expect(dbEntries).toEqual([{ locale: 'en-US', is_default: true }]);
+      expect(localesChanged).toEqual(true);
+    });
+
+    it('Sync with two locales and filled in-memory locales array -> updated in-memory locales array and locales row', async () => {
+      // Array
+      await insert('locales', [
+        { locale: DEFAULT_LOCALE_TAG, is_default: true },
+      ]).run(ctx.ownerPool);
+      await loadInMemoryLocales(ctx.ownerPool);
+
+      // Act
+      const localesChanged = await syncInMemoryLocales(
+        [
+          { language_tag: DEFAULT_LOCALE_TAG, is_default_locale: true },
+          { language_tag: 'de-DE', is_default_locale: false },
+        ],
+        ctx.ownerPool,
+      );
+
+      // Assert
+      const locales = getInMemoryLocales();
+      expect(locales).toIncludeSameMembers([DEFAULT_LOCALE_TAG, 'de-DE']);
+      const dbEntries = await select('locales', all).run(ctx.ownerPool);
+      expect(dbEntries).toIncludeSameMembers([
+        { locale: DEFAULT_LOCALE_TAG, is_default: true },
+        { locale: 'de-DE', is_default: false },
+      ]);
+      expect(localesChanged).toEqual(true);
+    });
+
+    it('Sync multiple times in parallel -> update only single time', async () => {
+      // Array
+      await insert('locales', [
+        { locale: DEFAULT_LOCALE_TAG, is_default: true },
+      ]).run(ctx.ownerPool);
+      await loadInMemoryLocales(ctx.ownerPool);
+
+      // Act
+      const results = await Promise.all(
+        Array.from({ length: 10 }).map(() =>
+          syncInMemoryLocales(
+            [
+              { language_tag: DEFAULT_LOCALE_TAG, is_default_locale: true },
+              { language_tag: 'de-DE', is_default_locale: false },
+              { language_tag: 'et-EE', is_default_locale: false },
+            ],
+            ctx.ownerPool,
+          ),
+        ),
+      );
+
+      // Assert
+      const locales = getInMemoryLocales();
+      expect(locales).toIncludeSameMembers([
+        DEFAULT_LOCALE_TAG,
+        'de-DE',
+        'et-EE',
+      ]);
+      const dbEntries = await select('locales', all).run(ctx.ownerPool);
+      expect(dbEntries).toIncludeSameMembers([
+        { locale: DEFAULT_LOCALE_TAG, is_default: true },
+        { locale: 'de-DE', is_default: false },
+        { locale: 'et-EE', is_default: false },
+      ]);
+      expect(results.filter((x) => x)).toHaveLength(1);
+      expect(results.filter((x) => !x)).toHaveLength(9);
+    });
+  });
+});

--- a/services/catalog/service/src/common/db/in-memory-locales.ts
+++ b/services/catalog/service/src/common/db/in-memory-locales.ts
@@ -118,7 +118,6 @@ export const startLocalesInsertedListener = async (
 
   try {
     closeActiveClient();
-    // TODO: add testing notes for scaling + pgBouncer
     const client = new Client(config.dbOwnerConnectionString);
 
     client.on('error', async (e) => {

--- a/services/catalog/service/src/common/db/in-memory-locales.ts
+++ b/services/catalog/service/src/common/db/in-memory-locales.ts
@@ -1,0 +1,74 @@
+import { OwnerPgPool } from '@axinom/mosaic-db-common';
+import { difference } from '@axinom/mosaic-service-common';
+import { all, deletes, insert, Queryable, select, SQL, sql } from 'zapatos/db';
+
+let inMemoryLocales: string[] = [];
+
+/**
+ * Returns a list of locales that currently exist in the system.
+ * If an API request is made for a specific locale and it is not in this array -
+ * default locale would be used instead.
+ */
+export const getInMemoryLocales = (): string[] => inMemoryLocales;
+
+/**
+ * Expects a list of all available locales as a parameter. Updates the in-memory
+ * array if its contents are different from the passed array. If current array
+ * and passed array are different - update the `app_public.locales` as well.
+ *
+ * Returns false if no changes were made and true if local `app_public.locales`
+ * table was updated
+ */
+export const syncInMemoryLocales = async (
+  input: { language_tag: string; is_default_locale: boolean }[],
+  queryable: Queryable,
+): Promise<boolean> => {
+  const locales = input.map((l) => l.language_tag);
+  if (locales.length === 0) {
+    return false;
+  }
+
+  const localesToAdd = difference(locales, inMemoryLocales);
+  const localesToDrop = difference(inMemoryLocales, locales);
+  if (localesToDrop.length === 0 && localesToAdd.length === 0) {
+    return false;
+  }
+  inMemoryLocales = locales;
+
+  await deletes('locales', {}).run(queryable);
+  await insert(
+    'locales',
+    input.map((i) => ({
+      locale: i.language_tag,
+      is_default: i.is_default_locale,
+    })),
+  ).run(queryable);
+  return true;
+};
+
+/**
+ * Loads locales from `app_public.locales` table into the in-memory array to be
+ * used during service runtime. If no locales are found - attempt to populate
+ * the `app_public.locales` using contents of `*_localizations` tables.
+ */
+export const loadInMemoryLocales = async (
+  ownerPool: OwnerPgPool,
+): Promise<void> => {
+  inMemoryLocales = (await select('locales', all).run(ownerPool)).map(
+    (l) => l.locale,
+  );
+
+  if (inMemoryLocales.length === 0) {
+    const [result] = await sql<
+      SQL,
+      { set_initial_locales: string[] }[]
+    >`select app_private.set_initial_locales();`.run(ownerPool);
+    inMemoryLocales = result.set_initial_locales;
+  }
+};
+
+export const exportedForTesting = {
+  clearInMemoryLocales: (): void => {
+    inMemoryLocales = [];
+  },
+};

--- a/services/catalog/service/src/common/db/in-memory-locales.ts
+++ b/services/catalog/service/src/common/db/in-memory-locales.ts
@@ -1,6 +1,13 @@
-import { OwnerPgPool } from '@axinom/mosaic-db-common';
-import { difference } from '@axinom/mosaic-service-common';
-import { all, deletes, insert, Queryable, select, SQL, sql } from 'zapatos/db';
+import {
+  difference,
+  ensureError,
+  Logger,
+  sleep,
+} from '@axinom/mosaic-service-common';
+import { Client } from 'pg';
+import { all, deletes, insert, Queryable, select } from 'zapatos/db';
+import { Config } from '../config';
+import { MOSAIC_LOCALE_NOTIFY } from '../constants';
 
 let inMemoryLocales: string[] = [];
 
@@ -52,18 +59,87 @@ export const syncInMemoryLocales = async (
  * the `app_public.locales` using contents of `*_localizations` tables.
  */
 export const loadInMemoryLocales = async (
-  ownerPool: OwnerPgPool,
+  queryable: Queryable,
+  logger: Logger,
 ): Promise<void> => {
-  inMemoryLocales = (await select('locales', all).run(ownerPool)).map(
+  inMemoryLocales = (await select('locales', all).run(queryable)).map(
     (l) => l.locale,
   );
+  logger.log({
+    message: 'In-memory locales successfully (re)loaded.',
+    details: { locales: inMemoryLocales },
+  });
+};
 
-  if (inMemoryLocales.length === 0) {
-    const [result] = await sql<
-      SQL,
-      { set_initial_locales: string[] }[]
-    >`select app_private.set_initial_locales();`.run(ownerPool);
-    inMemoryLocales = result.set_initial_locales;
+const maxRetryCount = 50;
+let currentRetry = 0;
+let activeClient: Client | null = null;
+
+/**
+ * During cases when connection with database is interrupted - errors can occur
+ * from multiple places, which can result in multiple reconnection attempts and
+ * end up with more than one client listening to notifications for a single
+ * service instance. For this reason, each time a connection is established -
+ * attempt to close other possible open connection.
+ */
+const closeActiveClient = async (): Promise<void> => {
+  if (activeClient) {
+    await activeClient.end();
+    activeClient = null;
+  }
+};
+/**
+ * Every time a message is received for localizable entities - we try to keep
+ * the used locales up-to-date. This includes updating the `app_public.locales`
+ * by drop-recreating all locales. A dedicated trigger will then send a
+ * notification that locales were changed. This listener picks it up and updates
+ * the in-memory locales array. This is only relevant in scaled scenarios, where
+ * multiple instances of the Catalog services are running, e.g. one instance
+ * receives the message and updates the locales table. Notification is then sent
+ * and in-memory locales array is updated by all instances.
+ */
+export const startLocalesInsertedListener = async (
+  config: Config,
+  logger: Logger,
+): Promise<void> => {
+  const handleError = async (e: unknown): Promise<void> => {
+    currentRetry++;
+    const error = ensureError(e);
+    if (currentRetry > maxRetryCount) {
+      throw error;
+    }
+    logger.error(
+      error,
+      `Listener database connection error occurred. Attempting to reconnect. (${currentRetry}/${maxRetryCount})`,
+    );
+    await sleep(currentRetry * 1000);
+    await startLocalesInsertedListener(config, logger);
+  };
+
+  try {
+    closeActiveClient();
+    // TODO: add testing notes for scaling + pgBouncer
+    const client = new Client(config.dbOwnerConnectionString);
+
+    client.on('error', async (e) => {
+      await handleError(e);
+    });
+
+    client.on('notification', async (msg) => {
+      if (msg.channel === MOSAIC_LOCALE_NOTIFY) {
+        await loadInMemoryLocales(client, logger);
+      }
+    });
+
+    await client.connect();
+    activeClient = client;
+    currentRetry = 0;
+
+    // Intentionally not using await to keep the connection open.
+    // Must use explicit client without Pool to do this.
+    client.query(`LISTEN ${MOSAIC_LOCALE_NOTIFY};`);
+  } catch (e) {
+    await handleError(e);
   }
 };
 
@@ -71,4 +147,6 @@ export const exportedForTesting = {
   clearInMemoryLocales: (): void => {
     inMemoryLocales = [];
   },
+  getActiveClient: (): Client | null => activeClient,
+  closeActiveClient,
 };

--- a/services/catalog/service/src/common/db/index.ts
+++ b/services/catalog/service/src/common/db/index.ts
@@ -1,2 +1,4 @@
 export * from './apply-migrations';
+export * from './get-mosaic-locale-setting';
+export * from './in-memory-locales';
 export * from './migration-settings';

--- a/services/catalog/service/src/common/db/migration-settings.ts
+++ b/services/catalog/service/src/common/db/migration-settings.ts
@@ -5,7 +5,11 @@ import {
 } from '@axinom/mosaic-db-common';
 import { Logger as MigrateLogger, Settings } from 'graphile-migrate';
 import { DbConfig } from '../config';
-import { DEFAULT_LOCALE_TAG, MOSAIC_LOCALE_PG_KEY } from '../constants';
+import {
+  DEFAULT_LOCALE_TAG,
+  MOSAIC_LOCALE_NOTIFY,
+  MOSAIC_LOCALE_PG_KEY,
+} from '../constants';
 
 export const getMigrationSettings = async (
   config: DbConfig,
@@ -29,6 +33,7 @@ export const getMigrationSettings = async (
       ':DEFAULT_USERNAME': DEFAULT_DB_USERNAME,
       ':DEFAULT_LOCALE_TAG': DEFAULT_LOCALE_TAG,
       ':MOSAIC_LOCALE': MOSAIC_LOCALE_PG_KEY,
+      ':MOSAIC_LOCALE_NOTIFY': MOSAIC_LOCALE_NOTIFY,
     },
     afterReset: [
       {

--- a/services/catalog/service/src/domains/channels/handlers/channel-published-event-handler.ts
+++ b/services/catalog/service/src/domains/channels/handlers/channel-published-event-handler.ts
@@ -10,7 +10,7 @@ import {
 import { ClientBase } from 'pg';
 import { deletes, insert, upsert } from 'zapatos/db';
 import { channel_images, channel_localizations } from 'zapatos/schema';
-import { Config } from '../../../common';
+import { Config, syncInMemoryLocales } from '../../../common';
 
 export class ChannelPublishedEventHandler extends TransactionalInboxMessageHandler<
   ChannelPublishedEvent,
@@ -58,6 +58,7 @@ export class ChannelPublishedEventHandler extends TransactionalInboxMessageHandl
 
     await deletes('channel_localizations', { channel_id }).run(txnClient);
     if (payload.localizations) {
+      await syncInMemoryLocales(payload.localizations, txnClient);
       await insert(
         'channel_localizations',
         payload.localizations.map(

--- a/services/catalog/service/src/domains/channels/handlers/playlist-published-event-handler.ts
+++ b/services/catalog/service/src/domains/channels/handlers/playlist-published-event-handler.ts
@@ -10,7 +10,7 @@ import {
 import { ClientBase } from 'pg';
 import { deletes, insert, upsert } from 'zapatos/db';
 import { program, program_images, program_localizations } from 'zapatos/schema';
-import { Config } from '../../../common';
+import { Config, syncInMemoryLocales } from '../../../common';
 import { EPISODE_ID_PREFIX, MOVIE_ID_PREFIX } from '../common';
 
 export class PlaylistPublishedEventHandler extends TransactionalInboxMessageHandler<
@@ -102,6 +102,10 @@ export class PlaylistPublishedEventHandler extends TransactionalInboxMessageHand
       }, {});
 
       if (localizations) {
+        await syncInMemoryLocales(
+          payload.programs[0]?.localizations ?? [],
+          txnClient,
+        );
         await insert(
           'program_localizations',
           localizations.map((l): program_localizations.Insertable => {

--- a/services/catalog/service/src/domains/collections/handlers/collection-published-event-handler.ts
+++ b/services/catalog/service/src/domains/collections/handlers/collection-published-event-handler.ts
@@ -14,7 +14,7 @@ import {
   collection_items_relation,
   collection_localizations,
 } from 'zapatos/schema';
-import { Config } from '../../../common';
+import { Config, syncInMemoryLocales } from '../../../common';
 
 export class CollectionPublishedEventHandler extends TransactionalInboxMessageHandler<
   CollectionPublishedEvent,
@@ -67,6 +67,7 @@ export class CollectionPublishedEventHandler extends TransactionalInboxMessageHa
     }
 
     if (payload.localizations) {
+      await syncInMemoryLocales(payload.localizations, txnClient);
       await insert(
         'collection_localizations',
         payload.localizations.map(

--- a/services/catalog/service/src/domains/movies/handlers/movie-genres-published-event-handler.ts
+++ b/services/catalog/service/src/domains/movies/handlers/movie-genres-published-event-handler.ts
@@ -10,7 +10,7 @@ import {
 import { ClientBase } from 'pg';
 import { conditions as c, deletes, insert, upsert } from 'zapatos/db';
 import { movie_genre_localizations } from 'zapatos/schema';
-import { Config } from '../../../common';
+import { Config, syncInMemoryLocales } from '../../../common';
 
 export class MovieGenresPublishedEventHandler extends TransactionalInboxMessageHandler<
   MovieGenresPublishedEvent,
@@ -55,6 +55,7 @@ export class MovieGenresPublishedEventHandler extends TransactionalInboxMessageH
       );
     });
 
+    await syncInMemoryLocales(payload.genres[0].localizations, txnClient);
     await deletes('movie_genre_localizations', {}).run(txnClient);
     await insert('movie_genre_localizations', localizations).run(txnClient);
   }

--- a/services/catalog/service/src/domains/movies/handlers/movie-published-event-handler.ts
+++ b/services/catalog/service/src/domains/movies/handlers/movie-published-event-handler.ts
@@ -16,7 +16,7 @@ import {
   movie_video_cue_points,
   movie_video_streams,
 } from 'zapatos/schema';
-import { Config } from '../../../common';
+import { Config, syncInMemoryLocales } from '../../../common';
 
 export class MoviePublishedEventHandler extends TransactionalInboxMessageHandler<
   MoviePublishedEvent,
@@ -119,6 +119,7 @@ export class MoviePublishedEventHandler extends TransactionalInboxMessageHandler
     }
 
     if (payload.localizations) {
+      await syncInMemoryLocales(payload.localizations, txnClient);
       await insert(
         'movie_localizations',
         payload.localizations.map(

--- a/services/catalog/service/src/domains/movies/plugins/extend-movie-query-with-country-code-plugin.db.spec.ts
+++ b/services/catalog/service/src/domains/movies/plugins/extend-movie-query-with-country-code-plugin.db.spec.ts
@@ -5,7 +5,7 @@ import {
 import gql from 'graphql-tag';
 import 'jest-extended';
 import { insert } from 'zapatos/db';
-import { CommonErrors } from '../../../common';
+import { CommonErrors, DEFAULT_LOCALE_TAG } from '../../../common';
 import { createTestContext, ITestContext } from '../../../tests/test-utils';
 
 const MOVIE_REQUEST = gql`
@@ -25,6 +25,12 @@ describe('ExtendMovieQueryWithCountryCodePlugin', () => {
   beforeAll(async () => {
     ctx = await createTestContext();
     await insert('movie', { id: movieId }).run(ctx.ownerPool);
+    await insert('movie_localizations', {
+      movie_id: movieId,
+      locale: DEFAULT_LOCALE_TAG,
+      is_default_locale: true,
+      title: 'test',
+    }).run(ctx.ownerPool);
   });
 
   beforeEach(async () => {

--- a/services/catalog/service/src/domains/tvshows/handlers/episode-published-event-handler.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/episode-published-event-handler.ts
@@ -16,7 +16,7 @@ import {
   episode_video_cue_points,
   episode_video_streams,
 } from 'zapatos/schema';
-import { Config } from '../../../common';
+import { Config, syncInMemoryLocales } from '../../../common';
 
 export class EpisodePublishedEventHandler extends TransactionalInboxMessageHandler<
   EpisodePublishedEvent,
@@ -119,6 +119,7 @@ export class EpisodePublishedEventHandler extends TransactionalInboxMessageHandl
     }
 
     if (payload.localizations) {
+      await syncInMemoryLocales(payload.localizations, txnClient);
       await insert(
         'episode_localizations',
         payload.localizations.map(

--- a/services/catalog/service/src/domains/tvshows/handlers/season-published-event-handler.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/season-published-event-handler.ts
@@ -16,7 +16,7 @@ import {
   season_video_cue_points,
   season_video_streams,
 } from 'zapatos/schema';
-import { Config } from '../../../common';
+import { Config, syncInMemoryLocales } from '../../../common';
 
 export class SeasonPublishedEventHandler extends TransactionalInboxMessageHandler<
   SeasonPublishedEvent,
@@ -118,6 +118,7 @@ export class SeasonPublishedEventHandler extends TransactionalInboxMessageHandle
     }
 
     if (payload.localizations) {
+      await syncInMemoryLocales(payload.localizations, txnClient);
       await insert(
         'season_localizations',
         payload.localizations.map(

--- a/services/catalog/service/src/domains/tvshows/handlers/tvshow-genres-published-event-handler.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/tvshow-genres-published-event-handler.ts
@@ -10,7 +10,7 @@ import {
 import { ClientBase } from 'pg';
 import { conditions as c, deletes, insert, upsert } from 'zapatos/db';
 import { tvshow_genre_localizations } from 'zapatos/schema';
-import { Config } from '../../../common';
+import { Config, syncInMemoryLocales } from '../../../common';
 
 export class TvshowGenresPublishedEventHandler extends TransactionalInboxMessageHandler<
   TvshowGenresPublishedEvent,
@@ -55,6 +55,7 @@ export class TvshowGenresPublishedEventHandler extends TransactionalInboxMessage
       );
     });
 
+    await syncInMemoryLocales(payload.genres[0].localizations, txnClient);
     await deletes('tvshow_genre_localizations', {}).run(txnClient);
     await insert('tvshow_genre_localizations', localizations).run(txnClient);
   }

--- a/services/catalog/service/src/domains/tvshows/handlers/tvshow-published-event-handler.ts
+++ b/services/catalog/service/src/domains/tvshows/handlers/tvshow-published-event-handler.ts
@@ -16,7 +16,7 @@ import {
   tvshow_video_cue_points,
   tvshow_video_streams,
 } from 'zapatos/schema';
-import { Config } from '../../../common';
+import { Config, syncInMemoryLocales } from '../../../common';
 
 export class TvshowPublishedEventHandler extends TransactionalInboxMessageHandler<
   TvshowPublishedEvent,
@@ -117,6 +117,7 @@ export class TvshowPublishedEventHandler extends TransactionalInboxMessageHandle
     }
 
     if (payload.localizations) {
+      await syncInMemoryLocales(payload.localizations, txnClient);
       await insert(
         'tvshow_localizations',
         payload.localizations.map(

--- a/services/catalog/service/src/domains/tvshows/plugins/extend-episode-query-with-country-code-plugin.db.spec.ts
+++ b/services/catalog/service/src/domains/tvshows/plugins/extend-episode-query-with-country-code-plugin.db.spec.ts
@@ -5,7 +5,7 @@ import {
 import gql from 'graphql-tag';
 import 'jest-extended';
 import { insert } from 'zapatos/db';
-import { CommonErrors } from '../../../common';
+import { CommonErrors, DEFAULT_LOCALE_TAG } from '../../../common';
 import { createTestContext, ITestContext } from '../../../tests/test-utils';
 
 const EPISODE_REQUEST = gql`
@@ -29,6 +29,12 @@ describe('ExtendEpisodeQueryWithCountryCodePlugin', () => {
     await insert('episode', { id: episodeId, season_id: seasonId }).run(
       ctx.ownerPool,
     );
+    await insert('episode_localizations', {
+      episode_id: episodeId,
+      locale: DEFAULT_LOCALE_TAG,
+      is_default_locale: true,
+      title: 'test',
+    }).run(ctx.ownerPool);
   });
 
   beforeEach(async () => {

--- a/services/catalog/service/src/generated/db/schema.sql
+++ b/services/catalog/service/src/generated/db/schema.sql
@@ -222,6 +222,45 @@ $$;
 
 
 --
+-- Name: add_default_placeholder_localizations(text); Type: FUNCTION; Schema: app_private; Owner: -
+--
+
+CREATE FUNCTION app_private.add_default_placeholder_localizations(newlocale text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    tableName text;
+    columnNames text[];
+    columnNamesStr text;
+    foreignKey text;
+BEGIN
+    FOR tableName IN
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'app_public' AND table_name LIKE '%_localizations'
+    LOOP
+        SELECT array_agg(column_name)
+        INTO columnNames
+        FROM information_schema.columns
+        WHERE table_schema = 'app_public' AND table_name = tableName AND column_name != 'locale' AND column_name != 'id' AND column_name != 'is_default_locale';
+        
+        SELECT columnName
+        INTO foreignKey
+        FROM UNNEST(columnNames) AS columnName
+        WHERE columnName ILIKE '%_id';
+
+        columnNamesStr := array_to_string(columnNames, ', ');
+        EXECUTE 'INSERT INTO app_public.' || tableName || ' (' || columnNamesStr || ', locale, is_default_locale) ' ||
+            'SELECT ' || columnNamesStr || ', ''' || newLocale || ''', FALSE ' ||
+            'FROM app_public.' || tableName || ' ' ||
+            'WHERE is_default_locale = TRUE ' ||
+            'ON CONFLICT (' || foreignKey || ', locale) DO NOTHING;';
+    END LOOP;
+END;
+$$;
+
+
+--
 -- Name: define_localization_view(text[], text, text, text); Type: FUNCTION; Schema: app_private; Owner: -
 --
 
@@ -233,18 +272,60 @@ DECLARE
 BEGIN
   EXECUTE 'DROP VIEW IF EXISTS app_public.' || tableName || '_view CASCADE;';
   EXECUTE 'CREATE VIEW app_public.' || tableName || '_view AS ' ||
-          'SELECT p.*, c.* FROM app_public.' || tableName || ' p ' ||
-          'LEFT OUTER JOIN LATERAL ( ' ||
-          'SELECT ' || localizableFieldsSelect || ' ' ||
-          'FROM app_public.' || localizationsTableName || ' l ' ||
-          'WHERE l.' || fkColumn || ' = p.id AND (l.locale = (SELECT pg_catalog.current_setting(''mosaic.locale'', true)) OR l.is_default_locale IS TRUE) ' ||
-          'ORDER BY l.is_default_locale ASC LIMIT 1) c ON TRUE;';
+          'SELECT p.*, ' || localizableFieldsSelect || ' FROM app_public.' || localizationsTableName || ' as l ' ||
+          'JOIN app_public.' || tableName || ' AS p ON l.' || fkColumn || ' = p.id ' ||
+          'WHERE l.locale = (SELECT pg_catalog.current_setting(''mosaic.locale'', true));';
 
   EXECUTE 'GRANT SELECT ON app_public.' || tableName || '_view TO "catalog_service_gql_role";';
 
   EXECUTE 'COMMENT ON TABLE app_public.' || tableName || ' IS E''@omit\n@name ' || tableName || '_data'';';
   EXECUTE 'COMMENT ON TABLE app_public.' || localizationsTableName || ' IS E''@omit'';';
   EXECUTE 'COMMENT ON VIEW app_public.' || tableName || '_view IS E''@name ' || tableName || '\n@primaryKey id'';';
+END;
+$$;
+
+
+--
+-- Name: set_initial_locales(); Type: FUNCTION; Schema: app_private; Owner: -
+--
+
+CREATE FUNCTION app_private.set_initial_locales() RETURNS text[]
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    tableName text;
+    localeRecord RECORD;
+    localesFound text[] := '{}';
+    query text;
+BEGIN
+    FOR tableName IN
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'app_public' AND table_name LIKE '%_localizations'
+    LOOP
+        IF localesFound != '{}' THEN
+            -- If locales have been found in a previous iteration, exit the loop
+            EXIT;
+        END IF;
+
+        query := 'SELECT DISTINCT locale, is_default_locale FROM app_public.' || tableName || ';';
+        FOR localeRecord IN EXECUTE query
+        LOOP
+          IF localesFound = '{}' THEN
+            -- If something is found and this is the first locale to be
+            -- processed - drop existing locales
+            DELETE FROM app_public.locales;
+          END IF;
+
+          INSERT INTO app_public.locales (locale, is_default)
+          VALUES (localeRecord.locale, localeRecord.is_default_locale)
+          ON CONFLICT (locale) DO NOTHING;
+
+          localesFound := array_append(localesFound, localeRecord.locale);
+        END LOOP;
+    END LOOP;
+
+    RETURN localesFound;
 END;
 $$;
 
@@ -260,8 +341,8 @@ DECLARE
   found_column text;
 begin
   EXECUTE '
-    SELECT column_name 
-    FROM information_schema.columns 
+    SELECT column_name
+    FROM information_schema.columns
     WHERE table_schema='''||schemaName||''' and table_name='''||tableName||''' and column_name='''||columnName||''';
   ' INTO found_column;
 
@@ -337,6 +418,184 @@ $$;
 
 
 --
+-- Name: create_messaging_health_monitoring(); Type: FUNCTION; Schema: ax_define; Owner: -
+--
+
+CREATE FUNCTION ax_define.create_messaging_health_monitoring() RETURNS void
+    LANGUAGE plpgsql
+    AS $_$
+BEGIN
+
+  EXECUTE 'DROP TABLE IF EXISTS app_private.messaging_health CASCADE;';
+  EXECUTE '
+  CREATE TABLE app_private.messaging_health (
+    key TEXT PRIMARY KEY,
+    success BOOLEAN
+  );';
+  
+  EXECUTE 'CREATE OR REPLACE FUNCTION app_private.messaging_health_notify()
+    RETURNS trigger
+    LANGUAGE plpgsql
+  AS $function$
+  BEGIN
+    PERFORM pg_notify(''messaging_health_handled'', row_to_json(NEW)::text);
+    RETURN NULL;
+  END;
+  $function$ ';
+
+  EXECUTE  'DROP TRIGGER IF EXISTS _500_messaging_health_trigger ON app_private.messaging_health;';
+  EXECUTE  'CREATE trigger _500_messaging_health_trigger
+              AFTER UPDATE ON app_private.messaging_health
+              FOR EACH ROW EXECUTE PROCEDURE app_private.messaging_health_notify();';
+
+END;
+$_$;
+
+
+--
+-- Name: create_trx_next_messages_function(text, text, text); Type: FUNCTION; Schema: ax_define; Owner: -
+--
+
+CREATE FUNCTION ax_define.create_trx_next_messages_function(trx_next_message_function_schema text, trx_table_schema text, trx_table_name text) RETURNS void
+    LANGUAGE plpgsql
+    AS $_$
+BEGIN
+  EXECUTE 'DROP FUNCTION IF EXISTS ' || trx_next_message_function_schema || '.next_'|| trx_table_name ||'_messages(integer, integer);';
+  EXECUTE 'CREATE OR REPLACE FUNCTION ' || trx_next_message_function_schema || '.next_'|| trx_table_name ||'_messages(
+  max_size integer, lock_ms integer)
+    RETURNS SETOF ' || trx_table_schema || '.'|| trx_table_name ||' 
+    LANGUAGE ''plpgsql''
+
+AS $BODY$
+DECLARE 
+  loop_row ' || trx_table_schema || '.'|| trx_table_name ||'%ROWTYPE;
+  message_row ' || trx_table_schema || '.'|| trx_table_name ||'%ROWTYPE;
+  ids uuid[] := ''{}'';
+BEGIN
+
+  IF max_size < 1 THEN
+    RAISE EXCEPTION ''The max_size for the next messages batch must be at least one.'' using errcode = ''MAXNR'';
+  END IF;
+
+  -- get (only) the oldest message of every segment but only return it if it is not locked
+  FOR loop_row IN
+    SELECT * FROM ' || trx_table_schema || '.'|| trx_table_name ||' m WHERE m.id in (SELECT DISTINCT ON (segment) id
+      FROM ' || trx_table_schema || '.'|| trx_table_name ||'
+      WHERE processed_at IS NULL AND abandoned_at IS NULL
+      ORDER BY segment, created_at) order by created_at
+  LOOP
+    BEGIN
+      EXIT WHEN cardinality(ids) >= max_size;
+    
+      SELECT *
+        INTO message_row
+        FROM ' || trx_table_schema || '.'|| trx_table_name ||'
+        WHERE id = loop_row.id
+        FOR NO KEY UPDATE NOWAIT; -- throw/catch error when locked
+      
+      IF message_row.locked_until > NOW() THEN
+        CONTINUE;
+      END IF;
+      
+      ids := array_append(ids, message_row.id);
+    EXCEPTION 
+      WHEN lock_not_available THEN
+        CONTINUE;
+      WHEN serialization_failure THEN
+        CONTINUE;
+    END;
+  END LOOP;
+  
+  -- if max_size not reached: get the oldest parallelizable message independent of segment
+  IF cardinality(ids) < max_size THEN
+    FOR loop_row IN
+      SELECT * FROM ' || trx_table_schema || '.'|| trx_table_name ||'
+        WHERE concurrency = ''parallel'' AND processed_at IS NULL AND abandoned_at IS NULL AND locked_until < NOW() 
+          AND id NOT IN (SELECT UNNEST(ids))
+        order by created_at
+    LOOP
+      BEGIN
+        EXIT WHEN cardinality(ids) >= max_size;
+
+        SELECT *
+          INTO message_row
+          FROM ' || trx_table_schema || '.'|| trx_table_name ||'
+          WHERE id = loop_row.id
+          FOR NO KEY UPDATE NOWAIT; -- throw/catch error when locked
+
+        ids := array_append(ids, message_row.id);
+      EXCEPTION 
+        WHEN lock_not_available THEN
+          CONTINUE;
+        WHEN serialization_failure THEN
+          CONTINUE;
+      END;
+    END LOOP;
+  END IF;
+  
+  -- set a short lock value so the the workers can each process a message
+  IF cardinality(ids) > 0 THEN
+
+    RETURN QUERY 
+      UPDATE ' || trx_table_schema || '.'|| trx_table_name ||'
+        SET locked_until = clock_timestamp() + (lock_ms || '' milliseconds'')::INTERVAL, started_attempts = started_attempts + 1
+        WHERE ID = ANY(ids)
+        RETURNING *;
+
+  END IF;
+END;
+$BODY$;';
+END;
+$_$;
+
+
+--
+-- Name: create_trx_table(text, text, text[], text); Type: FUNCTION; Schema: ax_define; Owner: -
+--
+
+CREATE FUNCTION ax_define.create_trx_table(trx_schema text, trx_table_name text, additional_roles_to_grant text[], concurrency text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE 
+  role_ TEXT;
+BEGIN
+  EXECUTE 'DROP TABLE IF EXISTS ' || trx_schema || '.'|| trx_table_name ||' CASCADE;';
+  EXECUTE 'CREATE TABLE ' || trx_schema || '.'|| trx_table_name ||' (
+            id uuid PRIMARY KEY,
+            aggregate_type TEXT NOT NULL,
+            aggregate_id TEXT NOT NULL, 
+            message_type TEXT NOT NULL,
+            payload JSONB NOT NULL,
+            metadata JSONB,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+            processed_at TIMESTAMPTZ,
+            started_attempts smallint NOT NULL DEFAULT 0,
+            finished_attempts smallint NOT NULL DEFAULT 0,
+            segment TEXT,
+            locked_until TIMESTAMPTZ NOT NULL DEFAULT to_timestamp(0),
+            concurrency TEXT NOT NULL DEFAULT ''' || concurrency || ''',
+            abandoned_at TIMESTAMPTZ
+          );';
+  EXECUTE 'ALTER TABLE ' || trx_schema || '.'|| trx_table_name ||' ADD CONSTRAINT '|| trx_table_name ||'_concurrency_check
+            CHECK (concurrency IN (''sequential'', ''parallel''));';
+  
+  -- The owner role has full access - no grants needed
+  -- Grants for additional roles are given here
+  FOREACH role_ IN ARRAY additional_roles_to_grant LOOP
+    EXECUTE 'GRANT SELECT, INSERT, DELETE ON ' || trx_schema || '.'|| trx_table_name ||' TO ' || role_ || ';';
+    EXECUTE 'GRANT UPDATE (locked_until, processed_at, abandoned_at, started_attempts, finished_attempts) ON ' || trx_schema || '.'|| trx_table_name ||' TO ' || role_ || ';';
+  END LOOP;  
+
+  EXECUTE 'SELECT ax_define.define_index(''segment'', '''|| trx_table_name ||''', '''||trx_schema||''');';
+  EXECUTE 'SELECT ax_define.define_index(''created_at'', '''|| trx_table_name ||''', ''' || trx_schema || ''');';
+  EXECUTE 'SELECT ax_define.define_index(''processed_at'', '''|| trx_table_name ||''', ''' || trx_schema || ''');';
+  EXECUTE 'SELECT ax_define.define_index(''abandoned_at'', '''|| trx_table_name ||''', ''' || trx_schema || ''');';
+  EXECUTE 'SELECT ax_define.define_index(''locked_until'', '''|| trx_table_name ||''', ''' || trx_schema || ''');';
+END;
+$$;
+
+
+--
 -- Name: define_audit_date_fields_on_table(text, text); Type: FUNCTION; Schema: ax_define; Owner: -
 --
 
@@ -345,7 +604,7 @@ CREATE FUNCTION ax_define.define_audit_date_fields_on_table(tablename text, sche
     AS $_$
 BEGIN
   EXECUTE '
-    DO $do$ BEGIN 
+    DO $do$ BEGIN
       BEGIN
           ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN created_date timestamptz NOT NULL DEFAULT (now() at time zone ''utc'');
           ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN updated_date timestamptz NOT NULL DEFAULT (now() at time zone ''utc'');
@@ -368,7 +627,7 @@ CREATE FUNCTION ax_define.define_audit_user_fields_on_table(tablename text, sche
     AS $_$
 BEGIN
   EXECUTE '
-    DO $do$ BEGIN 
+    DO $do$ BEGIN
       BEGIN
           ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN created_user text NOT NULL DEFAULT ''' || defaultUserName || ''';
           ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN updated_user text NOT NULL DEFAULT ''' || defaultUserName || ''';
@@ -442,8 +701,8 @@ DECLARE
 BEGIN
   EXECUTE 'ALTER TABLE ' || schemaName || '.' || tableName || ' ENABLE ROW LEVEL SECURITY;';
   EXECUTE 'DROP POLICY IF EXISTS ' || tableName || '_end_user_authorization ON ' || schemaName || '.' || tableName || ';';
-  
- 
+
+
   EXECUTE 'CREATE POLICY ' || tableName || '_end_user_authorization ON ' || schemaName || '.' || tableName || ' AS RESTRICTIVE FOR ALL
     USING (' || end_user_rls_string || ');';
 
@@ -469,10 +728,10 @@ $$;
 
 
 --
--- Name: define_indexes_with_id(text, text, text, text, text); Type: FUNCTION; Schema: ax_define; Owner: -
+-- Name: define_indexes_with_id(text, text, text, text, text, text); Type: FUNCTION; Schema: ax_define; Owner: -
 --
 
-CREATE FUNCTION ax_define.define_indexes_with_id(fieldname text, tablename text, schemaname text, indexnameasc text DEFAULT NULL::text, indexnamedesc text DEFAULT NULL::text) RETURNS void
+CREATE FUNCTION ax_define.define_indexes_with_id(fieldname text, tablename text, schemaname text, indexnameasc text DEFAULT NULL::text, indexnamedesc text DEFAULT NULL::text, idfieldname text DEFAULT 'id'::text) RETURNS void
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -481,8 +740,8 @@ BEGIN
   PERFORM ax_utils.validate_identifier_length(indexNameAsc, 'If the auto-generated name is too long then an "indexNameAsc" argument must be provided.');
   PERFORM ax_utils.validate_identifier_length(indexNameDesc, 'If the auto-generated name is too long then an "indexNameDesc" argument must be provided.');
   PERFORM ax_define.drop_indexes_with_id(fieldName, tableName, indexNameAsc, indexNameDesc);
-  EXECUTE 'CREATE INDEX idx_' || tableName || '_' || fieldName || '_asc_with_id ON ' || schemaName || '.' || tableName || ' (' || fieldName || ' ASC, id ASC);';
-  EXECUTE 'CREATE INDEX idx_' || tableName || '_' || fieldName || '_desc_with_id ON ' || schemaName || '.' || tableName || ' (' || fieldName || ' DESC, id ASC);';
+  EXECUTE 'CREATE INDEX idx_' || tableName || '_' || fieldName || '_asc_with_id ON ' || schemaName || '.' || tableName || ' (' || fieldName || ' ASC, ' || idFieldName || ' ASC);';
+  EXECUTE 'CREATE INDEX idx_' || tableName || '_' || fieldName || '_desc_with_id ON ' || schemaName || '.' || tableName || ' (' || fieldName || ' DESC, ' || idFieldName || ' ASC);';
 END;
 $$;
 
@@ -542,18 +801,24 @@ $$;
 CREATE FUNCTION ax_define.define_subscription_triggers(idcolumn text, tablename text, schemaname text, maintablename text, eventtype text) RETURNS void
     LANGUAGE plpgsql
     AS $$
+DECLARE
+  createEvent text = eventType || '_CREATED';
+  changeEvent text = eventType || '_CHANGED';
+  deleteEvent text = eventType || '_DELETED';
 BEGIN
+  EXECUTE 'COMMENT ON TABLE ' || schemaName || '.' || tableName || '  IS E''@subscription_events_' || mainTableName || ' ' || createEvent || ',' || changeEvent || ',' || deleteEvent || ''';';
+  
   EXECUTE 'DROP TRIGGER IF EXISTS _500_gql_' || tableName || '_inserted ON ' || schemaName || '.' || tableName;
   EXECUTE 'CREATE TRIGGER _500_gql_' || tableName || '_inserted after insert on ' || schemaName || '.' || tableName || ' ' ||
-          'for each row execute procedure ax_utils.tg__graphql_subscription(''' || eventType || 'Created'',''graphql:' || mainTableName || ''',''' || idColumn || ''');';
+          'for each row execute procedure ax_utils.tg__graphql_subscription(''' || createEvent || ''',''graphql:' || mainTableName || ''',''' || idColumn || ''');';
 
   EXECUTE 'DROP TRIGGER IF EXISTS _500_gql_' || tableName || '_updated ON ' || schemaName || '.' || tableName;
   EXECUTE 'CREATE TRIGGER _500_gql_' || tableName || '_updated after update on ' || schemaName || '.' || tableName || ' ' ||
-          'for each row execute procedure ax_utils.tg__graphql_subscription(''' || eventType || 'Changed'',''graphql:' || mainTableName || ''',''' || idColumn || ''');';
+          'for each row execute procedure ax_utils.tg__graphql_subscription(''' || changeEvent || ''',''graphql:' || mainTableName || ''',''' || idColumn || ''');';
 
   EXECUTE 'DROP TRIGGER IF EXISTS _500_gql_' || tableName || '_deleted ON ' || schemaName || '.' || tableName;
   EXECUTE 'CREATE TRIGGER _500_gql_' || tableName || '_deleted before delete on ' || schemaName || '.' || tableName || ' ' ||
-          'for each row execute procedure ax_utils.tg__graphql_subscription(''' || eventType || 'Deleted'',''graphql:' || mainTableName || ''',''' || idColumn || ''');';
+          'for each row execute procedure ax_utils.tg__graphql_subscription(''' || deleteEvent || ''',''graphql:' || mainTableName || ''',''' || idColumn || ''');';
 END;
 $$;
 
@@ -588,15 +853,15 @@ BEGIN
   -- Set updated_date=now() on the foreign table. This will propogate UPDATE triggers.
   --
   -- A new function is created for each table to do this.
-  --     It *may* be possible to use a stock function with trigger arguments but its not easy as NEW and OLD cannot be accessed with dynamic column names. A possible 
-  --     solution to that is described here: https://itectec.com/database/postgresql-assignment-of-a-column-with-dynamic-column-name/. But even there the advise is 
+  --     It *may* be possible to use a stock function with trigger arguments but its not easy as NEW and OLD cannot be accessed with dynamic column names. A possible
+  --     solution to that is described here: https://itectec.com/database/postgresql-assignment-of-a-column-with-dynamic-column-name/. But even there the advise is
   --     to: "Just write a new trigger function for each table. Less hassle, better performance. Byte the bullet on code duplication:"
   --
-  -- WARNING: This function uses "SECURITY DEFINER". This is required to ensure that update to the target table is allowed. This means that the function is 
+  -- WARNING: This function uses "SECURITY DEFINER". This is required to ensure that update to the target table is allowed. This means that the function is
   --          executed with role "DB_OWNER". Any propogated trigger functions will also execute with role "DB_OWNER".
   EXECUTE  '
             CREATE OR REPLACE FUNCTION ' || schemaName || '.' || functionName || '() RETURNS TRIGGER
-            LANGUAGE plpgsql 
+            LANGUAGE plpgsql
             SECURITY DEFINER
             SET search_path = pg_temp
             AS $b$
@@ -609,31 +874,31 @@ BEGIN
                         RETURN NULL;
                     END IF;
                 END IF;
-                
+
                 -- UPDATE (where relationship is unchanged, or changed to another entity in which case a change is triggered on both the old and new relation)
                 IF (OLD.' || idColumnName || ' IS NOT NULL AND NEW.' || idColumnName || ' IS NOT NULL) THEN
                     UPDATE ' || foreignSchemaName || '.' || foreignTableName || ' SET updated_date=now()
                     WHERE (' || foreignIdColumnName || ' = OLD.' || idColumnName || ') OR (' || foreignIdColumnName || ' = NEW.' || idColumnName || ');
-                
+
                 -- INSERT (or UPDATE which sets nullable relationship)
                 ELSIF (NEW.' || idColumnName || ' IS NOT NULL) THEN
                     UPDATE ' || foreignSchemaName || '.' || foreignTableName || ' SET updated_date=now()
                     WHERE ' || foreignIdColumnName || ' = NEW.' || idColumnName || ';
-                
+
                 -- DELETE (or UPDATE which removes nullable relationship)
                 ELSIF (OLD.' || idColumnName || ' IS NOT NULL) THEN
                     UPDATE ' || foreignSchemaName || '.' || foreignTableName || ' SET updated_date=now()
                     WHERE ' || foreignIdColumnName || ' = OLD.' || idColumnName || ';
-                    
+
                 END IF;
                 RETURN NULL;
             END $b$;
             REVOKE EXECUTE ON FUNCTION ' || schemaName || '.' || functionName || '() FROM public;
             ';
-  
+
   -- Function runs *AFTER* INSERT, UPDATE, DELETE. Propogated queries can still raise an error and rollback the transaction
   EXECUTE  'DROP TRIGGER IF EXISTS _200_propogate_timestamps on ' || schemaName || '.' || tableName;
-  EXECUTE  'CREATE trigger _200_propogate_timestamps 
+  EXECUTE  'CREATE trigger _200_propogate_timestamps
             AFTER INSERT OR UPDATE OR DELETE ON ' || schemaName || '.' || tableName || '
             FOR EACH ROW EXECUTE PROCEDURE ' || schemaName || '.' || functionName || '();';
 END;
@@ -697,17 +962,17 @@ CREATE FUNCTION ax_define.define_user_id_on_table(tablename text, schemaname tex
     AS $_$
 BEGIN
   EXECUTE '
-    DO $do$ BEGIN 
+    DO $do$ BEGIN
       BEGIN
           ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN user_id UUID NOT NULL DEFAULT ''00000000-0000-0000-0000-000000000000'';
       EXCEPTION
           WHEN duplicate_column THEN RAISE NOTICE ''The column user_id already exists in the ' || schemaName || '.' || tableName || ' table.'';
       END;
     END $do$;
-    
+
     ALTER TABLE ' || schemaName || '.' || tableName || ' DROP CONSTRAINT IF EXISTS user_id_not_default;
     ALTER TABLE ' || schemaName || '.' || tableName || ' ADD CONSTRAINT user_id_not_default CHECK (ax_utils.constraint_not_default_uuid(user_id, uuid_nil()));
-    
+
     SELECT ax_define.define_user_id_trigger(''' || tableName || ''', ''' || schemaName || ''');
   ';
 END;
@@ -916,6 +1181,59 @@ $_$;
 
 
 --
+-- Name: pgmemento_create_table_audit(text, text, text, boolean, boolean, boolean); Type: FUNCTION; Schema: ax_define; Owner: -
+--
+
+CREATE FUNCTION ax_define.pgmemento_create_table_audit(table_name text, schema_name text DEFAULT 'app_public'::text, audit_id_column_name text DEFAULT 'pgmemento_audit_id'::text, log_old_data boolean DEFAULT true, log_new_data boolean DEFAULT false, log_state boolean DEFAULT false) RETURNS void
+    LANGUAGE plpgsql
+    AS $_$
+BEGIN
+    PERFORM pgmemento.create_table_audit($1, $2, $3, $4, $5, $6, TRUE);
+EXCEPTION
+    -- If this has been run before the table will already have the pgmemento_audit_id column and an error will be thrown.
+    WHEN duplicate_column THEN
+        RAISE INFO 'Column % already exists on %.%', $3, $2, $1 ;
+END;
+$_$;
+
+
+--
+-- Name: pgmemento_delete_old_logs(interval); Type: FUNCTION; Schema: ax_define; Owner: -
+--
+
+CREATE FUNCTION ax_define.pgmemento_delete_old_logs(age interval) RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    counter INTEGER;
+    transaction_id INTEGER;
+    tablename TEXT;
+    schemaname TEXT;
+BEGIN
+    counter := 0;
+    FOR transaction_id, tablename, schemaname IN (
+        -- 1. Get all transaction metadata and associated table event metadata older than specified age.
+        SELECT DISTINCT
+            tl.id, el.table_name, el.schema_name
+        FROM
+            pgmemento.transaction_log tl
+            JOIN pgmemento.table_event_log el ON tl.id = el.transaction_id
+        WHERE
+            tl.txid_time  < NOW() - age)
+    LOOP
+        -- 2. Delete all table event metadata and row log entries associated with the transaction.
+        PERFORM  pgmemento.delete_table_event_log(transaction_id, tablename, schemaname);
+        -- 3. Delete the transaction metadata itself.
+        PERFORM pgmemento.delete_txid_log(transaction_id);
+        counter := counter + 1;
+    END LOOP;
+
+    RETURN counter;
+END;
+$$;
+
+
+--
 -- Name: set_enum_as_column_type(text, text, text, text, text, text, text, text); Type: FUNCTION; Schema: ax_define; Owner: -
 --
 
@@ -932,10 +1250,10 @@ BEGIN
   END IF;
   IF NOT ax_define.column_exists(columnName, tableName, schemaName) THEN
     EXECUTE 'ALTER TABLE ' || schemaName || '.' || tableName || ' ADD COLUMN ' || columnName ||' text ' || default_setting || ' ' || notNullOptions || ';';
-  END IF; 
+  END IF;
 
   -- Set the column that uses enum value as a foreign key
-  EXECUTE 'ALTER TABLE ' || schemaName || '.' || tableName || ' ADD CONSTRAINT ' || constraintName || ' FOREIGN KEY ('|| columnName ||') REFERENCES ' || enumSchemaName || '.' || enumName || '(value);'; 
+  EXECUTE 'ALTER TABLE ' || schemaName || '.' || tableName || ' ADD CONSTRAINT ' || constraintName || ' FOREIGN KEY ('|| columnName ||') REFERENCES ' || enumSchemaName || '.' || enumName || '(value);';
 END;
 $$;
 
@@ -949,8 +1267,8 @@ CREATE FUNCTION ax_define.set_enum_domain(columnname text, tablename text, schem
     AS $_$
 BEGIN
   EXECUTE '
-    DO $do$ BEGIN 
-      BEGIN 
+    DO $do$ BEGIN
+      BEGIN
         CREATE DOMAIN ' || enumSchemaName || '.' || enumName || ' AS text;
       EXCEPTION
         WHEN duplicate_object THEN RAISE NOTICE ''Domain already existed.'';
@@ -1993,17 +2311,12 @@ ALTER TABLE app_public.collection_localizations ALTER COLUMN id ADD GENERATED BY
 CREATE VIEW app_public.collection_view AS
  SELECT p.id,
     p.tags,
-    c.title,
-    c.description,
-    c.synopsis
-   FROM (app_public.collection p
-     LEFT JOIN LATERAL ( SELECT l.title,
-            l.description,
-            l.synopsis
-           FROM app_public.collection_localizations l
-          WHERE ((l.collection_id = p.id) AND ((l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting)) OR (l.is_default_locale IS TRUE)))
-          ORDER BY l.is_default_locale
-         LIMIT 1) c ON (true));
+    l.title,
+    l.description,
+    l.synopsis
+   FROM (app_public.collection_localizations l
+     JOIN app_public.collection p ON ((l.collection_id = p.id)))
+  WHERE (l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting));
 
 
 --
@@ -2272,17 +2585,12 @@ CREATE VIEW app_public.episode_view AS
     p.episode_cast,
     p.tags,
     p.production_countries,
-    c.title,
-    c.description,
-    c.synopsis
-   FROM (app_public.episode p
-     LEFT JOIN LATERAL ( SELECT l.title,
-            l.description,
-            l.synopsis
-           FROM app_public.episode_localizations l
-          WHERE ((l.episode_id = p.id) AND ((l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting)) OR (l.is_default_locale IS TRUE)))
-          ORDER BY l.is_default_locale
-         LIMIT 1) c ON (true));
+    l.title,
+    l.description,
+    l.synopsis
+   FROM (app_public.episode_localizations l
+     JOIN app_public.episode p ON ((l.episode_id = p.id)))
+  WHERE (l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting));
 
 
 --
@@ -2291,6 +2599,16 @@ CREATE VIEW app_public.episode_view AS
 
 COMMENT ON VIEW app_public.episode_view IS '@name episode
 @primaryKey id';
+
+
+--
+-- Name: locales; Type: TABLE; Schema: app_public; Owner: -
+--
+
+CREATE TABLE app_public.locales (
+    locale text NOT NULL,
+    is_default boolean DEFAULT false NOT NULL
+);
 
 
 --
@@ -2375,13 +2693,10 @@ ALTER TABLE app_public.movie_genre_localizations ALTER COLUMN id ADD GENERATED B
 CREATE VIEW app_public.movie_genre_view AS
  SELECT p.id,
     p.order_no,
-    c.title
-   FROM (app_public.movie_genre p
-     LEFT JOIN LATERAL ( SELECT l.title
-           FROM app_public.movie_genre_localizations l
-          WHERE ((l.movie_genre_id = p.id) AND ((l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting)) OR (l.is_default_locale IS TRUE)))
-          ORDER BY l.is_default_locale
-         LIMIT 1) c ON (true));
+    l.title
+   FROM (app_public.movie_genre_localizations l
+     JOIN app_public.movie_genre p ON ((l.movie_genre_id = p.id)))
+  WHERE (l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting));
 
 
 --
@@ -2623,17 +2938,12 @@ CREATE VIEW app_public.movie_view AS
     p.movie_cast,
     p.production_countries,
     p.tags,
-    c.title,
-    c.description,
-    c.synopsis
-   FROM (app_public.movie p
-     LEFT JOIN LATERAL ( SELECT l.title,
-            l.description,
-            l.synopsis
-           FROM app_public.movie_localizations l
-          WHERE ((l.movie_id = p.id) AND ((l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting)) OR (l.is_default_locale IS TRUE)))
-          ORDER BY l.is_default_locale
-         LIMIT 1) c ON (true));
+    l.title,
+    l.description,
+    l.synopsis
+   FROM (app_public.movie_localizations l
+     JOIN app_public.movie p ON ((l.movie_id = p.id)))
+  WHERE (l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting));
 
 
 --
@@ -3035,15 +3345,11 @@ CREATE VIEW app_public.season_view AS
     p.season_cast,
     p.production_countries,
     p.tags,
-    c.description,
-    c.synopsis
-   FROM (app_public.season p
-     LEFT JOIN LATERAL ( SELECT l.description,
-            l.synopsis
-           FROM app_public.season_localizations l
-          WHERE ((l.season_id = p.id) AND ((l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting)) OR (l.is_default_locale IS TRUE)))
-          ORDER BY l.is_default_locale
-         LIMIT 1) c ON (true));
+    l.description,
+    l.synopsis
+   FROM (app_public.season_localizations l
+     JOIN app_public.season p ON ((l.season_id = p.id)))
+  WHERE (l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting));
 
 
 --
@@ -3136,13 +3442,10 @@ ALTER TABLE app_public.tvshow_genre_localizations ALTER COLUMN id ADD GENERATED 
 CREATE VIEW app_public.tvshow_genre_view AS
  SELECT p.id,
     p.order_no,
-    c.title
-   FROM (app_public.tvshow_genre p
-     LEFT JOIN LATERAL ( SELECT l.title
-           FROM app_public.tvshow_genre_localizations l
-          WHERE ((l.tvshow_genre_id = p.id) AND ((l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting)) OR (l.is_default_locale IS TRUE)))
-          ORDER BY l.is_default_locale
-         LIMIT 1) c ON (true));
+    l.title
+   FROM (app_public.tvshow_genre_localizations l
+     JOIN app_public.tvshow_genre p ON ((l.tvshow_genre_id = p.id)))
+  WHERE (l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting));
 
 
 --
@@ -3384,17 +3687,12 @@ CREATE VIEW app_public.tvshow_view AS
     p.tvshow_cast,
     p.production_countries,
     p.tags,
-    c.title,
-    c.description,
-    c.synopsis
-   FROM (app_public.tvshow p
-     LEFT JOIN LATERAL ( SELECT l.title,
-            l.description,
-            l.synopsis
-           FROM app_public.tvshow_localizations l
-          WHERE ((l.tvshow_id = p.id) AND ((l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting)) OR (l.is_default_locale IS TRUE)))
-          ORDER BY l.is_default_locale
-         LIMIT 1) c ON (true));
+    l.title,
+    l.description,
+    l.synopsis
+   FROM (app_public.tvshow_localizations l
+     JOIN app_public.tvshow p ON ((l.tvshow_id = p.id)))
+  WHERE (l.locale = ( SELECT current_setting('mosaic.locale'::text, true) AS current_setting));
 
 
 --
@@ -3556,6 +3854,14 @@ ALTER TABLE ONLY app_public.episode_video_streams
 
 ALTER TABLE ONLY app_public.episode_videos
     ADD CONSTRAINT episode_videos_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: locales locales_pkey; Type: CONSTRAINT; Schema: app_public; Owner: -
+--
+
+ALTER TABLE ONLY app_public.locales
+    ADD CONSTRAINT locales_pkey PRIMARY KEY (locale);
 
 
 --
@@ -3815,6 +4121,62 @@ ALTER TABLE ONLY app_public.tvshow_videos
 
 
 --
+-- Name: collection_localizations unique_by_collection_id_and_locale; Type: CONSTRAINT; Schema: app_public; Owner: -
+--
+
+ALTER TABLE ONLY app_public.collection_localizations
+    ADD CONSTRAINT unique_by_collection_id_and_locale UNIQUE (collection_id, locale);
+
+
+--
+-- Name: episode_localizations unique_by_episode_id_and_locale; Type: CONSTRAINT; Schema: app_public; Owner: -
+--
+
+ALTER TABLE ONLY app_public.episode_localizations
+    ADD CONSTRAINT unique_by_episode_id_and_locale UNIQUE (episode_id, locale);
+
+
+--
+-- Name: movie_genre_localizations unique_by_movie_genre_id_and_locale; Type: CONSTRAINT; Schema: app_public; Owner: -
+--
+
+ALTER TABLE ONLY app_public.movie_genre_localizations
+    ADD CONSTRAINT unique_by_movie_genre_id_and_locale UNIQUE (movie_genre_id, locale);
+
+
+--
+-- Name: movie_localizations unique_by_movie_id_and_locale; Type: CONSTRAINT; Schema: app_public; Owner: -
+--
+
+ALTER TABLE ONLY app_public.movie_localizations
+    ADD CONSTRAINT unique_by_movie_id_and_locale UNIQUE (movie_id, locale);
+
+
+--
+-- Name: season_localizations unique_by_season_id_and_locale; Type: CONSTRAINT; Schema: app_public; Owner: -
+--
+
+ALTER TABLE ONLY app_public.season_localizations
+    ADD CONSTRAINT unique_by_season_id_and_locale UNIQUE (season_id, locale);
+
+
+--
+-- Name: tvshow_genre_localizations unique_by_tvshow_genre_id_and_locale; Type: CONSTRAINT; Schema: app_public; Owner: -
+--
+
+ALTER TABLE ONLY app_public.tvshow_genre_localizations
+    ADD CONSTRAINT unique_by_tvshow_genre_id_and_locale UNIQUE (tvshow_genre_id, locale);
+
+
+--
+-- Name: tvshow_localizations unique_by_tvshow_id_and_locale; Type: CONSTRAINT; Schema: app_public; Owner: -
+--
+
+ALTER TABLE ONLY app_public.tvshow_localizations
+    ADD CONSTRAINT unique_by_tvshow_id_and_locale UNIQUE (tvshow_id, locale);
+
+
+--
 -- Name: video_stream_type video_stream_type_pkey; Type: CONSTRAINT; Schema: app_public; Owner: -
 --
 
@@ -3942,6 +4304,20 @@ CREATE INDEX idx_collection_localizations_locale ON app_public.collection_locali
 
 
 --
+-- Name: idx_collection_localizations_title_asc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_collection_localizations_title_asc_with_id ON app_public.collection_localizations USING btree (title, collection_id);
+
+
+--
+-- Name: idx_collection_localizations_title_desc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_collection_localizations_title_desc_with_id ON app_public.collection_localizations USING btree (title DESC, collection_id);
+
+
+--
 -- Name: idx_episode_genres_relation_episode_id; Type: INDEX; Schema: app_public; Owner: -
 --
 
@@ -3988,6 +4364,20 @@ CREATE INDEX idx_episode_localizations_episode_id ON app_public.episode_localiza
 --
 
 CREATE INDEX idx_episode_localizations_locale ON app_public.episode_localizations USING btree (locale);
+
+
+--
+-- Name: idx_episode_localizations_title_asc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_episode_localizations_title_asc_with_id ON app_public.episode_localizations USING btree (title, episode_id);
+
+
+--
+-- Name: idx_episode_localizations_title_desc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_episode_localizations_title_desc_with_id ON app_public.episode_localizations USING btree (title DESC, episode_id);
 
 
 --
@@ -4047,6 +4437,20 @@ CREATE INDEX idx_movie_genre_localizations_movie_genre_id ON app_public.movie_ge
 
 
 --
+-- Name: idx_movie_genre_localizations_title_asc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_movie_genre_localizations_title_asc_with_id ON app_public.movie_genre_localizations USING btree (title, movie_genre_id);
+
+
+--
+-- Name: idx_movie_genre_localizations_title_desc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_movie_genre_localizations_title_desc_with_id ON app_public.movie_genre_localizations USING btree (title DESC, movie_genre_id);
+
+
+--
 -- Name: idx_movie_genre_order_no; Type: INDEX; Schema: app_public; Owner: -
 --
 
@@ -4093,6 +4497,20 @@ CREATE INDEX idx_movie_localizations_locale ON app_public.movie_localizations US
 --
 
 CREATE INDEX idx_movie_localizations_movie_id ON app_public.movie_localizations USING btree (movie_id);
+
+
+--
+-- Name: idx_movie_localizations_title_asc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_movie_localizations_title_asc_with_id ON app_public.movie_localizations USING btree (title, movie_id);
+
+
+--
+-- Name: idx_movie_localizations_title_desc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_movie_localizations_title_desc_with_id ON app_public.movie_localizations USING btree (title DESC, movie_id);
 
 
 --
@@ -4257,10 +4675,66 @@ CREATE INDEX idx_season_videos_season_id ON app_public.season_videos USING btree
 
 
 --
+-- Name: idx_trgm_collection_localizations_title; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_trgm_collection_localizations_title ON app_public.collection_localizations USING gin (title public.gin_trgm_ops);
+
+
+--
+-- Name: idx_trgm_episode_localizations_title; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_trgm_episode_localizations_title ON app_public.episode_localizations USING gin (title public.gin_trgm_ops);
+
+
+--
+-- Name: idx_trgm_movie_genre_localizations_title; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_trgm_movie_genre_localizations_title ON app_public.movie_genre_localizations USING gin (title public.gin_trgm_ops);
+
+
+--
+-- Name: idx_trgm_movie_localizations_title; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_trgm_movie_localizations_title ON app_public.movie_localizations USING gin (title public.gin_trgm_ops);
+
+
+--
+-- Name: idx_trgm_tvshow_genre_localizations_title; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_trgm_tvshow_genre_localizations_title ON app_public.tvshow_genre_localizations USING gin (title public.gin_trgm_ops);
+
+
+--
+-- Name: idx_trgm_tvshow_localizations_title; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_trgm_tvshow_localizations_title ON app_public.tvshow_localizations USING gin (title public.gin_trgm_ops);
+
+
+--
 -- Name: idx_tvshow_genre_localizations_locale; Type: INDEX; Schema: app_public; Owner: -
 --
 
 CREATE INDEX idx_tvshow_genre_localizations_locale ON app_public.tvshow_genre_localizations USING btree (locale);
+
+
+--
+-- Name: idx_tvshow_genre_localizations_title_asc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_tvshow_genre_localizations_title_asc_with_id ON app_public.tvshow_genre_localizations USING btree (title, tvshow_genre_id);
+
+
+--
+-- Name: idx_tvshow_genre_localizations_title_desc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_tvshow_genre_localizations_title_desc_with_id ON app_public.tvshow_genre_localizations USING btree (title DESC, tvshow_genre_id);
 
 
 --
@@ -4317,6 +4791,20 @@ CREATE INDEX idx_tvshow_licenses_tvshow_id ON app_public.tvshow_licenses USING b
 --
 
 CREATE INDEX idx_tvshow_localizations_locale ON app_public.tvshow_localizations USING btree (locale);
+
+
+--
+-- Name: idx_tvshow_localizations_title_asc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_tvshow_localizations_title_asc_with_id ON app_public.tvshow_localizations USING btree (title, tvshow_id);
+
+
+--
+-- Name: idx_tvshow_localizations_title_desc_with_id; Type: INDEX; Schema: app_public; Owner: -
+--
+
+CREATE INDEX idx_tvshow_localizations_title_desc_with_id ON app_public.tvshow_localizations USING btree (title DESC, tvshow_id);
 
 
 --
@@ -4829,10 +5317,24 @@ GRANT ALL ON FUNCTION app_hidden.next_inbox_messages(max_size integer, lock_ms i
 
 
 --
+-- Name: FUNCTION add_default_placeholder_localizations(newlocale text); Type: ACL; Schema: app_private; Owner: -
+--
+
+REVOKE ALL ON FUNCTION app_private.add_default_placeholder_localizations(newlocale text) FROM PUBLIC;
+
+
+--
 -- Name: FUNCTION define_localization_view(localizablefields text[], tablename text, localizationstablename text, fkcolumn text); Type: ACL; Schema: app_private; Owner: -
 --
 
 REVOKE ALL ON FUNCTION app_private.define_localization_view(localizablefields text[], tablename text, localizationstablename text, fkcolumn text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION set_initial_locales(); Type: ACL; Schema: app_private; Owner: -
+--
+
+REVOKE ALL ON FUNCTION app_private.set_initial_locales() FROM PUBLIC;
 
 
 --
@@ -4857,6 +5359,30 @@ GRANT ALL ON FUNCTION ax_define.create_enum_table(enumname text, schemaname text
 
 REVOKE ALL ON FUNCTION ax_define.create_messaging_counter_table() FROM PUBLIC;
 GRANT ALL ON FUNCTION ax_define.create_messaging_counter_table() TO catalog_service_gql_role;
+
+
+--
+-- Name: FUNCTION create_messaging_health_monitoring(); Type: ACL; Schema: ax_define; Owner: -
+--
+
+REVOKE ALL ON FUNCTION ax_define.create_messaging_health_monitoring() FROM PUBLIC;
+GRANT ALL ON FUNCTION ax_define.create_messaging_health_monitoring() TO catalog_service_gql_role;
+
+
+--
+-- Name: FUNCTION create_trx_next_messages_function(trx_next_message_function_schema text, trx_table_schema text, trx_table_name text); Type: ACL; Schema: ax_define; Owner: -
+--
+
+REVOKE ALL ON FUNCTION ax_define.create_trx_next_messages_function(trx_next_message_function_schema text, trx_table_schema text, trx_table_name text) FROM PUBLIC;
+GRANT ALL ON FUNCTION ax_define.create_trx_next_messages_function(trx_next_message_function_schema text, trx_table_schema text, trx_table_name text) TO catalog_service_gql_role;
+
+
+--
+-- Name: FUNCTION create_trx_table(trx_schema text, trx_table_name text, additional_roles_to_grant text[], concurrency text); Type: ACL; Schema: ax_define; Owner: -
+--
+
+REVOKE ALL ON FUNCTION ax_define.create_trx_table(trx_schema text, trx_table_name text, additional_roles_to_grant text[], concurrency text) FROM PUBLIC;
+GRANT ALL ON FUNCTION ax_define.create_trx_table(trx_schema text, trx_table_name text, additional_roles_to_grant text[], concurrency text) TO catalog_service_gql_role;
 
 
 --
@@ -4908,11 +5434,11 @@ GRANT ALL ON FUNCTION ax_define.define_index(fieldname text, tablename text, sch
 
 
 --
--- Name: FUNCTION define_indexes_with_id(fieldname text, tablename text, schemaname text, indexnameasc text, indexnamedesc text); Type: ACL; Schema: ax_define; Owner: -
+-- Name: FUNCTION define_indexes_with_id(fieldname text, tablename text, schemaname text, indexnameasc text, indexnamedesc text, idfieldname text); Type: ACL; Schema: ax_define; Owner: -
 --
 
-REVOKE ALL ON FUNCTION ax_define.define_indexes_with_id(fieldname text, tablename text, schemaname text, indexnameasc text, indexnamedesc text) FROM PUBLIC;
-GRANT ALL ON FUNCTION ax_define.define_indexes_with_id(fieldname text, tablename text, schemaname text, indexnameasc text, indexnamedesc text) TO catalog_service_gql_role;
+REVOKE ALL ON FUNCTION ax_define.define_indexes_with_id(fieldname text, tablename text, schemaname text, indexnameasc text, indexnamedesc text, idfieldname text) FROM PUBLIC;
+GRANT ALL ON FUNCTION ax_define.define_indexes_with_id(fieldname text, tablename text, schemaname text, indexnameasc text, indexnamedesc text, idfieldname text) TO catalog_service_gql_role;
 
 
 --
@@ -5097,6 +5623,22 @@ GRANT ALL ON FUNCTION ax_define.drop_users_trigger(tablename text, schemaname te
 
 REVOKE ALL ON FUNCTION ax_define.live_suggestions_endpoint(propertyname text, typename text, schemaname text) FROM PUBLIC;
 GRANT ALL ON FUNCTION ax_define.live_suggestions_endpoint(propertyname text, typename text, schemaname text) TO catalog_service_gql_role;
+
+
+--
+-- Name: FUNCTION pgmemento_create_table_audit(table_name text, schema_name text, audit_id_column_name text, log_old_data boolean, log_new_data boolean, log_state boolean); Type: ACL; Schema: ax_define; Owner: -
+--
+
+REVOKE ALL ON FUNCTION ax_define.pgmemento_create_table_audit(table_name text, schema_name text, audit_id_column_name text, log_old_data boolean, log_new_data boolean, log_state boolean) FROM PUBLIC;
+GRANT ALL ON FUNCTION ax_define.pgmemento_create_table_audit(table_name text, schema_name text, audit_id_column_name text, log_old_data boolean, log_new_data boolean, log_state boolean) TO catalog_service_gql_role;
+
+
+--
+-- Name: FUNCTION pgmemento_delete_old_logs(age interval); Type: ACL; Schema: ax_define; Owner: -
+--
+
+REVOKE ALL ON FUNCTION ax_define.pgmemento_delete_old_logs(age interval) FROM PUBLIC;
+GRANT ALL ON FUNCTION ax_define.pgmemento_delete_old_logs(age interval) TO catalog_service_gql_role;
 
 
 --
@@ -5627,6 +6169,13 @@ GRANT SELECT,USAGE ON SEQUENCE app_public.episode_videos_id_seq TO catalog_servi
 --
 
 GRANT SELECT ON TABLE app_public.episode_view TO catalog_service_gql_role;
+
+
+--
+-- Name: TABLE locales; Type: ACL; Schema: app_public; Owner: -
+--
+
+GRANT SELECT ON TABLE app_public.locales TO catalog_service_gql_role;
 
 
 --

--- a/services/catalog/service/src/generated/db/zapatos/schema.d.ts
+++ b/services/catalog/service/src/generated/db/zapatos/schema.d.ts
@@ -1643,7 +1643,7 @@ declare module 'zapatos/schema' {
       */
       synopsis?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex = 'collection_localizations_pkey';
+    export type UniqueIndex = 'collection_localizations_pkey' | 'unique_by_collection_id_and_locale';
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
     export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
@@ -2837,7 +2837,7 @@ declare module 'zapatos/schema' {
       */
       synopsis?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex = 'episode_localizations_pkey';
+    export type UniqueIndex = 'episode_localizations_pkey' | 'unique_by_episode_id_and_locale';
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
     export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
@@ -4360,6 +4360,85 @@ declare module 'zapatos/schema' {
     export type SQL = SQLExpression | SQLExpression[];
   }
 
+  export namespace locales {
+    export type Table = 'locales';
+    export interface Selectable {
+      /**
+      * **locales.locale**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      locale: string;
+      /**
+      * **locales.is_default**
+      * - `bool` in database
+      * - `NOT NULL`, default: `false`
+      */
+      is_default: boolean;
+    }
+    export interface JSONSelectable {
+      /**
+      * **locales.locale**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      locale: string;
+      /**
+      * **locales.is_default**
+      * - `bool` in database
+      * - `NOT NULL`, default: `false`
+      */
+      is_default: boolean;
+    }
+    export interface Whereable {
+      /**
+      * **locales.locale**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      locale?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
+      /**
+      * **locales.is_default**
+      * - `bool` in database
+      * - `NOT NULL`, default: `false`
+      */
+      is_default?: boolean | db.Parameter<boolean> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, boolean | db.Parameter<boolean> | db.SQLFragment | db.ParentColumn>;
+    }
+    export interface Insertable {
+      /**
+      * **locales.locale**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      locale: string | db.Parameter<string> | db.SQLFragment;
+      /**
+      * **locales.is_default**
+      * - `bool` in database
+      * - `NOT NULL`, default: `false`
+      */
+      is_default?: boolean | db.Parameter<boolean> | db.DefaultType | db.SQLFragment;
+    }
+    export interface Updatable {
+      /**
+      * **locales.locale**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      locale?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+      * **locales.is_default**
+      * - `bool` in database
+      * - `NOT NULL`, default: `false`
+      */
+      is_default?: boolean | db.Parameter<boolean> | db.DefaultType | db.SQLFragment | db.SQLFragment<any, boolean | db.Parameter<boolean> | db.DefaultType | db.SQLFragment>;
+    }
+    export type UniqueIndex = 'locales_pkey';
+    export type Column = keyof Selectable;
+    export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
+    export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
+    export type SQL = SQLExpression | SQLExpression[];
+  }
+
   export namespace movie {
     export type Table = 'movie';
     export interface Selectable {
@@ -4830,7 +4909,7 @@ declare module 'zapatos/schema' {
       */
       title?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
     }
-    export type UniqueIndex = 'movie_genre_localizations_pkey';
+    export type UniqueIndex = 'movie_genre_localizations_pkey' | 'unique_by_movie_genre_id_and_locale';
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
     export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
@@ -5675,7 +5754,7 @@ declare module 'zapatos/schema' {
       */
       synopsis?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex = 'movie_localizations_pkey';
+    export type UniqueIndex = 'movie_localizations_pkey' | 'unique_by_movie_id_and_locale';
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
     export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
@@ -8971,7 +9050,7 @@ declare module 'zapatos/schema' {
       */
       synopsis?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex = 'season_localizations_pkey';
+    export type UniqueIndex = 'season_localizations_pkey' | 'unique_by_season_id_and_locale';
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
     export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
@@ -10904,7 +10983,7 @@ declare module 'zapatos/schema' {
       */
       title?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
     }
-    export type UniqueIndex = 'tvshow_genre_localizations_pkey';
+    export type UniqueIndex = 'tvshow_genre_localizations_pkey' | 'unique_by_tvshow_genre_id_and_locale';
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
     export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
@@ -11749,7 +11828,7 @@ declare module 'zapatos/schema' {
       */
       synopsis?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex = 'tvshow_localizations_pkey';
+    export type UniqueIndex = 'tvshow_localizations_pkey' | 'unique_by_tvshow_id_and_locale';
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
     export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
@@ -13311,15 +13390,15 @@ declare module 'zapatos/schema' {
 
   /* === cross-table types === */
 
-  export type Table = channel.Table | channel_images.Table | channel_localizations.Table | channel_view.Table | collection.Table | collection_images.Table | collection_items_relation.Table | collection_localizations.Table | collection_view.Table | episode.Table | episode_genres_relation.Table | episode_images.Table | episode_licenses.Table | episode_localizations.Table | episode_video_cue_points.Table | episode_video_streams.Table | episode_videos.Table | episode_view.Table | messaging_counter.Table | movie.Table | movie_genre.Table | movie_genre_localizations.Table | movie_genre_view.Table | movie_genres_relation.Table | movie_images.Table | movie_licenses.Table | movie_localizations.Table | movie_video_cue_points.Table | movie_video_streams.Table | movie_videos.Table | movie_view.Table | playlist.Table | program.Table | program_images.Table | program_localizations.Table | program_view.Table | season.Table | season_genres_relation.Table | season_images.Table | season_licenses.Table | season_localizations.Table | season_video_cue_points.Table | season_video_streams.Table | season_videos.Table | season_view.Table | tvshow.Table | tvshow_genre.Table | tvshow_genre_localizations.Table | tvshow_genre_view.Table | tvshow_genres_relation.Table | tvshow_images.Table | tvshow_licenses.Table | tvshow_localizations.Table | tvshow_video_cue_points.Table | tvshow_video_streams.Table | tvshow_videos.Table | tvshow_view.Table | video_stream_type.Table;
-  export type Selectable = channel.Selectable | channel_images.Selectable | channel_localizations.Selectable | channel_view.Selectable | collection.Selectable | collection_images.Selectable | collection_items_relation.Selectable | collection_localizations.Selectable | collection_view.Selectable | episode.Selectable | episode_genres_relation.Selectable | episode_images.Selectable | episode_licenses.Selectable | episode_localizations.Selectable | episode_video_cue_points.Selectable | episode_video_streams.Selectable | episode_videos.Selectable | episode_view.Selectable | messaging_counter.Selectable | movie.Selectable | movie_genre.Selectable | movie_genre_localizations.Selectable | movie_genre_view.Selectable | movie_genres_relation.Selectable | movie_images.Selectable | movie_licenses.Selectable | movie_localizations.Selectable | movie_video_cue_points.Selectable | movie_video_streams.Selectable | movie_videos.Selectable | movie_view.Selectable | playlist.Selectable | program.Selectable | program_images.Selectable | program_localizations.Selectable | program_view.Selectable | season.Selectable | season_genres_relation.Selectable | season_images.Selectable | season_licenses.Selectable | season_localizations.Selectable | season_video_cue_points.Selectable | season_video_streams.Selectable | season_videos.Selectable | season_view.Selectable | tvshow.Selectable | tvshow_genre.Selectable | tvshow_genre_localizations.Selectable | tvshow_genre_view.Selectable | tvshow_genres_relation.Selectable | tvshow_images.Selectable | tvshow_licenses.Selectable | tvshow_localizations.Selectable | tvshow_video_cue_points.Selectable | tvshow_video_streams.Selectable | tvshow_videos.Selectable | tvshow_view.Selectable | video_stream_type.Selectable;
-  export type JSONSelectable = channel.JSONSelectable | channel_images.JSONSelectable | channel_localizations.JSONSelectable | channel_view.JSONSelectable | collection.JSONSelectable | collection_images.JSONSelectable | collection_items_relation.JSONSelectable | collection_localizations.JSONSelectable | collection_view.JSONSelectable | episode.JSONSelectable | episode_genres_relation.JSONSelectable | episode_images.JSONSelectable | episode_licenses.JSONSelectable | episode_localizations.JSONSelectable | episode_video_cue_points.JSONSelectable | episode_video_streams.JSONSelectable | episode_videos.JSONSelectable | episode_view.JSONSelectable | messaging_counter.JSONSelectable | movie.JSONSelectable | movie_genre.JSONSelectable | movie_genre_localizations.JSONSelectable | movie_genre_view.JSONSelectable | movie_genres_relation.JSONSelectable | movie_images.JSONSelectable | movie_licenses.JSONSelectable | movie_localizations.JSONSelectable | movie_video_cue_points.JSONSelectable | movie_video_streams.JSONSelectable | movie_videos.JSONSelectable | movie_view.JSONSelectable | playlist.JSONSelectable | program.JSONSelectable | program_images.JSONSelectable | program_localizations.JSONSelectable | program_view.JSONSelectable | season.JSONSelectable | season_genres_relation.JSONSelectable | season_images.JSONSelectable | season_licenses.JSONSelectable | season_localizations.JSONSelectable | season_video_cue_points.JSONSelectable | season_video_streams.JSONSelectable | season_videos.JSONSelectable | season_view.JSONSelectable | tvshow.JSONSelectable | tvshow_genre.JSONSelectable | tvshow_genre_localizations.JSONSelectable | tvshow_genre_view.JSONSelectable | tvshow_genres_relation.JSONSelectable | tvshow_images.JSONSelectable | tvshow_licenses.JSONSelectable | tvshow_localizations.JSONSelectable | tvshow_video_cue_points.JSONSelectable | tvshow_video_streams.JSONSelectable | tvshow_videos.JSONSelectable | tvshow_view.JSONSelectable | video_stream_type.JSONSelectable;
-  export type Whereable = channel.Whereable | channel_images.Whereable | channel_localizations.Whereable | channel_view.Whereable | collection.Whereable | collection_images.Whereable | collection_items_relation.Whereable | collection_localizations.Whereable | collection_view.Whereable | episode.Whereable | episode_genres_relation.Whereable | episode_images.Whereable | episode_licenses.Whereable | episode_localizations.Whereable | episode_video_cue_points.Whereable | episode_video_streams.Whereable | episode_videos.Whereable | episode_view.Whereable | messaging_counter.Whereable | movie.Whereable | movie_genre.Whereable | movie_genre_localizations.Whereable | movie_genre_view.Whereable | movie_genres_relation.Whereable | movie_images.Whereable | movie_licenses.Whereable | movie_localizations.Whereable | movie_video_cue_points.Whereable | movie_video_streams.Whereable | movie_videos.Whereable | movie_view.Whereable | playlist.Whereable | program.Whereable | program_images.Whereable | program_localizations.Whereable | program_view.Whereable | season.Whereable | season_genres_relation.Whereable | season_images.Whereable | season_licenses.Whereable | season_localizations.Whereable | season_video_cue_points.Whereable | season_video_streams.Whereable | season_videos.Whereable | season_view.Whereable | tvshow.Whereable | tvshow_genre.Whereable | tvshow_genre_localizations.Whereable | tvshow_genre_view.Whereable | tvshow_genres_relation.Whereable | tvshow_images.Whereable | tvshow_licenses.Whereable | tvshow_localizations.Whereable | tvshow_video_cue_points.Whereable | tvshow_video_streams.Whereable | tvshow_videos.Whereable | tvshow_view.Whereable | video_stream_type.Whereable;
-  export type Insertable = channel.Insertable | channel_images.Insertable | channel_localizations.Insertable | channel_view.Insertable | collection.Insertable | collection_images.Insertable | collection_items_relation.Insertable | collection_localizations.Insertable | collection_view.Insertable | episode.Insertable | episode_genres_relation.Insertable | episode_images.Insertable | episode_licenses.Insertable | episode_localizations.Insertable | episode_video_cue_points.Insertable | episode_video_streams.Insertable | episode_videos.Insertable | episode_view.Insertable | messaging_counter.Insertable | movie.Insertable | movie_genre.Insertable | movie_genre_localizations.Insertable | movie_genre_view.Insertable | movie_genres_relation.Insertable | movie_images.Insertable | movie_licenses.Insertable | movie_localizations.Insertable | movie_video_cue_points.Insertable | movie_video_streams.Insertable | movie_videos.Insertable | movie_view.Insertable | playlist.Insertable | program.Insertable | program_images.Insertable | program_localizations.Insertable | program_view.Insertable | season.Insertable | season_genres_relation.Insertable | season_images.Insertable | season_licenses.Insertable | season_localizations.Insertable | season_video_cue_points.Insertable | season_video_streams.Insertable | season_videos.Insertable | season_view.Insertable | tvshow.Insertable | tvshow_genre.Insertable | tvshow_genre_localizations.Insertable | tvshow_genre_view.Insertable | tvshow_genres_relation.Insertable | tvshow_images.Insertable | tvshow_licenses.Insertable | tvshow_localizations.Insertable | tvshow_video_cue_points.Insertable | tvshow_video_streams.Insertable | tvshow_videos.Insertable | tvshow_view.Insertable | video_stream_type.Insertable;
-  export type Updatable = channel.Updatable | channel_images.Updatable | channel_localizations.Updatable | channel_view.Updatable | collection.Updatable | collection_images.Updatable | collection_items_relation.Updatable | collection_localizations.Updatable | collection_view.Updatable | episode.Updatable | episode_genres_relation.Updatable | episode_images.Updatable | episode_licenses.Updatable | episode_localizations.Updatable | episode_video_cue_points.Updatable | episode_video_streams.Updatable | episode_videos.Updatable | episode_view.Updatable | messaging_counter.Updatable | movie.Updatable | movie_genre.Updatable | movie_genre_localizations.Updatable | movie_genre_view.Updatable | movie_genres_relation.Updatable | movie_images.Updatable | movie_licenses.Updatable | movie_localizations.Updatable | movie_video_cue_points.Updatable | movie_video_streams.Updatable | movie_videos.Updatable | movie_view.Updatable | playlist.Updatable | program.Updatable | program_images.Updatable | program_localizations.Updatable | program_view.Updatable | season.Updatable | season_genres_relation.Updatable | season_images.Updatable | season_licenses.Updatable | season_localizations.Updatable | season_video_cue_points.Updatable | season_video_streams.Updatable | season_videos.Updatable | season_view.Updatable | tvshow.Updatable | tvshow_genre.Updatable | tvshow_genre_localizations.Updatable | tvshow_genre_view.Updatable | tvshow_genres_relation.Updatable | tvshow_images.Updatable | tvshow_licenses.Updatable | tvshow_localizations.Updatable | tvshow_video_cue_points.Updatable | tvshow_video_streams.Updatable | tvshow_videos.Updatable | tvshow_view.Updatable | video_stream_type.Updatable;
-  export type UniqueIndex = channel.UniqueIndex | channel_images.UniqueIndex | channel_localizations.UniqueIndex | channel_view.UniqueIndex | collection.UniqueIndex | collection_images.UniqueIndex | collection_items_relation.UniqueIndex | collection_localizations.UniqueIndex | collection_view.UniqueIndex | episode.UniqueIndex | episode_genres_relation.UniqueIndex | episode_images.UniqueIndex | episode_licenses.UniqueIndex | episode_localizations.UniqueIndex | episode_video_cue_points.UniqueIndex | episode_video_streams.UniqueIndex | episode_videos.UniqueIndex | episode_view.UniqueIndex | messaging_counter.UniqueIndex | movie.UniqueIndex | movie_genre.UniqueIndex | movie_genre_localizations.UniqueIndex | movie_genre_view.UniqueIndex | movie_genres_relation.UniqueIndex | movie_images.UniqueIndex | movie_licenses.UniqueIndex | movie_localizations.UniqueIndex | movie_video_cue_points.UniqueIndex | movie_video_streams.UniqueIndex | movie_videos.UniqueIndex | movie_view.UniqueIndex | playlist.UniqueIndex | program.UniqueIndex | program_images.UniqueIndex | program_localizations.UniqueIndex | program_view.UniqueIndex | season.UniqueIndex | season_genres_relation.UniqueIndex | season_images.UniqueIndex | season_licenses.UniqueIndex | season_localizations.UniqueIndex | season_video_cue_points.UniqueIndex | season_video_streams.UniqueIndex | season_videos.UniqueIndex | season_view.UniqueIndex | tvshow.UniqueIndex | tvshow_genre.UniqueIndex | tvshow_genre_localizations.UniqueIndex | tvshow_genre_view.UniqueIndex | tvshow_genres_relation.UniqueIndex | tvshow_images.UniqueIndex | tvshow_licenses.UniqueIndex | tvshow_localizations.UniqueIndex | tvshow_video_cue_points.UniqueIndex | tvshow_video_streams.UniqueIndex | tvshow_videos.UniqueIndex | tvshow_view.UniqueIndex | video_stream_type.UniqueIndex;
-  export type Column = channel.Column | channel_images.Column | channel_localizations.Column | channel_view.Column | collection.Column | collection_images.Column | collection_items_relation.Column | collection_localizations.Column | collection_view.Column | episode.Column | episode_genres_relation.Column | episode_images.Column | episode_licenses.Column | episode_localizations.Column | episode_video_cue_points.Column | episode_video_streams.Column | episode_videos.Column | episode_view.Column | messaging_counter.Column | movie.Column | movie_genre.Column | movie_genre_localizations.Column | movie_genre_view.Column | movie_genres_relation.Column | movie_images.Column | movie_licenses.Column | movie_localizations.Column | movie_video_cue_points.Column | movie_video_streams.Column | movie_videos.Column | movie_view.Column | playlist.Column | program.Column | program_images.Column | program_localizations.Column | program_view.Column | season.Column | season_genres_relation.Column | season_images.Column | season_licenses.Column | season_localizations.Column | season_video_cue_points.Column | season_video_streams.Column | season_videos.Column | season_view.Column | tvshow.Column | tvshow_genre.Column | tvshow_genre_localizations.Column | tvshow_genre_view.Column | tvshow_genres_relation.Column | tvshow_images.Column | tvshow_licenses.Column | tvshow_localizations.Column | tvshow_video_cue_points.Column | tvshow_video_streams.Column | tvshow_videos.Column | tvshow_view.Column | video_stream_type.Column;
-  export type AllTables = [channel.Table, channel_images.Table, channel_localizations.Table, channel_view.Table, collection.Table, collection_images.Table, collection_items_relation.Table, collection_localizations.Table, collection_view.Table, episode.Table, episode_genres_relation.Table, episode_images.Table, episode_licenses.Table, episode_localizations.Table, episode_video_cue_points.Table, episode_video_streams.Table, episode_videos.Table, episode_view.Table, messaging_counter.Table, movie.Table, movie_genre.Table, movie_genre_localizations.Table, movie_genre_view.Table, movie_genres_relation.Table, movie_images.Table, movie_licenses.Table, movie_localizations.Table, movie_video_cue_points.Table, movie_video_streams.Table, movie_videos.Table, movie_view.Table, playlist.Table, program.Table, program_images.Table, program_localizations.Table, program_view.Table, season.Table, season_genres_relation.Table, season_images.Table, season_licenses.Table, season_localizations.Table, season_video_cue_points.Table, season_video_streams.Table, season_videos.Table, season_view.Table, tvshow.Table, tvshow_genre.Table, tvshow_genre_localizations.Table, tvshow_genre_view.Table, tvshow_genres_relation.Table, tvshow_images.Table, tvshow_licenses.Table, tvshow_localizations.Table, tvshow_video_cue_points.Table, tvshow_video_streams.Table, tvshow_videos.Table, tvshow_view.Table, video_stream_type.Table];
+  export type Table = channel.Table | channel_images.Table | channel_localizations.Table | channel_view.Table | collection.Table | collection_images.Table | collection_items_relation.Table | collection_localizations.Table | collection_view.Table | episode.Table | episode_genres_relation.Table | episode_images.Table | episode_licenses.Table | episode_localizations.Table | episode_video_cue_points.Table | episode_video_streams.Table | episode_videos.Table | episode_view.Table | locales.Table | messaging_counter.Table | movie.Table | movie_genre.Table | movie_genre_localizations.Table | movie_genre_view.Table | movie_genres_relation.Table | movie_images.Table | movie_licenses.Table | movie_localizations.Table | movie_video_cue_points.Table | movie_video_streams.Table | movie_videos.Table | movie_view.Table | playlist.Table | program.Table | program_images.Table | program_localizations.Table | program_view.Table | season.Table | season_genres_relation.Table | season_images.Table | season_licenses.Table | season_localizations.Table | season_video_cue_points.Table | season_video_streams.Table | season_videos.Table | season_view.Table | tvshow.Table | tvshow_genre.Table | tvshow_genre_localizations.Table | tvshow_genre_view.Table | tvshow_genres_relation.Table | tvshow_images.Table | tvshow_licenses.Table | tvshow_localizations.Table | tvshow_video_cue_points.Table | tvshow_video_streams.Table | tvshow_videos.Table | tvshow_view.Table | video_stream_type.Table;
+  export type Selectable = channel.Selectable | channel_images.Selectable | channel_localizations.Selectable | channel_view.Selectable | collection.Selectable | collection_images.Selectable | collection_items_relation.Selectable | collection_localizations.Selectable | collection_view.Selectable | episode.Selectable | episode_genres_relation.Selectable | episode_images.Selectable | episode_licenses.Selectable | episode_localizations.Selectable | episode_video_cue_points.Selectable | episode_video_streams.Selectable | episode_videos.Selectable | episode_view.Selectable | locales.Selectable | messaging_counter.Selectable | movie.Selectable | movie_genre.Selectable | movie_genre_localizations.Selectable | movie_genre_view.Selectable | movie_genres_relation.Selectable | movie_images.Selectable | movie_licenses.Selectable | movie_localizations.Selectable | movie_video_cue_points.Selectable | movie_video_streams.Selectable | movie_videos.Selectable | movie_view.Selectable | playlist.Selectable | program.Selectable | program_images.Selectable | program_localizations.Selectable | program_view.Selectable | season.Selectable | season_genres_relation.Selectable | season_images.Selectable | season_licenses.Selectable | season_localizations.Selectable | season_video_cue_points.Selectable | season_video_streams.Selectable | season_videos.Selectable | season_view.Selectable | tvshow.Selectable | tvshow_genre.Selectable | tvshow_genre_localizations.Selectable | tvshow_genre_view.Selectable | tvshow_genres_relation.Selectable | tvshow_images.Selectable | tvshow_licenses.Selectable | tvshow_localizations.Selectable | tvshow_video_cue_points.Selectable | tvshow_video_streams.Selectable | tvshow_videos.Selectable | tvshow_view.Selectable | video_stream_type.Selectable;
+  export type JSONSelectable = channel.JSONSelectable | channel_images.JSONSelectable | channel_localizations.JSONSelectable | channel_view.JSONSelectable | collection.JSONSelectable | collection_images.JSONSelectable | collection_items_relation.JSONSelectable | collection_localizations.JSONSelectable | collection_view.JSONSelectable | episode.JSONSelectable | episode_genres_relation.JSONSelectable | episode_images.JSONSelectable | episode_licenses.JSONSelectable | episode_localizations.JSONSelectable | episode_video_cue_points.JSONSelectable | episode_video_streams.JSONSelectable | episode_videos.JSONSelectable | episode_view.JSONSelectable | locales.JSONSelectable | messaging_counter.JSONSelectable | movie.JSONSelectable | movie_genre.JSONSelectable | movie_genre_localizations.JSONSelectable | movie_genre_view.JSONSelectable | movie_genres_relation.JSONSelectable | movie_images.JSONSelectable | movie_licenses.JSONSelectable | movie_localizations.JSONSelectable | movie_video_cue_points.JSONSelectable | movie_video_streams.JSONSelectable | movie_videos.JSONSelectable | movie_view.JSONSelectable | playlist.JSONSelectable | program.JSONSelectable | program_images.JSONSelectable | program_localizations.JSONSelectable | program_view.JSONSelectable | season.JSONSelectable | season_genres_relation.JSONSelectable | season_images.JSONSelectable | season_licenses.JSONSelectable | season_localizations.JSONSelectable | season_video_cue_points.JSONSelectable | season_video_streams.JSONSelectable | season_videos.JSONSelectable | season_view.JSONSelectable | tvshow.JSONSelectable | tvshow_genre.JSONSelectable | tvshow_genre_localizations.JSONSelectable | tvshow_genre_view.JSONSelectable | tvshow_genres_relation.JSONSelectable | tvshow_images.JSONSelectable | tvshow_licenses.JSONSelectable | tvshow_localizations.JSONSelectable | tvshow_video_cue_points.JSONSelectable | tvshow_video_streams.JSONSelectable | tvshow_videos.JSONSelectable | tvshow_view.JSONSelectable | video_stream_type.JSONSelectable;
+  export type Whereable = channel.Whereable | channel_images.Whereable | channel_localizations.Whereable | channel_view.Whereable | collection.Whereable | collection_images.Whereable | collection_items_relation.Whereable | collection_localizations.Whereable | collection_view.Whereable | episode.Whereable | episode_genres_relation.Whereable | episode_images.Whereable | episode_licenses.Whereable | episode_localizations.Whereable | episode_video_cue_points.Whereable | episode_video_streams.Whereable | episode_videos.Whereable | episode_view.Whereable | locales.Whereable | messaging_counter.Whereable | movie.Whereable | movie_genre.Whereable | movie_genre_localizations.Whereable | movie_genre_view.Whereable | movie_genres_relation.Whereable | movie_images.Whereable | movie_licenses.Whereable | movie_localizations.Whereable | movie_video_cue_points.Whereable | movie_video_streams.Whereable | movie_videos.Whereable | movie_view.Whereable | playlist.Whereable | program.Whereable | program_images.Whereable | program_localizations.Whereable | program_view.Whereable | season.Whereable | season_genres_relation.Whereable | season_images.Whereable | season_licenses.Whereable | season_localizations.Whereable | season_video_cue_points.Whereable | season_video_streams.Whereable | season_videos.Whereable | season_view.Whereable | tvshow.Whereable | tvshow_genre.Whereable | tvshow_genre_localizations.Whereable | tvshow_genre_view.Whereable | tvshow_genres_relation.Whereable | tvshow_images.Whereable | tvshow_licenses.Whereable | tvshow_localizations.Whereable | tvshow_video_cue_points.Whereable | tvshow_video_streams.Whereable | tvshow_videos.Whereable | tvshow_view.Whereable | video_stream_type.Whereable;
+  export type Insertable = channel.Insertable | channel_images.Insertable | channel_localizations.Insertable | channel_view.Insertable | collection.Insertable | collection_images.Insertable | collection_items_relation.Insertable | collection_localizations.Insertable | collection_view.Insertable | episode.Insertable | episode_genres_relation.Insertable | episode_images.Insertable | episode_licenses.Insertable | episode_localizations.Insertable | episode_video_cue_points.Insertable | episode_video_streams.Insertable | episode_videos.Insertable | episode_view.Insertable | locales.Insertable | messaging_counter.Insertable | movie.Insertable | movie_genre.Insertable | movie_genre_localizations.Insertable | movie_genre_view.Insertable | movie_genres_relation.Insertable | movie_images.Insertable | movie_licenses.Insertable | movie_localizations.Insertable | movie_video_cue_points.Insertable | movie_video_streams.Insertable | movie_videos.Insertable | movie_view.Insertable | playlist.Insertable | program.Insertable | program_images.Insertable | program_localizations.Insertable | program_view.Insertable | season.Insertable | season_genres_relation.Insertable | season_images.Insertable | season_licenses.Insertable | season_localizations.Insertable | season_video_cue_points.Insertable | season_video_streams.Insertable | season_videos.Insertable | season_view.Insertable | tvshow.Insertable | tvshow_genre.Insertable | tvshow_genre_localizations.Insertable | tvshow_genre_view.Insertable | tvshow_genres_relation.Insertable | tvshow_images.Insertable | tvshow_licenses.Insertable | tvshow_localizations.Insertable | tvshow_video_cue_points.Insertable | tvshow_video_streams.Insertable | tvshow_videos.Insertable | tvshow_view.Insertable | video_stream_type.Insertable;
+  export type Updatable = channel.Updatable | channel_images.Updatable | channel_localizations.Updatable | channel_view.Updatable | collection.Updatable | collection_images.Updatable | collection_items_relation.Updatable | collection_localizations.Updatable | collection_view.Updatable | episode.Updatable | episode_genres_relation.Updatable | episode_images.Updatable | episode_licenses.Updatable | episode_localizations.Updatable | episode_video_cue_points.Updatable | episode_video_streams.Updatable | episode_videos.Updatable | episode_view.Updatable | locales.Updatable | messaging_counter.Updatable | movie.Updatable | movie_genre.Updatable | movie_genre_localizations.Updatable | movie_genre_view.Updatable | movie_genres_relation.Updatable | movie_images.Updatable | movie_licenses.Updatable | movie_localizations.Updatable | movie_video_cue_points.Updatable | movie_video_streams.Updatable | movie_videos.Updatable | movie_view.Updatable | playlist.Updatable | program.Updatable | program_images.Updatable | program_localizations.Updatable | program_view.Updatable | season.Updatable | season_genres_relation.Updatable | season_images.Updatable | season_licenses.Updatable | season_localizations.Updatable | season_video_cue_points.Updatable | season_video_streams.Updatable | season_videos.Updatable | season_view.Updatable | tvshow.Updatable | tvshow_genre.Updatable | tvshow_genre_localizations.Updatable | tvshow_genre_view.Updatable | tvshow_genres_relation.Updatable | tvshow_images.Updatable | tvshow_licenses.Updatable | tvshow_localizations.Updatable | tvshow_video_cue_points.Updatable | tvshow_video_streams.Updatable | tvshow_videos.Updatable | tvshow_view.Updatable | video_stream_type.Updatable;
+  export type UniqueIndex = channel.UniqueIndex | channel_images.UniqueIndex | channel_localizations.UniqueIndex | channel_view.UniqueIndex | collection.UniqueIndex | collection_images.UniqueIndex | collection_items_relation.UniqueIndex | collection_localizations.UniqueIndex | collection_view.UniqueIndex | episode.UniqueIndex | episode_genres_relation.UniqueIndex | episode_images.UniqueIndex | episode_licenses.UniqueIndex | episode_localizations.UniqueIndex | episode_video_cue_points.UniqueIndex | episode_video_streams.UniqueIndex | episode_videos.UniqueIndex | episode_view.UniqueIndex | locales.UniqueIndex | messaging_counter.UniqueIndex | movie.UniqueIndex | movie_genre.UniqueIndex | movie_genre_localizations.UniqueIndex | movie_genre_view.UniqueIndex | movie_genres_relation.UniqueIndex | movie_images.UniqueIndex | movie_licenses.UniqueIndex | movie_localizations.UniqueIndex | movie_video_cue_points.UniqueIndex | movie_video_streams.UniqueIndex | movie_videos.UniqueIndex | movie_view.UniqueIndex | playlist.UniqueIndex | program.UniqueIndex | program_images.UniqueIndex | program_localizations.UniqueIndex | program_view.UniqueIndex | season.UniqueIndex | season_genres_relation.UniqueIndex | season_images.UniqueIndex | season_licenses.UniqueIndex | season_localizations.UniqueIndex | season_video_cue_points.UniqueIndex | season_video_streams.UniqueIndex | season_videos.UniqueIndex | season_view.UniqueIndex | tvshow.UniqueIndex | tvshow_genre.UniqueIndex | tvshow_genre_localizations.UniqueIndex | tvshow_genre_view.UniqueIndex | tvshow_genres_relation.UniqueIndex | tvshow_images.UniqueIndex | tvshow_licenses.UniqueIndex | tvshow_localizations.UniqueIndex | tvshow_video_cue_points.UniqueIndex | tvshow_video_streams.UniqueIndex | tvshow_videos.UniqueIndex | tvshow_view.UniqueIndex | video_stream_type.UniqueIndex;
+  export type Column = channel.Column | channel_images.Column | channel_localizations.Column | channel_view.Column | collection.Column | collection_images.Column | collection_items_relation.Column | collection_localizations.Column | collection_view.Column | episode.Column | episode_genres_relation.Column | episode_images.Column | episode_licenses.Column | episode_localizations.Column | episode_video_cue_points.Column | episode_video_streams.Column | episode_videos.Column | episode_view.Column | locales.Column | messaging_counter.Column | movie.Column | movie_genre.Column | movie_genre_localizations.Column | movie_genre_view.Column | movie_genres_relation.Column | movie_images.Column | movie_licenses.Column | movie_localizations.Column | movie_video_cue_points.Column | movie_video_streams.Column | movie_videos.Column | movie_view.Column | playlist.Column | program.Column | program_images.Column | program_localizations.Column | program_view.Column | season.Column | season_genres_relation.Column | season_images.Column | season_licenses.Column | season_localizations.Column | season_video_cue_points.Column | season_video_streams.Column | season_videos.Column | season_view.Column | tvshow.Column | tvshow_genre.Column | tvshow_genre_localizations.Column | tvshow_genre_view.Column | tvshow_genres_relation.Column | tvshow_images.Column | tvshow_licenses.Column | tvshow_localizations.Column | tvshow_video_cue_points.Column | tvshow_video_streams.Column | tvshow_videos.Column | tvshow_view.Column | video_stream_type.Column;
+  export type AllTables = [channel.Table, channel_images.Table, channel_localizations.Table, channel_view.Table, collection.Table, collection_images.Table, collection_items_relation.Table, collection_localizations.Table, collection_view.Table, episode.Table, episode_genres_relation.Table, episode_images.Table, episode_licenses.Table, episode_localizations.Table, episode_video_cue_points.Table, episode_video_streams.Table, episode_videos.Table, episode_view.Table, locales.Table, messaging_counter.Table, movie.Table, movie_genre.Table, movie_genre_localizations.Table, movie_genre_view.Table, movie_genres_relation.Table, movie_images.Table, movie_licenses.Table, movie_localizations.Table, movie_video_cue_points.Table, movie_video_streams.Table, movie_videos.Table, movie_view.Table, playlist.Table, program.Table, program_images.Table, program_localizations.Table, program_view.Table, season.Table, season_genres_relation.Table, season_images.Table, season_licenses.Table, season_localizations.Table, season_video_cue_points.Table, season_video_streams.Table, season_videos.Table, season_view.Table, tvshow.Table, tvshow_genre.Table, tvshow_genre_localizations.Table, tvshow_genre_view.Table, tvshow_genres_relation.Table, tvshow_images.Table, tvshow_licenses.Table, tvshow_localizations.Table, tvshow_video_cue_points.Table, tvshow_video_streams.Table, tvshow_videos.Table, tvshow_view.Table, video_stream_type.Table];
   export type AllMaterializedViews = [];
 
 
@@ -13342,6 +13421,7 @@ declare module 'zapatos/schema' {
     episode_video_streams: episode_video_streams.Selectable;
     episode_videos: episode_videos.Selectable;
     episode_view: episode_view.Selectable;
+    locales: locales.Selectable;
     messaging_counter: messaging_counter.Selectable;
     movie: movie.Selectable;
     movie_genre: movie_genre.Selectable;
@@ -13403,6 +13483,7 @@ declare module 'zapatos/schema' {
     episode_video_streams: episode_video_streams.JSONSelectable;
     episode_videos: episode_videos.JSONSelectable;
     episode_view: episode_view.JSONSelectable;
+    locales: locales.JSONSelectable;
     messaging_counter: messaging_counter.JSONSelectable;
     movie: movie.JSONSelectable;
     movie_genre: movie_genre.JSONSelectable;
@@ -13464,6 +13545,7 @@ declare module 'zapatos/schema' {
     episode_video_streams: episode_video_streams.Whereable;
     episode_videos: episode_videos.Whereable;
     episode_view: episode_view.Whereable;
+    locales: locales.Whereable;
     messaging_counter: messaging_counter.Whereable;
     movie: movie.Whereable;
     movie_genre: movie_genre.Whereable;
@@ -13525,6 +13607,7 @@ declare module 'zapatos/schema' {
     episode_video_streams: episode_video_streams.Insertable;
     episode_videos: episode_videos.Insertable;
     episode_view: episode_view.Insertable;
+    locales: locales.Insertable;
     messaging_counter: messaging_counter.Insertable;
     movie: movie.Insertable;
     movie_genre: movie_genre.Insertable;
@@ -13586,6 +13669,7 @@ declare module 'zapatos/schema' {
     episode_video_streams: episode_video_streams.Updatable;
     episode_videos: episode_videos.Updatable;
     episode_view: episode_view.Updatable;
+    locales: locales.Updatable;
     messaging_counter: messaging_counter.Updatable;
     movie: movie.Updatable;
     movie_genre: movie_genre.Updatable;
@@ -13647,6 +13731,7 @@ declare module 'zapatos/schema' {
     episode_video_streams: episode_video_streams.UniqueIndex;
     episode_videos: episode_videos.UniqueIndex;
     episode_view: episode_view.UniqueIndex;
+    locales: locales.UniqueIndex;
     messaging_counter: messaging_counter.UniqueIndex;
     movie: movie.UniqueIndex;
     movie_genre: movie_genre.UniqueIndex;
@@ -13708,6 +13793,7 @@ declare module 'zapatos/schema' {
     episode_video_streams: episode_video_streams.Column;
     episode_videos: episode_videos.Column;
     episode_view: episode_view.Column;
+    locales: locales.Column;
     messaging_counter: messaging_counter.Column;
     movie: movie.Column;
     movie_genre: movie_genre.Column;
@@ -13769,6 +13855,7 @@ declare module 'zapatos/schema' {
     episode_video_streams: episode_video_streams.SQL;
     episode_videos: episode_videos.SQL;
     episode_view: episode_view.SQL;
+    locales: locales.SQL;
     messaging_counter: messaging_counter.SQL;
     movie: movie.SQL;
     movie_genre: movie_genre.SQL;

--- a/services/catalog/service/src/generated/db/zapatos/schema.d.ts
+++ b/services/catalog/service/src/generated/db/zapatos/schema.d.ts
@@ -678,7 +678,7 @@ declare module 'zapatos/schema' {
       */
       description?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex = 'channel_localizations_pkey';
+    export type UniqueIndex = 'channel_localizations_pkey' | 'unique_by_channel_id_and_locale';
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
     export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
@@ -7886,7 +7886,7 @@ declare module 'zapatos/schema' {
       */
       title?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
     }
-    export type UniqueIndex = 'program_localizations_pkey';
+    export type UniqueIndex = 'program_localizations_pkey' | 'unique_by_program_id_and_locale';
     export type Column = keyof Selectable;
     export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
     export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;

--- a/services/catalog/service/src/generated/graphql/schema.graphql
+++ b/services/catalog/service/src/generated/graphql/schema.graphql
@@ -108,6 +108,40 @@ type Query {
     filter: EpisodeFilter
   ): EpisodesConnection
 
+  """Reads and enables pagination through a set of `Locale`."""
+  locales(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Locale`."""
+    orderBy: [LocalesOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: LocaleCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: LocaleFilter
+  ): LocalesConnection
+
   """Reads and enables pagination through a set of `MovieGenre`."""
   movieGenres(
     """Only read the first `n` values of the set."""
@@ -314,6 +348,7 @@ type Query {
   channel(id: String!): Channel
   collection(id: String!): Collection
   episode(id: String!, countryCode: String): Episode
+  locale(locale: String!): Locale
   movieGenre(id: String!): MovieGenre
   movie(id: String!, countryCode: String): Movie
   playlist(id: String!): Playlist
@@ -3174,6 +3209,8 @@ enum EpisodesOrderBy {
   ID_DESC
   SEASON_ID_ASC
   SEASON_ID_DESC
+  TITLE_ASC
+  TITLE_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -3187,6 +3224,9 @@ input EpisodeCondition {
 
   """Checks for equality with the object’s `seasonId` field."""
   seasonId: String
+
+  """Checks for equality with the object’s `title` field."""
+  title: String
 }
 
 """
@@ -3198,6 +3238,9 @@ input EpisodeFilter {
 
   """Filter by the object’s `seasonId` field."""
   seasonId: StringFilter
+
+  """Filter by the object’s `title` field."""
+  title: StringFilter
 
   """Checks for all expressions in this list."""
   and: [EpisodeFilter!]
@@ -5198,6 +5241,8 @@ enum CollectionsOrderBy {
   NATURAL
   ID_ASC
   ID_DESC
+  TITLE_ASC
+  TITLE_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -5209,6 +5254,9 @@ for equality and combined with a logical ‘and.’
 input CollectionCondition {
   """Checks for equality with the object’s `id` field."""
   id: String
+
+  """Checks for equality with the object’s `title` field."""
+  title: String
 }
 
 """
@@ -5218,6 +5266,9 @@ input CollectionFilter {
   """Filter by the object’s `id` field."""
   id: StringFilter
 
+  """Filter by the object’s `title` field."""
+  title: StringFilter
+
   """Checks for all expressions in this list."""
   and: [CollectionFilter!]
 
@@ -5226,6 +5277,121 @@ input CollectionFilter {
 
   """Negates the expression."""
   not: CollectionFilter
+}
+
+"""A connection to a list of `Locale` values."""
+type LocalesConnection {
+  """A list of `Locale` objects."""
+  nodes: [Locale!]!
+
+  """
+  A list of edges which contains the `Locale` and cursor to aid in pagination.
+  """
+  edges: [LocalesEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Locale` you could get from the connection."""
+  totalCount: Int!
+}
+
+type Locale {
+  locale: String!
+  isDefault: Boolean!
+}
+
+"""A `Locale` edge in the connection."""
+type LocalesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Locale` at the end of the edge."""
+  node: Locale!
+}
+
+"""Methods to use when ordering `Locale`."""
+enum LocalesOrderBy {
+  NATURAL
+  LOCALE_ASC
+  LOCALE_DESC
+  IS_DEFAULT_ASC
+  IS_DEFAULT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Locale` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input LocaleCondition {
+  """Checks for equality with the object’s `locale` field."""
+  locale: String
+
+  """Checks for equality with the object’s `isDefault` field."""
+  isDefault: Boolean
+}
+
+"""
+A filter to be used against `Locale` object types. All fields are combined with a logical ‘and.’
+"""
+input LocaleFilter {
+  """Filter by the object’s `locale` field."""
+  locale: StringFilter
+
+  """Filter by the object’s `isDefault` field."""
+  isDefault: BooleanFilter
+
+  """Checks for all expressions in this list."""
+  and: [LocaleFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [LocaleFilter!]
+
+  """Negates the expression."""
+  not: LocaleFilter
+}
+
+"""
+A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
+"""
+input BooleanFilter {
+  """
+  Is null (if `true` is specified) or is not null (if `false` is specified).
+  """
+  isNull: Boolean
+
+  """Equal to the specified value."""
+  equalTo: Boolean
+
+  """Not equal to the specified value."""
+  notEqualTo: Boolean
+
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Boolean
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Boolean
+
+  """Included in the specified list."""
+  in: [Boolean!]
+
+  """Not included in the specified list."""
+  notIn: [Boolean!]
+
+  """Less than the specified value."""
+  lessThan: Boolean
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Boolean
+
+  """Greater than the specified value."""
+  greaterThan: Boolean
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Boolean
 }
 
 """A connection to a list of `MovieGenre` values."""
@@ -5261,6 +5427,8 @@ enum MovieGenresOrderBy {
   ID_DESC
   ORDER_NO_ASC
   ORDER_NO_DESC
+  TITLE_ASC
+  TITLE_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -5275,6 +5443,9 @@ input MovieGenreCondition {
 
   """Checks for equality with the object’s `orderNo` field."""
   orderNo: Int
+
+  """Checks for equality with the object’s `title` field."""
+  title: String
 }
 
 """
@@ -5286,6 +5457,9 @@ input MovieGenreFilter {
 
   """Filter by the object’s `orderNo` field."""
   orderNo: IntFilter
+
+  """Filter by the object’s `title` field."""
+  title: StringFilter
 
   """Checks for all expressions in this list."""
   and: [MovieGenreFilter!]
@@ -5328,6 +5502,8 @@ enum MoviesOrderBy {
   NATURAL
   ID_ASC
   ID_DESC
+  TITLE_ASC
+  TITLE_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -5338,6 +5514,9 @@ A condition to be used against `Movie` object types. All fields are tested for e
 input MovieCondition {
   """Checks for equality with the object’s `id` field."""
   id: String
+
+  """Checks for equality with the object’s `title` field."""
+  title: String
 }
 
 """
@@ -5346,6 +5525,9 @@ A filter to be used against `Movie` object types. All fields are combined with a
 input MovieFilter {
   """Filter by the object’s `id` field."""
   id: StringFilter
+
+  """Filter by the object’s `title` field."""
+  title: StringFilter
 
   """Checks for all expressions in this list."""
   and: [MovieFilter!]
@@ -5390,6 +5572,8 @@ enum TvshowGenresOrderBy {
   ID_DESC
   ORDER_NO_ASC
   ORDER_NO_DESC
+  TITLE_ASC
+  TITLE_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -5404,6 +5588,9 @@ input TvshowGenreCondition {
 
   """Checks for equality with the object’s `orderNo` field."""
   orderNo: Int
+
+  """Checks for equality with the object’s `title` field."""
+  title: String
 }
 
 """
@@ -5415,6 +5602,9 @@ input TvshowGenreFilter {
 
   """Filter by the object’s `orderNo` field."""
   orderNo: IntFilter
+
+  """Filter by the object’s `title` field."""
+  title: StringFilter
 
   """Checks for all expressions in this list."""
   and: [TvshowGenreFilter!]
@@ -5457,6 +5647,8 @@ enum TvshowsOrderBy {
   NATURAL
   ID_ASC
   ID_DESC
+  TITLE_ASC
+  TITLE_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -5467,6 +5659,9 @@ A condition to be used against `Tvshow` object types. All fields are tested for 
 input TvshowCondition {
   """Checks for equality with the object’s `id` field."""
   id: String
+
+  """Checks for equality with the object’s `title` field."""
+  title: String
 }
 
 """
@@ -5475,6 +5670,9 @@ A filter to be used against `Tvshow` object types. All fields are combined with 
 input TvshowFilter {
   """Filter by the object’s `id` field."""
   id: StringFilter
+
+  """Filter by the object’s `title` field."""
+  title: StringFilter
 
   """Checks for all expressions in this list."""
   and: [TvshowFilter!]

--- a/services/catalog/service/src/generated/graphql/schema.graphql
+++ b/services/catalog/service/src/generated/graphql/schema.graphql
@@ -848,6 +848,8 @@ type Program {
 
   """The episode ID."""
   episodeId: String
+
+  """Title of the program."""
   title: String
 
   """Reads a single `Playlist` that is related to this `Program`."""
@@ -4853,6 +4855,8 @@ enum ChannelsOrderBy {
   NATURAL
   ID_ASC
   ID_DESC
+  TITLE_ASC
+  TITLE_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -4863,6 +4867,9 @@ A condition to be used against `Channel` object types. All fields are tested for
 input ChannelCondition {
   """Checks for equality with the object’s `id` field."""
   id: String
+
+  """Checks for equality with the object’s `title` field."""
+  title: String
 }
 
 """
@@ -4871,6 +4878,9 @@ A filter to be used against `Channel` object types. All fields are combined with
 input ChannelFilter {
   """Filter by the object’s `id` field."""
   id: StringFilter
+
+  """Filter by the object’s `title` field."""
+  title: StringFilter
 
   """Checks for all expressions in this list."""
   and: [ChannelFilter!]

--- a/services/catalog/service/src/graphql/plugins/smart-tags-plugin.ts
+++ b/services/catalog/service/src/graphql/plugins/smart-tags-plugin.ts
@@ -14,7 +14,6 @@ export const SmartTagsPlugin = makeJSONPgSmartTagsPlugin({
         attribute: {
           title: {
             description: 'Title of the movie.',
-            ...disableFilterAndOrder,
           },
           original_title: {
             description: 'Original title of the movie.',
@@ -300,7 +299,6 @@ export const SmartTagsPlugin = makeJSONPgSmartTagsPlugin({
         attribute: {
           title: {
             description: 'Title of the genre.',
-            ...disableFilterAndOrder,
           },
           order_no: {
             description: 'Global ordering number for the genre.',
@@ -315,7 +313,6 @@ export const SmartTagsPlugin = makeJSONPgSmartTagsPlugin({
         attribute: {
           title: {
             description: 'Title of the TV show.',
-            ...disableFilterAndOrder,
           },
           synopsis: {
             description: 'Short description of the main plot elements.',
@@ -602,7 +599,6 @@ export const SmartTagsPlugin = makeJSONPgSmartTagsPlugin({
         attribute: {
           title: {
             description: 'Title of the genre.',
-            ...disableFilterAndOrder,
           },
           order_no: {
             description: 'Global ordering number for the genre.',
@@ -902,7 +898,6 @@ export const SmartTagsPlugin = makeJSONPgSmartTagsPlugin({
         attribute: {
           title: {
             description: 'Title of the episode.',
-            ...disableFilterAndOrder,
           },
           synopsis: {
             description: 'Short description of the main plot elements.',
@@ -1194,7 +1189,6 @@ export const SmartTagsPlugin = makeJSONPgSmartTagsPlugin({
         attribute: {
           title: {
             description: 'Title of the collection.',
-            ...disableFilterAndOrder,
           },
           synopsis: {
             description: 'Short description.',

--- a/services/catalog/service/src/graphql/plugins/smart-tags-plugin.ts
+++ b/services/catalog/service/src/graphql/plugins/smart-tags-plugin.ts
@@ -1259,7 +1259,6 @@ export const SmartTagsPlugin = makeJSONPgSmartTagsPlugin({
         attribute: {
           title: {
             description: 'Title of the channel.',
-            ...disableFilterAndOrder,
           },
           description: {
             description: 'Description of the channel.',
@@ -1336,6 +1335,9 @@ export const SmartTagsPlugin = makeJSONPgSmartTagsPlugin({
       program_view: {
         description: 'Definition of the program object.',
         attribute: {
+          title: {
+            description: 'Title of the program.',
+          },
           sort_index: {
             description: 'The sort index of the program.',
             tags: { omit: 'filter' },

--- a/services/catalog/service/src/graphql/postgraphile-options.ts
+++ b/services/catalog/service/src/graphql/postgraphile-options.ts
@@ -17,8 +17,8 @@ import {
   catalogLogMapper,
   CommonErrors,
   Config,
+  getMosaicLocaleSetting,
   MOSAIC_LOCALE_HEADER_KEY,
-  MOSAIC_LOCALE_PG_KEY,
 } from '../common';
 import { AllChannelPlugins } from '../domains/channels/plugins/all-channel-plugins';
 import { AllCollectionPlugins } from '../domains/collections/plugins/all-collection-plugins';
@@ -45,7 +45,7 @@ export function buildPostgraphileOptions(
     })
     .setPgSettings(async (req) => ({
       role: config.dbGqlRole,
-      [MOSAIC_LOCALE_PG_KEY]: req.headers[MOSAIC_LOCALE_HEADER_KEY],
+      ...getMosaicLocaleSetting(req),
     }))
     .addPlugins(
       PgSimplifyInflectorPlugin,

--- a/services/catalog/service/src/index.ts
+++ b/services/catalog/service/src/index.ts
@@ -22,7 +22,7 @@ import {
 import express from 'express';
 import { PoolConfig } from 'pg';
 import { postgraphile } from 'postgraphile';
-import { applyMigrations, getFullConfig } from './common';
+import { applyMigrations, getFullConfig, loadInMemoryLocales } from './common';
 import { registerMessaging } from './domains/register-messaging';
 import { buildPostgraphileOptions } from './graphql/postgraphile-options';
 
@@ -58,6 +58,8 @@ async function bootstrap(): Promise<void> {
     shutdownActions,
     poolConfig,
   );
+
+  await loadInMemoryLocales(ownerPool);
 
   const broker = await registerMessaging(
     app,

--- a/services/catalog/service/src/index.ts
+++ b/services/catalog/service/src/index.ts
@@ -22,12 +22,16 @@ import {
 import express from 'express';
 import { PoolConfig } from 'pg';
 import { postgraphile } from 'postgraphile';
-import { applyMigrations, getFullConfig, loadInMemoryLocales } from './common';
+import {
+  applyMigrations,
+  getFullConfig,
+  loadInMemoryLocales,
+  startLocalesInsertedListener,
+} from './common';
 import { registerMessaging } from './domains/register-messaging';
 import { buildPostgraphileOptions } from './graphql/postgraphile-options';
 
 const logger = new Logger({ context: 'bootstrap' });
-
 // Entry point for the service. For annotated version please see /services/media/service/src/index.ts.
 async function bootstrap(): Promise<void> {
   handleGlobalErrors(logger);
@@ -59,7 +63,8 @@ async function bootstrap(): Promise<void> {
     poolConfig,
   );
 
-  await loadInMemoryLocales(ownerPool);
+  await startLocalesInsertedListener(config, logger);
+  await loadInMemoryLocales(ownerPool, logger);
 
   const broker = await registerMessaging(
     app,

--- a/services/catalog/service/src/tests/channels/localizations.db.spec.ts
+++ b/services/catalog/service/src/tests/channels/localizations.db.spec.ts
@@ -1,7 +1,11 @@
 import gql from 'graphql-tag';
 import 'jest-extended';
 import { insert } from 'zapatos/db';
-import { DEFAULT_LOCALE_TAG, MOSAIC_LOCALE_HEADER_KEY } from '../../common';
+import {
+  DEFAULT_LOCALE_TAG,
+  MOSAIC_LOCALE_HEADER_KEY,
+  syncInMemoryLocales,
+} from '../../common';
 import { createTestContext, ITestContext } from '../test-utils';
 
 const CHANNEL_REQUEST = gql`
@@ -22,6 +26,14 @@ describe('Channel Localization Graphql Requests', () => {
   beforeAll(async () => {
     ctx = await createTestContext();
     await insert('channel', { id: channelId }).run(ctx.ownerPool);
+    await syncInMemoryLocales(
+      [
+        { language_tag: DEFAULT_LOCALE_TAG, is_default_locale: true },
+        { language_tag: 'de-DE', is_default_locale: false },
+        { language_tag: 'et-EE', is_default_locale: false },
+      ],
+      ctx.ownerPool,
+    );
   });
 
   beforeEach(async () => {

--- a/services/catalog/service/src/tests/collections/localizations.db.spec.ts
+++ b/services/catalog/service/src/tests/collections/localizations.db.spec.ts
@@ -1,7 +1,11 @@
 import gql from 'graphql-tag';
 import 'jest-extended';
 import { insert } from 'zapatos/db';
-import { DEFAULT_LOCALE_TAG, MOSAIC_LOCALE_HEADER_KEY } from '../../common';
+import {
+  DEFAULT_LOCALE_TAG,
+  MOSAIC_LOCALE_HEADER_KEY,
+  syncInMemoryLocales,
+} from '../../common';
 import { createTestContext, ITestContext } from '../test-utils';
 
 const COLLECTION_REQUEST = gql`
@@ -23,6 +27,14 @@ describe('Collection Localization Graphql Requests', () => {
   beforeAll(async () => {
     ctx = await createTestContext();
     await insert('collection', { id: collectionId }).run(ctx.ownerPool);
+    await syncInMemoryLocales(
+      [
+        { language_tag: DEFAULT_LOCALE_TAG, is_default_locale: true },
+        { language_tag: 'de-DE', is_default_locale: false },
+        { language_tag: 'et-EE', is_default_locale: false },
+      ],
+      ctx.ownerPool,
+    );
   });
 
   beforeEach(async () => {

--- a/services/catalog/service/src/tests/episodes/localizations.db.spec.ts
+++ b/services/catalog/service/src/tests/episodes/localizations.db.spec.ts
@@ -1,7 +1,11 @@
 import gql from 'graphql-tag';
 import 'jest-extended';
 import { insert } from 'zapatos/db';
-import { DEFAULT_LOCALE_TAG, MOSAIC_LOCALE_HEADER_KEY } from '../../common';
+import {
+  DEFAULT_LOCALE_TAG,
+  MOSAIC_LOCALE_HEADER_KEY,
+  syncInMemoryLocales,
+} from '../../common';
 import { createTestContext, ITestContext } from '../test-utils';
 
 const EPISODE_REQUEST = gql`
@@ -23,6 +27,14 @@ describe('Episode Localization Graphql Requests', () => {
   beforeAll(async () => {
     ctx = await createTestContext();
     await insert('episode', { id: episodeId }).run(ctx.ownerPool);
+    await syncInMemoryLocales(
+      [
+        { language_tag: DEFAULT_LOCALE_TAG, is_default_locale: true },
+        { language_tag: 'de-DE', is_default_locale: false },
+        { language_tag: 'et-EE', is_default_locale: false },
+      ],
+      ctx.ownerPool,
+    );
   });
 
   beforeEach(async () => {

--- a/services/catalog/service/src/tests/movie-genres/localizations.db.spec.ts
+++ b/services/catalog/service/src/tests/movie-genres/localizations.db.spec.ts
@@ -1,7 +1,11 @@
 import gql from 'graphql-tag';
 import 'jest-extended';
 import { insert } from 'zapatos/db';
-import { DEFAULT_LOCALE_TAG, MOSAIC_LOCALE_HEADER_KEY } from '../../common';
+import {
+  DEFAULT_LOCALE_TAG,
+  MOSAIC_LOCALE_HEADER_KEY,
+  syncInMemoryLocales,
+} from '../../common';
 import { createTestContext, ITestContext } from '../test-utils';
 
 const MOVIE_GENRE_REQUEST = gql`
@@ -21,6 +25,14 @@ describe('Movie genre Localization Graphql Requests', () => {
   beforeAll(async () => {
     ctx = await createTestContext();
     await insert('movie_genre', { id: movieGenreId }).run(ctx.ownerPool);
+    await syncInMemoryLocales(
+      [
+        { language_tag: DEFAULT_LOCALE_TAG, is_default_locale: true },
+        { language_tag: 'de-DE', is_default_locale: false },
+        { language_tag: 'et-EE', is_default_locale: false },
+      ],
+      ctx.ownerPool,
+    );
   });
 
   beforeEach(async () => {

--- a/services/catalog/service/src/tests/movies/localizations.db.spec.ts
+++ b/services/catalog/service/src/tests/movies/localizations.db.spec.ts
@@ -1,7 +1,11 @@
 import gql from 'graphql-tag';
 import 'jest-extended';
 import { insert } from 'zapatos/db';
-import { DEFAULT_LOCALE_TAG, MOSAIC_LOCALE_HEADER_KEY } from '../../common';
+import {
+  DEFAULT_LOCALE_TAG,
+  MOSAIC_LOCALE_HEADER_KEY,
+  syncInMemoryLocales,
+} from '../../common';
 import { createTestContext, ITestContext } from '../test-utils';
 
 const MOVIE_REQUEST = gql`
@@ -23,6 +27,14 @@ describe('Movie Localization Graphql Requests', () => {
   beforeAll(async () => {
     ctx = await createTestContext();
     await insert('movie', { id: movieId }).run(ctx.ownerPool);
+    await syncInMemoryLocales(
+      [
+        { language_tag: DEFAULT_LOCALE_TAG, is_default_locale: true },
+        { language_tag: 'de-DE', is_default_locale: false },
+        { language_tag: 'et-EE', is_default_locale: false },
+      ],
+      ctx.ownerPool,
+    );
   });
 
   beforeEach(async () => {

--- a/services/catalog/service/src/tests/seasons/localizations.db.spec.ts
+++ b/services/catalog/service/src/tests/seasons/localizations.db.spec.ts
@@ -1,7 +1,11 @@
 import gql from 'graphql-tag';
 import 'jest-extended';
 import { insert } from 'zapatos/db';
-import { DEFAULT_LOCALE_TAG, MOSAIC_LOCALE_HEADER_KEY } from '../../common';
+import {
+  DEFAULT_LOCALE_TAG,
+  MOSAIC_LOCALE_HEADER_KEY,
+  syncInMemoryLocales,
+} from '../../common';
 import { createTestContext, ITestContext } from '../test-utils';
 
 const SEASON_REQUEST = gql`
@@ -22,6 +26,14 @@ describe('Season Localization Graphql Requests', () => {
   beforeAll(async () => {
     ctx = await createTestContext();
     await insert('season', { id: seasonId }).run(ctx.ownerPool);
+    await syncInMemoryLocales(
+      [
+        { language_tag: DEFAULT_LOCALE_TAG, is_default_locale: true },
+        { language_tag: 'de-DE', is_default_locale: false },
+        { language_tag: 'et-EE', is_default_locale: false },
+      ],
+      ctx.ownerPool,
+    );
   });
 
   beforeEach(async () => {

--- a/services/catalog/service/src/tests/tvshow-genres/localizations.db.spec.ts
+++ b/services/catalog/service/src/tests/tvshow-genres/localizations.db.spec.ts
@@ -1,7 +1,11 @@
 import gql from 'graphql-tag';
 import 'jest-extended';
 import { insert } from 'zapatos/db';
-import { DEFAULT_LOCALE_TAG, MOSAIC_LOCALE_HEADER_KEY } from '../../common';
+import {
+  DEFAULT_LOCALE_TAG,
+  MOSAIC_LOCALE_HEADER_KEY,
+  syncInMemoryLocales,
+} from '../../common';
 import { createTestContext, ITestContext } from '../test-utils';
 
 const TVSHOW_GENRE_REQUEST = gql`
@@ -21,6 +25,14 @@ describe('Tvshow genre Localization Graphql Requests', () => {
   beforeAll(async () => {
     ctx = await createTestContext();
     await insert('tvshow_genre', { id: tvshowGenreId }).run(ctx.ownerPool);
+    await syncInMemoryLocales(
+      [
+        { language_tag: DEFAULT_LOCALE_TAG, is_default_locale: true },
+        { language_tag: 'de-DE', is_default_locale: false },
+        { language_tag: 'et-EE', is_default_locale: false },
+      ],
+      ctx.ownerPool,
+    );
   });
 
   beforeEach(async () => {

--- a/services/catalog/service/src/tests/tvshows/localizations.db.spec.ts
+++ b/services/catalog/service/src/tests/tvshows/localizations.db.spec.ts
@@ -1,7 +1,11 @@
 import gql from 'graphql-tag';
 import 'jest-extended';
 import { insert } from 'zapatos/db';
-import { DEFAULT_LOCALE_TAG, MOSAIC_LOCALE_HEADER_KEY } from '../../common';
+import {
+  DEFAULT_LOCALE_TAG,
+  MOSAIC_LOCALE_HEADER_KEY,
+  syncInMemoryLocales,
+} from '../../common';
 import { createTestContext, ITestContext } from '../test-utils';
 
 const TVSHOW_REQUEST = gql`
@@ -23,6 +27,14 @@ describe('Tvshow Localization Graphql Requests', () => {
   beforeAll(async () => {
     ctx = await createTestContext();
     await insert('tvshow', { id: tvshowId }).run(ctx.ownerPool);
+    await syncInMemoryLocales(
+      [
+        { language_tag: DEFAULT_LOCALE_TAG, is_default_locale: true },
+        { language_tag: 'de-DE', is_default_locale: false },
+        { language_tag: 'et-EE', is_default_locale: false },
+      ],
+      ctx.ownerPool,
+    );
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [x] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [x] appropriate labels for the PR applied

## Release notes

- Localization views adjusted to be more performant and easily trigger indexes. 
- As a result - the view became simpler and will now just return rows for the specified locale, but will not perform any fallback logic to the default locale.
- To preserve the previous logic - the fallback to the default locale now happens on the code level (and not database level), by checking if specified locale exists, and if it does not - use default locale.
- It is now expected that all entities in the catalog service should have localizations for the same locales to avoid inconsistent request results. (was already ensured by the media service publish validation)
- In case a new locale is introduced to be supported - you might want to consider adding an explicit database migration to add fallback rows for new locale until it is properly published from the media service (e.g. using provided `app_private.add_default_placeholder_localizations` function)
- As an example change - `title` property can now be used in filters and ordering and has corresponding indexes added to support performant querying.

## Description

In addition to the Release notes:

- `locales` endpoint available to query a list of available locales
- An in-memory list of active locales is now being maintained during the service runtime.
   - it is initialized on service startup and updated every time a *Published event is received for the localizable entity.
- Locales header filter is now case-insensitive (e.g. filtering by `de-de` and `de-DE` would return the same result and not fall back to default locale. 
- Listen/Notify approach implemented to update in-memory locales array whenever new locales are inserted. This is done mainly horizontal scaling cases, e.g.
   - one instance of catalog service receives a Published message and updates the locales table
   - Notification is emitted
   - Every instance of the catalog service receives it and updates its in-memory locales array.

## Testing notes

- Have 2 movies with some non-default localizations, publish them, check in the catalog service that they can be requested without locale header and with locale header, and that values for appropriate locale is returned.
   - In Portal Admin - deactivate some locale
   - re-publish one of the above movies - this will update the in-memory locales to no longer include deactivated locale
   - query both re-published and second movie for deactivated locale - both would return default fallback locale
   - Expectation for "deactivating old locale" in prod environment scenario - re-publishing of all movies to drop obsolete localizations or explicit database migration to drop no longer supported localizations

- Have 2 movies with some non-default localizations, publish them, check in the catalog service that they can be requested without locale header and with locale header, and that values for appropriate locale is returned.
   - In Portal Admin - add and activate a new locale
   - For one of the movies - fill in localizations for the new locale and re-publish it.
   - Requesting re-published movie for new locale would return it appropriately
   - Requesting not re-published movie (that does not have a new locale) - would return null (if a single movie is requested), or not be returned (if a `movies` query is used)
   - Expectation for "activating a new locale" in prod environment scenario -  either re-publish all entities or add an explicit database migration to add fallback localizations rows for new locale

- After one of the cases above (either works) - check the logs - there should be a single log entry with message `In-memory locales successfully (re)loaded.`
   - Ask SE Team to scale the catalog service horizontally to have 2 instances (pods).
   - After that is done - retry a case by either activating or de-activating a locale and re-publishing the movie.
   - Check the logs again - it should have 2 new `In-memory locales successfully (re)loaded.` logs, one for each running catalog service instance.