### PR TITLE
[AB#45113] fix: add cancel button to video select explorer on program management

### DIFF
--- a/services/channel/workflows/src/stations/Channels/ProgramManagement/VideoScheduleExplorer/VideoScheduleExplorer.tsx
+++ b/services/channel/workflows/src/stations/Channels/ProgramManagement/VideoScheduleExplorer/VideoScheduleExplorer.tsx
@@ -62,6 +62,7 @@ export const ScheduleVideoExplorer: React.FC<
         stationKey="program-management-schedule"
         predefinedFilterValues={predefinedFilters}
         onSelection={(val) => onSelectionHandler(val)}
+        onCancel={() => setVideoSelect(undefined)}
       />
     </Modal>
   );


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [ ] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

<!-- describe your changes here -->
Before the VideoSelectExplorer on the Program Management station didn't display a 'Cancel'  action. Now it does.