### PR TITLE
[AB#45115] set the publishing user for channels and playlists

### DIFF
--- a/services/channel/service/migrations/committed/000004-set-publishing-user.sql
+++ b/services/channel/service/migrations/committed/000004-set-publishing-user.sql
@@ -1,8 +1,8 @@
 --! Previous: sha1:098d8bbe4239517488649a1d765960a3af604d22
---! Hash: sha1:52abbb9213fd3185b16dbeeac849074c5fe06a07
+--! Hash: sha1:9bdbe7ce3091a2a4eee11d8c0601f7114d59ad50
 --! Message: set-publishing-user
 
--- creation method to create publish audit field triggers
+DROP FUNCTION if exists app_hidden.define_publish_trigger(text, text, text);
 CREATE OR REPLACE FUNCTION app_hidden.define_publish_trigger(tableName text, schemaName text) RETURNS void
     LANGUAGE plpgsql
     AS $$

--- a/services/channel/service/migrations/committed/000004-set-publishing-user.sql
+++ b/services/channel/service/migrations/committed/000004-set-publishing-user.sql
@@ -1,0 +1,17 @@
+--! Previous: sha1:098d8bbe4239517488649a1d765960a3af604d22
+--! Hash: sha1:52abbb9213fd3185b16dbeeac849074c5fe06a07
+--! Message: set-publishing-user
+
+-- creation method to create publish audit field triggers
+CREATE OR REPLACE FUNCTION app_hidden.define_publish_trigger(tableName text, schemaName text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  EXECUTE 'DROP TRIGGER IF EXISTS _900__publish_user ON ' || schemaName || '.' || tableName || ';';
+  EXECUTE 'CREATE trigger _900__publish_user BEFORE INSERT OR UPDATE ON ' || schemaName || '.' || tableName ||
+          ' FOR EACH ROW EXECUTE PROCEDURE app_hidden.tg__publish_audit_fields();';
+END;
+$$;
+
+SELECT app_hidden.define_publish_trigger('channels', 'app_public');
+SELECT app_hidden.define_publish_trigger('playlists', 'app_public');

--- a/services/channel/service/src/generated/db/schema.sql
+++ b/services/channel/service/src/generated/db/schema.sql
@@ -241,21 +241,6 @@ $$;
 
 
 --
--- Name: define_publish_trigger(text, text, text); Type: FUNCTION; Schema: app_hidden; Owner: -
---
-
-CREATE FUNCTION app_hidden.define_publish_trigger(tablename text, schemaname text, columnnames text) RETURNS void
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-  EXECUTE 'DROP TRIGGER IF EXISTS _900__publish_user ON ' || schemaName || '.' || tableName || ';';
-  EXECUTE 'CREATE trigger _900__publish_user BEFORE INSERT OR UPDATE OF ' || columnNames || ' ON ' || schemaName || '.' || tableName ||
-          ' FOR EACH ROW EXECUTE PROCEDURE app_hidden.tg__publish_audit_fields();';
-END;
-$$;
-
-
---
 -- Name: is_localization_enabled(); Type: FUNCTION; Schema: app_hidden; Owner: -
 --
 
@@ -3981,14 +3966,6 @@ GRANT ALL ON FUNCTION app_hidden.create_localizable_entity_triggers(aggregateid 
 
 REVOKE ALL ON FUNCTION app_hidden.define_publish_trigger(tablename text, schemaname text) FROM PUBLIC;
 GRANT ALL ON FUNCTION app_hidden.define_publish_trigger(tablename text, schemaname text) TO channel_service_gql_role;
-
-
---
--- Name: FUNCTION define_publish_trigger(tablename text, schemaname text, columnnames text); Type: ACL; Schema: app_hidden; Owner: -
---
-
-REVOKE ALL ON FUNCTION app_hidden.define_publish_trigger(tablename text, schemaname text, columnnames text) FROM PUBLIC;
-GRANT ALL ON FUNCTION app_hidden.define_publish_trigger(tablename text, schemaname text, columnnames text) TO channel_service_gql_role;
 
 
 --

--- a/services/channel/service/src/generated/db/schema.sql
+++ b/services/channel/service/src/generated/db/schema.sql
@@ -226,6 +226,21 @@ $_$;
 
 
 --
+-- Name: define_publish_trigger(text, text); Type: FUNCTION; Schema: app_hidden; Owner: -
+--
+
+CREATE FUNCTION app_hidden.define_publish_trigger(tablename text, schemaname text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  EXECUTE 'DROP TRIGGER IF EXISTS _900__publish_user ON ' || schemaName || '.' || tableName || ';';
+  EXECUTE 'CREATE trigger _900__publish_user BEFORE INSERT OR UPDATE ON ' || schemaName || '.' || tableName ||
+          ' FOR EACH ROW EXECUTE PROCEDURE app_hidden.tg__publish_audit_fields();';
+END;
+$$;
+
+
+--
 -- Name: define_publish_trigger(text, text, text); Type: FUNCTION; Schema: app_hidden; Owner: -
 --
 
@@ -3642,14 +3657,14 @@ CREATE TRIGGER _500_gql_programs_updated AFTER UPDATE ON app_public.programs FOR
 -- Name: channels _900__publish_user; Type: TRIGGER; Schema: app_public; Owner: -
 --
 
-CREATE TRIGGER _900__publish_user BEFORE INSERT OR UPDATE OF title, description, placeholder_video_id ON app_public.channels FOR EACH ROW EXECUTE FUNCTION app_hidden.tg__publish_audit_fields();
+CREATE TRIGGER _900__publish_user BEFORE INSERT OR UPDATE ON app_public.channels FOR EACH ROW EXECUTE FUNCTION app_hidden.tg__publish_audit_fields();
 
 
 --
 -- Name: playlists _900__publish_user; Type: TRIGGER; Schema: app_public; Owner: -
 --
 
-CREATE TRIGGER _900__publish_user BEFORE INSERT OR UPDATE OF title, start_date_time, calculated_duration_in_seconds, channel_id ON app_public.playlists FOR EACH ROW EXECUTE FUNCTION app_hidden.tg__publish_audit_fields();
+CREATE TRIGGER _900__publish_user BEFORE INSERT OR UPDATE ON app_public.playlists FOR EACH ROW EXECUTE FUNCTION app_hidden.tg__publish_audit_fields();
 
 
 --
@@ -3958,6 +3973,14 @@ GRANT USAGE ON SCHEMA public TO channel_service_gql_role;
 
 REVOKE ALL ON FUNCTION app_hidden.create_localizable_entity_triggers(aggregateid text, tablename text, entitytype text, localizable_fields text, required_fields text) FROM PUBLIC;
 GRANT ALL ON FUNCTION app_hidden.create_localizable_entity_triggers(aggregateid text, tablename text, entitytype text, localizable_fields text, required_fields text) TO channel_service_gql_role;
+
+
+--
+-- Name: FUNCTION define_publish_trigger(tablename text, schemaname text); Type: ACL; Schema: app_hidden; Owner: -
+--
+
+REVOKE ALL ON FUNCTION app_hidden.define_publish_trigger(tablename text, schemaname text) FROM PUBLIC;
+GRANT ALL ON FUNCTION app_hidden.define_publish_trigger(tablename text, schemaname text) TO channel_service_gql_role;
 
 
 --


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [X] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

When a channel or a playlist is published it will not only set the published date now as an audit field but also the user that started the publishing operation for channels and playlists.