### PR TITLE
[AB#45156] fix: issue with playlist breadcrumb caching

### DIFF
--- a/services/channel/workflows/src/generated/graphql.tsx
+++ b/services/channel/workflows/src/generated/graphql.tsx
@@ -2861,7 +2861,7 @@ export type CreatePlaylistMutationVariables = Exact<{
 }>;
 
 
-export type CreatePlaylistMutation = { __typename?: 'Mutation', createPlaylist?: { __typename?: 'CreatePlaylistPayload', playlist?: { __typename?: 'Playlist', id: any, channelId: any, startDateTime: any } | null } | null };
+export type CreatePlaylistMutation = { __typename?: 'Mutation', createPlaylist?: { __typename?: 'CreatePlaylistPayload', playlist?: { __typename?: 'Playlist', id: any, channelId: any, title: string, startDateTime: any } | null } | null };
 
 export type PlaylistQueryVariables = Exact<{
   id: Scalars['UUID'];
@@ -2896,7 +2896,7 @@ export type PlaylistTitleQueryVariables = Exact<{
 }>;
 
 
-export type PlaylistTitleQuery = { __typename?: 'Query', playlist?: { __typename?: 'Playlist', title: string } | null };
+export type PlaylistTitleQuery = { __typename?: 'Query', playlist?: { __typename?: 'Playlist', id: any, title: string } | null };
 
 export type ValidatePlaylistQueryVariables = Exact<{
   id: Scalars['UUID'];
@@ -3407,6 +3407,7 @@ export const CreatePlaylistDocument = gql`
     playlist {
       id
       channelId
+      title
       startDateTime
     }
   }
@@ -3597,6 +3598,7 @@ export type UnpublishPlaylistMutationOptions = Apollo.BaseMutationOptions<Unpubl
 export const PlaylistTitleDocument = gql`
     query PlaylistTitle($id: UUID!) {
   playlist(id: $id) {
+    id
     title
   }
 }

--- a/services/channel/workflows/src/stations/Channels/PlaylistDetails/PlaylistDetails.graphql
+++ b/services/channel/workflows/src/stations/Channels/PlaylistDetails/PlaylistDetails.graphql
@@ -46,6 +46,7 @@ mutation UnpublishPlaylist($input: UnpublishPlaylistInput!) {
 
 query PlaylistTitle($id: UUID!) {
   playlist(id: $id) {
+    id
     title
   }
 }

--- a/services/channel/workflows/src/stations/Channels/PlaylistDetails/PlaylistDetails.tsx
+++ b/services/channel/workflows/src/stations/Channels/PlaylistDetails/PlaylistDetails.tsx
@@ -65,6 +65,7 @@ export const PlaylistDetails: React.FC = () => {
             clientMutationId
             playlist {
               id
+              title
             }
           }
         }


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [ ] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

This PR fixes an issue where the breadcrumbs are not loading correctly after updating a playlist title. 
