### PR TITLE
[AB#45197] Removed the publish validation check if a video is DRM protected

### DIFF
--- a/services/channel/service/src/domains/channel/publishing/validate-channel.ts
+++ b/services/channel/service/src/domains/channel/publishing/validate-channel.ts
@@ -67,7 +67,6 @@ export async function validateChannel(
       publishDto.placeholder_video_id
         ? [{ videoId: publishDto.placeholder_video_id }]
         : [],
-      publishDto.is_drm_protected,
       true,
     ),
     isManagedServiceEnabled(

--- a/services/channel/service/src/domains/playlist/publishing/validate-playlist.ts
+++ b/services/channel/service/src/domains/playlist/publishing/validate-playlist.ts
@@ -119,7 +119,6 @@ export async function validatePlaylist(
       config.videoServiceBaseUrl,
       jwtToken,
       selectedVideos,
-      channel.is_drm_protected,
       false,
     ),
     isManagedServiceEnabled(

--- a/services/channel/service/src/publishing/common/video/get-validation-and-videos.spec.ts
+++ b/services/channel/service/src/publishing/common/video/get-validation-and-videos.spec.ts
@@ -70,7 +70,6 @@ describe('getValidationAndVideos', () => {
       authToken,
       [],
       true,
-      true,
     );
 
     // Assert
@@ -88,7 +87,6 @@ describe('getValidationAndVideos', () => {
       endpoint,
       authToken,
       [],
-      true,
       false,
     );
 
@@ -112,7 +110,6 @@ describe('getValidationAndVideos', () => {
       endpoint,
       authToken,
       [{ videoId: videoId1 }],
-      true,
       true,
     );
 
@@ -141,7 +138,6 @@ describe('getValidationAndVideos', () => {
       authToken,
       [{ videoId: videoId1 }],
       true,
-      true,
     );
 
     // Assert
@@ -163,7 +159,6 @@ describe('getValidationAndVideos', () => {
       authToken,
       [{ videoId: videoId1 }, { videoId: videoId2 }],
       false,
-      false,
     );
 
     // Assert
@@ -183,13 +178,7 @@ describe('getValidationAndVideos', () => {
 
     // Act
     const error = await rejectionOf(
-      getValidationAndVideos(
-        endpoint,
-        authToken,
-        [{ videoId: '1' }],
-        false,
-        true,
-      ),
+      getValidationAndVideos(endpoint, authToken, [{ videoId: '1' }], true),
     );
 
     // Assert
@@ -218,13 +207,7 @@ describe('getValidationAndVideos', () => {
 
     // Act
     const error = await rejectionOf(
-      getValidationAndVideos(
-        endpoint,
-        authToken,
-        [{ videoId: '1' }],
-        false,
-        true,
-      ),
+      getValidationAndVideos(endpoint, authToken, [{ videoId: '1' }], true),
     );
 
     // Assert
@@ -252,13 +235,7 @@ describe('getValidationAndVideos', () => {
 
     // Act
     const error = await rejectionOf(
-      getValidationAndVideos(
-        endpoint,
-        authToken,
-        [{ videoId: '1' }],
-        false,
-        true,
-      ),
+      getValidationAndVideos(endpoint, authToken, [{ videoId: '1' }], true),
     );
 
     // Assert

--- a/services/channel/service/src/publishing/common/video/get-validation-and-videos.ts
+++ b/services/channel/service/src/publishing/common/video/get-validation-and-videos.ts
@@ -27,7 +27,6 @@ export const getValidationAndVideos = async (
   videoServiceBaseUrl: string,
   authToken: string,
   selectedVideos: SelectedVideo[],
-  isDrmEnabled: boolean,
   exactlyOneVideo: boolean,
 ): Promise<{
   videos: DetailedVideo[];
@@ -68,26 +67,14 @@ export const getValidationAndVideos = async (
       }
 
       if (gqlVideo.isProtected) {
-        if (isDrmEnabled) {
-          if (
-            gqlVideo.videoStreams.nodes
-              .filter(
-                (s) => s.type !== 'SUBTITLE' && s.type !== 'CLOSED_CAPTION',
-              )
-              .find((s) => !s.keyId)
-          ) {
-            validations.push(
-              createValidationError(
-                `Video "${gqlVideo.title}" with ID ${gqlVideo.id} is protected but no key ids were found.`,
-                'VIDEOS',
-                source,
-              ),
-            );
-          }
-        } else {
+        if (
+          gqlVideo.videoStreams.nodes
+            .filter((s) => s.type !== 'SUBTITLE' && s.type !== 'CLOSED_CAPTION')
+            .find((s) => !s.keyId)
+        ) {
           validations.push(
             createValidationError(
-              `Video "${gqlVideo.title}" with ID ${gqlVideo.id} is DRM protected.`,
+              `Video "${gqlVideo.title}" with ID ${gqlVideo.id} is protected but no key ids were found.`,
               'VIDEOS',
               source,
             ),


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [X] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [X] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Right now there is a publishing validation that checks if a DRM-protected video is used for channels/playlists. That check creates an error if the channel says that the output should not be DRM protected but the input is. 

Actually, that is (now) incorrect (validation was based on the old logic) as the input can be anything, gets decrypted if it is a DRM-protected video, and then the output decides based on the channel setting if it should protect the output or not.

If the solution wants to use DRM-protected input videos for streams then they need to configure the DRM settings in the VOD-to-Live Service. No validation check is needed for that.

## Testing

You can add one/multiple DRM-protected videos to a channel and playlists where the channel is not DRM-protected. There should not be any validation error and the output should play without providing a DRM entitlement message as the channel is not protected.

The other scenarios should still work: a DRM protected channel should have a DRM protected/not protected video for the channel and the playlist should have videos that are DRM protected and not DRM protected. A JWT is required to play back the stream.