### PR TITLE
[AB#45280] published channel no longer set to Changed state after publishing

### DIFF
--- a/services/channel/service/migrations/committed/000005-publish-trigger-user-handling-dropped.sql
+++ b/services/channel/service/migrations/committed/000005-publish-trigger-user-handling-dropped.sql
@@ -1,0 +1,41 @@
+--! Previous: sha1:9bdbe7ce3091a2a4eee11d8c0601f7114d59ad50
+--! Hash: sha1:9e5086e5e54235c9638166bfa515fcb6c8252849
+--! Message: publish-trigger-user-handling-dropped
+
+DROP FUNCTION if exists app_hidden.define_publish_trigger(text, text);
+CREATE OR REPLACE FUNCTION app_hidden.define_publish_trigger(tableName text, schemaName text, columnNames text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  EXECUTE 'DROP TRIGGER IF EXISTS _900__publish_user ON ' || schemaName || '.' || tableName || ';';
+  EXECUTE 'CREATE trigger _900__publish_user BEFORE INSERT OR UPDATE OF ' || columnNames || ' ON ' || schemaName || '.' || tableName ||
+          ' FOR EACH ROW EXECUTE PROCEDURE app_hidden.tg__publish_audit_fields();';
+END;
+$$;
+
+-- published_user handling removed from the trigger and moved to the parts of
+-- the code that handle changing published_date
+CREATE OR REPLACE FUNCTION app_hidden.tg__publish_audit_fields() RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+	username text = pg_catalog.current_setting('mosaic.auth.subject_name', true);
+BEGIN
+  -- ensure that published_date is aligned with publication_state
+  IF (NEW.publication_state = 'PUBLISHED' OR NEW.publication_state = 'CHANGED') AND NEW.published_date IS NULL THEN
+    perform ax_utils.raise_error('published_date must not be null if publication_state is PUBLISHED or CHANGED.', 'PTERR');
+  END IF;
+  IF NEW.publication_state = 'NOT_PUBLISHED' AND NEW.published_date IS NOT NULL THEN
+    perform ax_utils.raise_error('published_date must be null if publication_state is NOT_PUBLISHED.', 'PTERR');
+  END IF;
+
+  -- set changed state
+  IF NEW.published_date = OLD.published_date AND NEW.updated_date <> OLD.updated_date THEN
+    NEW.publication_state = 'CHANGED';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+SELECT app_hidden.define_publish_trigger('channels', 'app_public', 'title,description,placeholder_video_id,is_drm_protected');
+SELECT app_hidden.define_publish_trigger('playlists', 'app_public', 'title,start_date_time,calculated_duration_in_seconds,channel_id');

--- a/services/channel/service/src/domains/channel/graphql/publish-channel-plugin.ts
+++ b/services/channel/service/src/domains/channel/graphql/publish-channel-plugin.ts
@@ -97,6 +97,7 @@ export const PublishChannelPlugin = makeExtendSchemaPlugin((build) => {
                   storeOutboxMessage,
                   ctx,
                   config,
+                  subject,
                 );
               },
             );

--- a/services/channel/service/src/domains/channel/publishing/publish-channel.db.spec.ts
+++ b/services/channel/service/src/domains/channel/publishing/publish-channel.db.spec.ts
@@ -191,6 +191,7 @@ describe('publishChannel', () => {
           storeOutboxMessage,
           txn,
           testContext.config,
+          testUser,
         ),
       ),
     );
@@ -256,6 +257,7 @@ describe('publishChannel', () => {
             storeOutboxMessage,
             txn,
             testContext.config,
+            testUser,
           ),
         ),
       );
@@ -300,6 +302,7 @@ describe('publishChannel', () => {
           storeOutboxMessage,
           txn,
           testContext.config,
+          testUser,
         ),
       ),
     );
@@ -369,6 +372,7 @@ describe('publishChannel', () => {
           storeOutboxMessage,
           txn,
           testContext.config,
+          testUser,
         ),
       );
 
@@ -442,6 +446,7 @@ describe('publishChannel', () => {
         storeOutboxMessage,
         txn,
         testContext.config,
+        testUser,
       ),
     );
 
@@ -517,6 +522,7 @@ describe('publishChannel', () => {
         storeOutboxMessage,
         txn,
         testContext.config,
+        testUser,
       ),
     );
 

--- a/services/channel/service/src/domains/channel/publishing/publish-channel.ts
+++ b/services/channel/service/src/domains/channel/publishing/publish-channel.ts
@@ -1,3 +1,4 @@
+import { AuthenticatedManagementSubject } from '@axinom/mosaic-id-guard';
 import { MosaicError } from '@axinom/mosaic-service-common';
 import { StoreOutboxMessage } from '@axinom/mosaic-transactional-inbox-outbox';
 import {
@@ -17,6 +18,7 @@ export async function publishChannel(
   storeOutboxMessage: StoreOutboxMessage,
   ownerClient: ClientBase,
   config: Config,
+  subject: AuthenticatedManagementSubject,
 ): Promise<void> {
   const { publishHash, publishPayload, validationStatus, validations } =
     await validateChannel(id, jwtToken, ownerClient, config);
@@ -36,7 +38,11 @@ export async function publishChannel(
   const publishedDate = new Date().toUTCString();
   await update(
     'channels',
-    { publication_state: 'PUBLISHED', published_date: publishedDate },
+    {
+      publication_state: 'PUBLISHED',
+      published_date: publishedDate,
+      published_user: subject.name,
+    },
     {
       id,
     },

--- a/services/channel/service/src/domains/channel/publishing/unpublish-channel.ts
+++ b/services/channel/service/src/domains/channel/publishing/unpublish-channel.ts
@@ -42,6 +42,7 @@ export async function unpublishChannel(
     {
       publication_state: 'NOT_PUBLISHED',
       published_date: null,
+      published_user: null,
       hls_stream_url: null,
       dash_stream_url: null,
       key_id: null,

--- a/services/channel/service/src/domains/playlist/graphql/publish-playlist-plugin.ts
+++ b/services/channel/service/src/domains/playlist/graphql/publish-playlist-plugin.ts
@@ -97,6 +97,7 @@ export const PublishPlaylistPlugin = makeExtendSchemaPlugin((build) => {
                   storeOutboxMessage,
                   ctx,
                   config,
+                  subject,
                 );
               },
             );

--- a/services/channel/service/src/domains/playlist/publishing/publish-playlist.db.spec.ts
+++ b/services/channel/service/src/domains/playlist/publishing/publish-playlist.db.spec.ts
@@ -131,6 +131,7 @@ describe('publishPlaylist', () => {
           storeOutboxMessage,
           txn,
           testContext.config,
+          testUser,
         ),
       ),
     );
@@ -179,6 +180,7 @@ describe('publishPlaylist', () => {
         storeOutboxMessage,
         txn,
         testContext.config,
+        testUser,
       );
     });
 

--- a/services/channel/service/src/domains/playlist/publishing/publish-playlist.ts
+++ b/services/channel/service/src/domains/playlist/publishing/publish-playlist.ts
@@ -1,3 +1,4 @@
+import { AuthenticatedManagementSubject } from '@axinom/mosaic-id-guard';
 import { MosaicError } from '@axinom/mosaic-service-common';
 import { StoreOutboxMessage } from '@axinom/mosaic-transactional-inbox-outbox';
 import {
@@ -17,6 +18,7 @@ export async function publishPlaylist(
   storeOutboxMessage: StoreOutboxMessage,
   ownerClient: ClientBase,
   config: Config,
+  subject: AuthenticatedManagementSubject,
 ): Promise<void> {
   // perform validation
   const validationResult = await validatePlaylist(
@@ -48,7 +50,11 @@ export async function publishPlaylist(
   const publishedDate = new Date().toUTCString();
   await update(
     'playlists',
-    { publication_state: 'PUBLISHED', published_date: publishedDate },
+    {
+      publication_state: 'PUBLISHED',
+      published_date: publishedDate,
+      published_user: subject.name,
+    },
     {
       id: id,
     },

--- a/services/channel/service/src/domains/playlist/publishing/unpublish-playlist.ts
+++ b/services/channel/service/src/domains/playlist/publishing/unpublish-playlist.ts
@@ -40,7 +40,11 @@ export async function unpublishPlaylist(
 
   await update(
     'playlists',
-    { publication_state: 'NOT_PUBLISHED', published_date: null },
+    {
+      publication_state: 'NOT_PUBLISHED',
+      published_date: null,
+      published_user: null,
+    },
     { id: id },
   ).run(ownerClient);
 


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

When channel is published - it's published state and user are set right away, but the whole publishing process also includes receiving events that set the URLs and DRM key ids by receiving explicit messages from vod-to-live service, and this is done after the publish button is clicked. Previously, these updates were re-setting the published state from `PUBLISHED` to `CHANGED`. Now, these updates are no longer doing that.

As a result of this fix, published_user is no longer set as part of the database trigger, instead it is set at the same places in the code where published_date is set,

## Testing notes:

- Create a channel, assign a video to it, set localizations (if any), publish it.
- The published state, published date, and published user should be set and visible on the Channel details station, e.g.
```
Publication State
PUBLISHED
Last Published
7/24/2024, 10:03 AM by Axinom Navy
```
- Create a publishable playlist and publish it.
- Playlist should have similar published properties visible on its details station.
- unpublish the playlist -> playlist state should be visible as `NOT_PUBLISHED` and published date/user should not be visible.
- unpublish the channel ->  playlist state should be visible as `NOT_PUBLISHED` and published date/user/urls/keyid should not be visible.
