### PR TITLE
[AB#45461] fix: :ambulance: make the db:reset script work on channel-service

### DIFF
--- a/services/channel/service/scripts/codegen-zapatos.ts
+++ b/services/channel/service/scripts/codegen-zapatos.ts
@@ -1,11 +1,23 @@
 /* eslint-disable no-console */
 import { transformCustomType } from '@axinom/mosaic-db-common';
+import { getValidatedConfig, pick } from '@axinom/mosaic-service-common';
 import { Config as ZapatosConfig, generate } from 'zapatos/generate';
-import { getFullConfig } from '../src/common';
+import { getConfigDefinitions } from '../src/common/config';
 
 async function main(): Promise<void> {
   const isCurrent = process.argv?.[2] === 'current';
-  const config = getFullConfig();
+  const configDefinitions = pick(
+    getConfigDefinitions(),
+    'dbOwnerConnectionString',
+    'dbShadowConnectionString',
+    'dbOwner',
+    'pgUserSuffix',
+    'dbOwnerPassword',
+    'pgHost',
+    'pgPort',
+    'dbName',
+  );
+  const config = getValidatedConfig(configDefinitions);
   const cfg: ZapatosConfig = {
     db: {
       connectionString: isCurrent

--- a/services/channel/service/scripts/db-reset.ts
+++ b/services/channel/service/scripts/db-reset.ts
@@ -5,7 +5,7 @@ import {
 } from '@axinom/mosaic-service-common';
 import { reset } from 'graphile-migrate';
 import { initializePgPool, runResetQueries } from '../../../../scripts/helpers';
-import { getMigrationSettings } from '../src/common';
+import { getMigrationSettings } from '../src/common/db';
 
 async function main(): Promise<void> {
   console.log('1. Validating Config...');


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [X] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [X] potential **release notes** to the PR description added
- [X] potential **testing notes** to the PR description added
- [X] appropriate labels for the PR applied

## Description

The channel-service scripts were adjusted to not make cascading imports that would require the `media-messages` lib to be built before running `db:reset` as well as require only the needed config env-vars to be set for performing the `db:reset`

## Testing Notes

- Setup the media-template using the mosaic-cli bootstrapping
- Run through the README to perform all the steps to run the media-template locally

## Release Notes

Fixed a bug that causes the `db:reset` & `setup` scripts to fail on the `channel-service` when the `media-messages` lib was not built or certain env-vars were not configured in the root `.env` file.