### PR TITLE
[AB#45461] fix: :ambulance: make the setup script work on channel-service

### DIFF
--- a/services/channel/service/scripts/setup.ts
+++ b/services/channel/service/scripts/setup.ts
@@ -5,7 +5,7 @@ import {
   pick,
 } from '@axinom/mosaic-service-common';
 import { serviceAccountSetup } from '../../../../scripts/helpers';
-import { getConfigDefinitions } from '../src/common';
+import { getConfigDefinitions } from '../src/common/config';
 
 async function main(): Promise<void> {
   const config = getValidatedConfig(


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [X] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [X] potential **testing notes** to the PR description added
- [X] appropriate labels for the PR applied

## Description

The channel-service scripts were adjusted to not make cascading imports that would require the media-messages lib to be built before running `setup`

## Testing Notes

- Setup the media-template using the mosaic-cli bootstrapping
- Run through the README to perform all the steps to run the media-template locally