### PR TITLE
[AB#45596] in-memory locales now stored as objects and default locale fallback considers is_default value

### DIFF
--- a/services/catalog/service/src/common/db/get-mosaic-locale-setting.ts
+++ b/services/catalog/service/src/common/db/get-mosaic-locale-setting.ts
@@ -1,18 +1,11 @@
 import { Dict } from '@axinom/mosaic-db-common';
 import { Request } from 'express';
-import {
-  DEFAULT_LOCALE_TAG,
-  MOSAIC_LOCALE_HEADER_KEY,
-  MOSAIC_LOCALE_PG_KEY,
-} from '../constants';
-import { getInMemoryLocales } from './in-memory-locales';
+import { MOSAIC_LOCALE_HEADER_KEY, MOSAIC_LOCALE_PG_KEY } from '../constants';
+import { getInMemoryLocale } from './in-memory-locales';
 
 export const getMosaicLocaleSetting = (req: Request): Dict<string> => {
   const header = String(req.headers[MOSAIC_LOCALE_HEADER_KEY]);
   return {
-    [MOSAIC_LOCALE_PG_KEY]:
-      getInMemoryLocales().find(
-        (locale) => locale.toLowerCase() === header.toLowerCase(),
-      ) ?? DEFAULT_LOCALE_TAG,
+    [MOSAIC_LOCALE_PG_KEY]: getInMemoryLocale(header),
   };
 };

--- a/services/catalog/service/src/common/db/in-memory-locales.ts
+++ b/services/catalog/service/src/common/db/in-memory-locales.ts
@@ -27,9 +27,9 @@ export const getInMemoryLocale = (locale: string): string => {
     return found.locale;
   }
 
-  const def = inMemoryLocales.find((l) => l.is_default);
-  if (def) {
-    return def.locale;
+  const foundDefault = inMemoryLocales.find((l) => l.is_default);
+  if (foundDefault) {
+    return foundDefault.locale;
   }
 
   return DEFAULT_LOCALE_TAG;


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Testing notes

- Make sure you have the `Default Locale Language Tag` in Admin Portal set to the default value `default`
- Publish some movie
- Request all movies from the Catalog GraphQL API without specifying the `mosaic-locale` header.
    - Expected: published movie is returned
- Change the `Default Locale Language Tag` in Admin Portal to something else, e.g. `en-US`
- Re-publish previously published movie
- Request all movies from the Catalog GraphQL API without specifying the `mosaic-locale` header.
    - Expected: published movie is returned
    - Previous behavior: Movie was not returned, because `is_default` property was not considered when performing a fallback to the default locale.
    
Control case:
- Try requesting movies from Catalog GraphQL API with `mosaic-locale`, requesting both for default and not default locales. Expected that movies are returned for specified locales with matching localized values.