### PR TITLE
[AB#46403] fix: Shell command built from environment values

### DIFF
--- a/scripts/open-test-coverage.ts
+++ b/scripts/open-test-coverage.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { resolve } from 'path';
 
 const url = resolve(
@@ -13,4 +13,4 @@ const start =
     : process.platform === 'win32'
     ? 'start'
     : 'xdg-open';
-exec(`${start} ${url}`);
+execFile(start, [url]);


### PR DESCRIPTION
Fixes [https://github.com/Axinom/mosaic-media-template/security/code-scanning/1](https://github.com/Axinom/mosaic-media-template/security/code-scanning/1)

To fix the problem, we should avoid constructing the shell command dynamically with user input. Instead, we can use `execFile` or `execFileSync` from the `child_process` module, which allows us to pass arguments separately and avoids shell interpretation issues.

1. Replace the `exec` call with `execFile` or `execFileSync`.
2. Pass the `start` command and `url` as separate arguments to avoid shell interpretation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
