### PR TITLE
[AB#42727] fix: allow filters to re-initialize if not touched

### DIFF
--- a/services/media/workflows/src/Stations/Ingest/IngestDocumentDetails/IngestItemsList/IngestItemsList.tsx
+++ b/services/media/workflows/src/Stations/Ingest/IngestDocumentDetails/IngestItemsList/IngestItemsList.tsx
@@ -44,9 +44,21 @@ export const IngestItemsList: React.FC<IngestItemsListProps> = ({ items }) => {
         };
       }),
     ]);
+
     if (!filterTouched.current && statuses.size > 0) {
       // re-initialize filter if it was not touched
       setFilter([...statuses]);
+    } else if (statuses.size > 0) {
+      setFilter((prev) => {
+        const selected = prev.filter((f) => statuses.has(f));
+        if (selected.length > 0) {
+          // keep the selected filters if they are still available
+          return selected;
+        } else {
+          // otherwise return all statuses
+          return [...statuses];
+        }
+      });
     }
   }, [items]);
 

--- a/services/media/workflows/src/Stations/Ingest/IngestDocumentDetails/IngestItemsList/IngestItemsList.tsx
+++ b/services/media/workflows/src/Stations/Ingest/IngestDocumentDetails/IngestItemsList/IngestItemsList.tsx
@@ -31,7 +31,7 @@ export const IngestItemsList: React.FC<IngestItemsListProps> = ({ items }) => {
   >([]);
 
   const [filter, setFilter] = useState<IngestItemStatus[]>([]);
-  const filterInitialized = useRef(false);
+  const filterTouched = useRef(false);
 
   useEffect(() => {
     const statuses = new Set<IngestItemStatus>();
@@ -44,9 +44,8 @@ export const IngestItemsList: React.FC<IngestItemsListProps> = ({ items }) => {
         };
       }),
     ]);
-    if (!filterInitialized.current && statuses.size > 0) {
-      // initialize filters only once, not on every data update
-      filterInitialized.current = true;
+    if (!filterTouched.current && statuses.size > 0) {
+      // re-initialize filter if it was not touched
       setFilter([...statuses]);
     }
   }, [items]);
@@ -61,7 +60,10 @@ export const IngestItemsList: React.FC<IngestItemsListProps> = ({ items }) => {
           inlineMode={true}
           tagsOptions={filterOptions}
           value={filter}
-          onChange={(value) => setFilter(value.currentTarget.value as any)}
+          onChange={(value) => {
+            setFilter(value.currentTarget.value as any);
+            filterTouched.current = true;
+          }}
           displayKey="label"
           valueKey="value"
           dropDownLabel="Add filter"


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [x] The PR is targeting the right branch (`dev` for features and `master` for
      releases)
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

This PR allows the Ingest Document Details page to reset Ingest items filter if the value was not touched. This addresses an issue where completed ingest items disappear when an Ingest is started. 

## Testing Notes

- Navigate to Ingest Upload
- Select a valid Ingest document 
- Click Upload

Previously, the completed items in the list would disappear if the user did not interact. With this update, the filters would be re-initialized with available and selected values. 
