### PR TITLE
[AB#47485] Add ADMIN as a permission for video playback

### DIFF
--- a/services/entitlement/service/src/domains/video/video-playback-middlewares.ts
+++ b/services/entitlement/service/src/domains/video/video-playback-middlewares.ts
@@ -38,7 +38,11 @@ const validateVideoPlaybackPermissionMiddleware = (
 
   const permissions =
     req.body?.payload?.management_user?.permissions?.['ax-video-service'] ?? [];
-  if (!permissions.includes('VIDEOS_STREAMING')) {
+  if (
+    !permissions.some((permission) =>
+      ['VIDEOS_STREAMING', 'ADMIN'].includes(permission),
+    )
+  ) {
     throw new MosaicError(CommonErrors.NoStreamingPermissions);
   }
   next();


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [ ] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description
This PR adds ADMIN permission for video playback.

## Testing Notes
1. Log into [mosaic-ott](https://navy.test.axinom.net).
2. Adjust the Admin User Role permission to not have VIDEOS_STREAMING permission from Video Service.
3. Pick a Video from the Video Service and try to preview. The video should play.
