### PR TITLE
[AB#50653] Remove logic related to service acount creation in setup script and deployment manifest

### DIFF
--- a/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
+++ b/services/entitlement/service/mosaic-hosting-deployment-manifest.yaml
@@ -98,12 +98,7 @@ secureVariables:
   DRM_LICENSE_COMMUNICATION_KEY: 'REPLACE_WITH_VALID_DRM_LICENSE_COMMUNICATION_KEY'
   DRM_LICENSE_COMMUNICATION_KEY_ID: 'REPLACE_WITH_VALID_DRM_LICENSE_COMMUNICATION_KEY_ID'
 
-serviceAccounts:
-  - name: 'primary'
-    permissionStructure:
-      - serviceId: 'ax-monetization-grants-service'
-        permissions:
-          - 'CLAIM_DEFINITIONS_SYNCHRONIZE'
+serviceAccounts: []
 
 pilets:
   # Defines the pilets (i.e. micro-frontends) associated with the service, and the required key-value pairs to run the pilet.

--- a/services/entitlement/service/scripts/setup.ts
+++ b/services/entitlement/service/scripts/setup.ts
@@ -4,7 +4,6 @@ import {
   isNullOrWhitespace,
   pick,
 } from '@axinom/mosaic-service-common';
-import { serviceAccountSetup } from '../../../../scripts/helpers';
 import { getConfigDefinitions } from '../src/common';
 import { userApplicationSetup } from './resources';
 
@@ -38,18 +37,6 @@ async function main(): Promise<void> {
   }
 
   await userApplicationSetup(config);
-  await serviceAccountSetup(
-    config.idServiceAuthBaseUrl,
-    config.devServiceAccountClientId,
-    config.devServiceAccountClientSecret,
-    config.serviceId,
-    [
-      {
-        serviceId: 'ax-monetization-grants-service',
-        permissions: ['CLAIM_DEFINITIONS_SYNCHRONIZE'],
-      },
-    ],
-  );
 }
 
 main().catch((error) => {


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [ ] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description
This PR removes logic related to service account creation in Entitlement Service in the setup script and the deployment manifest configuration.

## Testing Notes
When deploying Entitlement Service via Hosting Service, it should not create any service accounts.
