### PR TITLE
[AB#51143] add auto-increment for sort_order in collection_relations and update smart tag plugin

### DIFF
--- a/services/media/service/migrations/committed/000027-make-sort_order-auto-increment-in-collection_relations.sql
+++ b/services/media/service/migrations/committed/000027-make-sort_order-auto-increment-in-collection_relations.sql
@@ -1,0 +1,18 @@
+--! Previous: sha1:b74cde38f51e59d36d33923a186339559759f757
+--! Hash: sha1:25f0c9f515c338068eb854ead5e0c71af210d6e5
+--! Message: Make sort_order auto-increment in collection_relations
+
+-- create or replace the trigger to set the sort order to MAX + 1 for that specific collection if no value provided for sort_order
+CREATE OR REPLACE FUNCTION app_public.set_sort_order()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.sort_order IS NULL THEN
+        NEW.sort_order := COALESCE((SELECT MAX(sort_order) FROM app_public.collection_relations WHERE collection_id = NEW.collection_id), 0) + 1;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER set_sort_order_trigger
+BEFORE INSERT ON app_public.collection_relations
+FOR EACH ROW EXECUTE FUNCTION app_public.set_sort_order();

--- a/services/media/service/migrations/committed/000027-make-sort_order-auto-increment-in-collection_relations.sql
+++ b/services/media/service/migrations/committed/000027-make-sort_order-auto-increment-in-collection_relations.sql
@@ -1,18 +1,29 @@
 --! Previous: sha1:b74cde38f51e59d36d33923a186339559759f757
---! Hash: sha1:25f0c9f515c338068eb854ead5e0c71af210d6e5
+--! Hash: sha1:e941d1e38e76fad134ba61f00361c4c83ddb6500
 --! Message: Make sort_order auto-increment in collection_relations
 
 -- create or replace the trigger to set the sort order to MAX + 1 for that specific collection if no value provided for sort_order
 CREATE OR REPLACE FUNCTION app_public.set_sort_order()
 RETURNS TRIGGER AS $$
+DECLARE
+    max_sort_order INTEGER;
 BEGIN
     IF NEW.sort_order IS NULL THEN
-        NEW.sort_order := COALESCE((SELECT MAX(sort_order) FROM app_public.collection_relations WHERE collection_id = NEW.collection_id), 0) + 1;
+        SELECT COALESCE(MAX(sort_order), 0)
+        INTO max_sort_order
+        FROM
+        (
+          SELECT sort_order FROM app_public.collection_relations
+          WHERE collection_id = NEW.collection_id FOR UPDATE
+        );
+        NEW.sort_order := max_sort_order + 1;
     END IF;
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER set_sort_order_trigger
+DROP TRIGGER IF EXISTS set_sort_order_trigger ON app_public.collection_relations;
+
+CREATE TRIGGER set_sort_order_trigger
 BEFORE INSERT ON app_public.collection_relations
 FOR EACH ROW EXECUTE FUNCTION app_public.set_sort_order();

--- a/services/media/service/migrations/committed/000027-make-sort_order-auto-increment-in-collection_relations.sql
+++ b/services/media/service/migrations/committed/000027-make-sort_order-auto-increment-in-collection_relations.sql
@@ -1,22 +1,13 @@
 --! Previous: sha1:b74cde38f51e59d36d33923a186339559759f757
---! Hash: sha1:e941d1e38e76fad134ba61f00361c4c83ddb6500
+--! Hash: sha1:ed29a209c0cda142f10ecec524ea11c0f209d8bf
 --! Message: Make sort_order auto-increment in collection_relations
 
 -- create or replace the trigger to set the sort order to MAX + 1 for that specific collection if no value provided for sort_order
 CREATE OR REPLACE FUNCTION app_public.set_sort_order()
 RETURNS TRIGGER AS $$
-DECLARE
-    max_sort_order INTEGER;
 BEGIN
     IF NEW.sort_order IS NULL THEN
-        SELECT COALESCE(MAX(sort_order), 0)
-        INTO max_sort_order
-        FROM
-        (
-          SELECT sort_order FROM app_public.collection_relations
-          WHERE collection_id = NEW.collection_id FOR UPDATE
-        );
-        NEW.sort_order := max_sort_order + 1;
+        NEW.sort_order := COALESCE((SELECT MAX(sort_order) FROM app_public.collection_relations WHERE collection_id = NEW.collection_id), 0) + 1;
     END IF;
     RETURN NEW;
 END;

--- a/services/media/service/src/domains/collections/plugins/smart-tags-plugin.ts
+++ b/services/media/service/src/domains/collections/plugins/smart-tags-plugin.ts
@@ -42,6 +42,13 @@ export const SmartTagsPlugin = makeJSONPgSmartTagsPlugin({
             },
           },
         },
+        attribute: {
+          sort_order: {
+            tags: {
+              hasDefault: true,
+            },
+          },
+        },
       },
       'app_public.collections_snapshots': {
         tags: { omit: 'all,create,update,delete' },


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [ ] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Table: Media_service-app_public.collection_relations 

Requirement: make the sort order optional. It should auto increment based on the max value for the relevant collection id if no explicit sort order number is provided. 

Approach: Created a Before trigger to check the max sort order for a given collection id and to increment it by one if no value is provided for sort Order.

<!-- describe your changes here -->

1. create a migration 000027-make-sort_order-auto-increment-in-collection_relations.sql
2. append the hasDefault attribute for smart tag plugin for collection relations

## Testing

- sort order is incremented automatically for the collection id by one when not provided.
- sort order can be set explicitly with a non duplicate value.
- sort order starts by 1 for a collection id.
