### PR TITLE
[AB#49675] feat: add trimErrorsSkipMaskMiddleware to services

### DIFF
--- a/services/catalog/service/src/index.ts
+++ b/services/catalog/service/src/index.ts
@@ -13,11 +13,13 @@ import {
   MosaicErrors,
   setupGlobalConsoleOverride,
   setupGlobalLogMiddleware,
+  setupGlobalSkipMaskMiddleware,
   setupLivenessAndReadiness,
   setupMonitoring,
   setupServiceHealthEndpoint,
   setupShutdownActions,
   tenantEnvironmentIdsLogMiddleware,
+  trimErrorsSkipMaskMiddleware,
 } from '@axinom/mosaic-service-common';
 import express from 'express';
 import { PoolConfig } from 'pg';
@@ -35,6 +37,7 @@ const logger = new Logger({ context: 'bootstrap' });
 // Entry point for the service. For annotated version please see /services/media/service/src/index.ts.
 async function bootstrap(): Promise<void> {
   handleGlobalErrors(logger);
+  setupGlobalSkipMaskMiddleware(trimErrorsSkipMaskMiddleware);
   setupGlobalConsoleOverride(logger);
   const config = getFullConfig();
   setupGlobalLogMiddleware([tenantEnvironmentIdsLogMiddleware(config)]);


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [ ] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Axios errors are too long and unnecessarily verbose. They need to be cleaned before/while logging.

There is already a middleware present for this, named: trimErrorsSkipMaskMiddleware from @axinom/mosaic-service-common'. It is not applied by default and could be set at service level when bootstrapping as specified in the mosaic [docs](https://docs.axinom.com/concepts/logging_development_guide/#handling-huge-errors).

Other services except the catalog service had this already implemented. Therefore added the  call to the catalog service as well.

## Testing
Simulate a network error from each service which was modified (in this case Catalog service)  and check whether it is acceptable in size(not too long) and also it contains the important log worthy details like: statusCode, name, message, details, method, url, headers, component, stack trace.

<!-- describe your changes here -->
