### PR TITLE
[AB#51143] fix: push updated `schema.graphql` due to sort order input field change

### DIFF
--- a/services/media/service/src/generated/graphql/schema.graphql
+++ b/services/media/service/src/generated/graphql/schema.graphql
@@ -15114,7 +15114,7 @@ input CreateCollectionRelationInput {
 input CollectionRelationInput {
   id: Int
   collectionId: Int!
-  sortOrder: Int!
+  sortOrder: Int
   movieId: Int
   tvshowId: Int
   seasonId: Int


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [ ] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

in the PR #459 (make sort Order optional and auto incrementing for collection relations input), generated `services/media/service/src/generated/graphql/schema.graphql` file was missed when pushing the changes. Hence the hot-fix.

<!-- describe your changes here -->

Ran the services, committed the auto generated `schema.graphql` file. No manual changes.
