### PR TITLE
[AB#51931][AB#51932] fix: correct route resolver naming for TV show localizations

### DIFF
--- a/services/media/workflows/src/Stations/Ingest/IngestDocumentDetails/IngestItemsList/StepActionButton/StepActionButton.tsx
+++ b/services/media/workflows/src/Stations/Ingest/IngestDocumentDetails/IngestItemsList/StepActionButton/StepActionButton.tsx
@@ -23,10 +23,14 @@ export const StepActionButton: React.FC<StepActionButtonProps> = ({
 
   let path: string | undefined;
 
+  itemType =
+    itemType === IngestItemType.Tvshow ? IngestItemType.Tvshow : itemType;
+
   switch (stepType) {
-    case IngestItemStepType.Entity:
+    case IngestItemStepType.Entity: {
       path = getStationRoute(`${itemType}-details`, stepEntityId, resolveRoute);
       break;
+    }
     case IngestItemStepType.Localizations:
       path = getStationRoute(
         `${itemType}-${stepType}`,

--- a/services/media/workflows/src/Stations/Ingest/registrations.tsx
+++ b/services/media/workflows/src/Stations/Ingest/registrations.tsx
@@ -30,10 +30,20 @@ export function register(app: PiletApi, _extensions: Extensions): void {
     categoryName: 'Processing',
   });
 
-  app.registerPage('/ingest', IngestDocuments, {
-    breadcrumb: () => 'Ingest Explorer',
-    permissions: { 'media-service': ['ADMIN', 'INGESTS_EDIT', 'INGESTS_VIEW'] },
-  });
+  app.registerPage(
+    '/ingest',
+    () => (
+      <PortalContext.Provider value={{ resolveRoute: app.resolveRoute }}>
+        <IngestDocuments />
+      </PortalContext.Provider>
+    ),
+    {
+      breadcrumb: () => 'Ingest Explorer',
+      permissions: {
+        'media-service': ['ADMIN', 'INGESTS_EDIT', 'INGESTS_VIEW'],
+      },
+    },
+  );
 
   app.registerPage('/ingest/upload/', IngestDocumentUpload, {
     breadcrumb: () => 'Upload',

--- a/services/media/workflows/src/Stations/TvShows/registrations.tsx
+++ b/services/media/workflows/src/Stations/TvShows/registrations.tsx
@@ -53,7 +53,7 @@ export function register(app: PiletApi, extensions: Extensions): void {
     ]);
   }
 
-  app.setRouteResolver('tvshow-localizations', (dynamicRouteSegments) => {
+  app.setRouteResolver('tv_show-localizations', (dynamicRouteSegments) => {
     const localizationPath = getLocalizationEntryPoint('tv_show');
     const tvshowId =
       typeof dynamicRouteSegments === 'string'


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [ ] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

* pass context with route resolver to explorer station to add links to created items in ingest steps in bulk edit
*  in tvshow route resolvers use `tv_show` instead of `tvshow` 