### PR TITLE
[AB#52208] fix: use case insensitive filters for collections

### DIFF
--- a/services/media/workflows/src/Stations/Collections/CollectionsExplorer/Collections.filters.ts
+++ b/services/media/workflows/src/Stations/Collections/CollectionsExplorer/Collections.filters.ts
@@ -81,9 +81,9 @@ export function useCollectionsFilters(): {
     _excludeItems?: number[],
   ): CollectionFilter | undefined => {
     return filterToPostGraphileFilter<CollectionFilter>(filters, {
-      title: 'includes',
-      externalId: 'includes',
-      collectionsTags: ['some', 'name', 'includes'],
+      title: 'includesInsensitive',
+      externalId: 'includesInsensitive',
+      collectionsTags: ['some', 'name', 'includesInsensitive'],
       publishStatus: 'in',
       id: 'equalTo',
       createdDate: transformRange,


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [ ] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Updated filters in Collections to be case insensitive for text type filters. 
