### PR TITLE
[AB#52395] fix: :bug: handle deferred constraints separately for `collection_relations`

### DIFF
--- a/services/media/service/src/domains/common/handlers/bulk-edit-item-change-handler.ts
+++ b/services/media/service/src/domains/common/handlers/bulk-edit-item-change-handler.ts
@@ -44,14 +44,65 @@ export class BulkEditItemChangeHandler extends MediaGuardedTransactionalInboxMes
   ): Promise<void> {
     this.logger.debug({ details: { ...message.payload } });
 
-    const handled = await this.handleImageTableAddRelated(
+    const imageHandled = await this.handleImageTableAddRelated(
       message.payload,
       envOwnerClient,
     );
 
-    if (!handled) {
+    if (imageHandled) {
+      return;
+    }
+
+    const deferrableHandled = await this.handleDeferrableConstraintTables(
+      message.payload,
+      envOwnerClient,
+    );
+
+    if (!deferrableHandled) {
       await handlePerformItemChangeCommand(message.payload, envOwnerClient);
     }
+  }
+
+  private async handleDeferrableConstraintTables(
+    payload: PerformItemChangeCommand,
+    envOwnerClient: ClientBase,
+  ): Promise<boolean> {
+    // Handle collection_relations which has a DEFERRABLE sort_order constraint
+    // that conflicts with the `ON CONFLICT` clauses in the base `handlePerformItemChangeCommand` handler.
+    if (payload.table_name !== 'collection_relations') {
+      return false;
+    }
+
+    // Only handle ADD_RELATED_ENTITY as `ON CONFLICT` is not applicable for other actions
+    if (payload.action !== 'ADD_RELATED_ENTITY') {
+      return false;
+    }
+
+    const parsedPayload = JSON.parse(payload.stringified_payload);
+
+    // Use an INSERT + SELECT + WHERE NOT EXISTS query
+    // This gives best effort to avoid unique constraint violations for deferrable constraints
+    const columns = Object.keys(parsedPayload)
+      .map((col) => `"${col}"`)
+      .join(', ');
+    const values = Object.values(parsedPayload);
+    const placeholders = values.map((_, i) => `$${i + 1}`).join(', ');
+
+    const whereClause = Object.keys(parsedPayload)
+      .map((field, index) => `"${field}" = $${index + 1}`)
+      .join(' AND ');
+
+    const query = `
+      INSERT INTO "${payload.table_name}" (${columns})
+      SELECT ${placeholders}
+      WHERE NOT EXISTS (
+        SELECT 1 FROM "${payload.table_name}" WHERE ${whereClause}
+      )
+      RETURNING *
+    `;
+
+    await envOwnerClient.query(query, values);
+    return true;
   }
 
   private async handleImageTableAddRelated(

--- a/services/media/service/src/generated/graphql/schema.graphql
+++ b/services/media/service/src/generated/graphql/schema.graphql
@@ -15035,11 +15035,11 @@ type Mutation {
 
   """Creates a new Tvshow genres snapshot."""
   createTvshowGenresSnapshot: Snapshot
-  bulkEditMoviesAsync(filter: MovieFilter, set: MoviePatch, relatedEntitiesToRemove: BulkEditAsyncMovieRemoveInput, relatedEntitiesToAdd: BulkEditAsyncMovieAddInput): BulkEditAsyncPayloadType
-  bulkEditTvShowsAsync(filter: TvshowFilter, set: TvshowPatch, relatedEntitiesToRemove: BulkEditAsyncTvshowRemoveInput, relatedEntitiesToAdd: BulkEditAsyncTvshowAddInput): BulkEditAsyncPayloadType
-  bulkEditSeasonsAsync(filter: SeasonFilter, set: SeasonPatch, relatedEntitiesToRemove: BulkEditAsyncSeasonRemoveInput, relatedEntitiesToAdd: BulkEditAsyncSeasonAddInput): BulkEditAsyncPayloadType
-  bulkEditEpisodesAsync(filter: EpisodeFilter, set: EpisodePatch, relatedEntitiesToRemove: BulkEditAsyncEpisodeRemoveInput, relatedEntitiesToAdd: BulkEditAsyncEpisodeAddInput): BulkEditAsyncPayloadType
-  bulkEditCollectionsAsync(filter: CollectionFilter, set: CollectionPatch, relatedEntitiesToRemove: BulkEditAsyncCollectionRemoveInput, relatedEntitiesToAdd: BulkEditAsyncCollectionAddInput): BulkEditAsyncPayloadType
+  bulkEditMoviesAsync(filter: MovieFilter, set: MoviePatch, relatedEntitiesToClear: BulkEditAsyncMovieClearInput, relatedEntitiesToRemove: BulkEditAsyncMovieRemoveInput, relatedEntitiesToAdd: BulkEditAsyncMovieAddInput): BulkEditAsyncPayloadType
+  bulkEditTvShowsAsync(filter: TvshowFilter, set: TvshowPatch, relatedEntitiesToClear: BulkEditAsyncTvshowClearInput, relatedEntitiesToRemove: BulkEditAsyncTvshowRemoveInput, relatedEntitiesToAdd: BulkEditAsyncTvshowAddInput): BulkEditAsyncPayloadType
+  bulkEditSeasonsAsync(filter: SeasonFilter, set: SeasonPatch, relatedEntitiesToClear: BulkEditAsyncSeasonClearInput, relatedEntitiesToRemove: BulkEditAsyncSeasonRemoveInput, relatedEntitiesToAdd: BulkEditAsyncSeasonAddInput): BulkEditAsyncPayloadType
+  bulkEditEpisodesAsync(filter: EpisodeFilter, set: EpisodePatch, relatedEntitiesToClear: BulkEditAsyncEpisodeClearInput, relatedEntitiesToRemove: BulkEditAsyncEpisodeRemoveInput, relatedEntitiesToAdd: BulkEditAsyncEpisodeAddInput): BulkEditAsyncPayloadType
+  bulkEditCollectionsAsync(filter: CollectionFilter, set: CollectionPatch, relatedEntitiesToClear: BulkEditAsyncCollectionClearInput, relatedEntitiesToRemove: BulkEditAsyncCollectionRemoveInput, relatedEntitiesToAdd: BulkEditAsyncCollectionAddInput): BulkEditAsyncPayloadType
   populateCollections(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -21128,6 +21128,18 @@ type BulkEditAsyncPayloadType {
   filterMatchedIds: [String]
 }
 
+input BulkEditAsyncMovieClearInput {
+  moviesTags: Boolean
+  moviesCasts: Boolean
+  moviesLicenses: Boolean
+  moviesProductionCountries: Boolean
+  moviesMovieGenres: Boolean
+  moviesImages: Boolean
+  moviesTrailers: Boolean
+  collectionRelations: Boolean
+  moviesSnapshots: Boolean
+}
+
 input BulkEditAsyncMovieRemoveInput {
   moviesTags: [BulkEditAsyncMovieRemoveMoviesTagInput]
   moviesCasts: [BulkEditAsyncMovieRemoveMoviesCastInput]
@@ -21242,6 +21254,19 @@ input BulkEditAsyncMovieAddCollectionRelationInput {
 
 input BulkEditAsyncMovieAddMoviesSnapshotInput {
   snapshotId: Int!
+}
+
+input BulkEditAsyncTvshowClearInput {
+  tvshowsTags: Boolean
+  tvshowsCasts: Boolean
+  tvshowsLicenses: Boolean
+  tvshowsProductionCountries: Boolean
+  tvshowsTvshowGenres: Boolean
+  tvshowsImages: Boolean
+  tvshowsTrailers: Boolean
+  seasons: Boolean
+  collectionRelations: Boolean
+  tvshowsSnapshots: Boolean
 }
 
 input BulkEditAsyncTvshowRemoveInput {
@@ -21378,6 +21403,19 @@ input BulkEditAsyncTvshowAddCollectionRelationInput {
 
 input BulkEditAsyncTvshowAddTvshowsSnapshotInput {
   snapshotId: Int!
+}
+
+input BulkEditAsyncSeasonClearInput {
+  seasonsTags: Boolean
+  seasonsCasts: Boolean
+  seasonsLicenses: Boolean
+  seasonsProductionCountries: Boolean
+  seasonsTvshowGenres: Boolean
+  seasonsImages: Boolean
+  seasonsTrailers: Boolean
+  episodes: Boolean
+  collectionRelations: Boolean
+  seasonsSnapshots: Boolean
 }
 
 input BulkEditAsyncSeasonRemoveInput {
@@ -21532,6 +21570,18 @@ input BulkEditAsyncSeasonAddSeasonsSnapshotInput {
   snapshotId: Int!
 }
 
+input BulkEditAsyncEpisodeClearInput {
+  episodesTags: Boolean
+  episodesCasts: Boolean
+  episodesLicenses: Boolean
+  episodesProductionCountries: Boolean
+  episodesTvshowGenres: Boolean
+  episodesImages: Boolean
+  episodesTrailers: Boolean
+  collectionRelations: Boolean
+  episodesSnapshots: Boolean
+}
+
 input BulkEditAsyncEpisodeRemoveInput {
   episodesTags: [BulkEditAsyncEpisodeRemoveEpisodesTagInput]
   episodesCasts: [BulkEditAsyncEpisodeRemoveEpisodesCastInput]
@@ -21646,6 +21696,13 @@ input BulkEditAsyncEpisodeAddCollectionRelationInput {
 
 input BulkEditAsyncEpisodeAddEpisodesSnapshotInput {
   snapshotId: Int!
+}
+
+input BulkEditAsyncCollectionClearInput {
+  collectionRelations: Boolean
+  collectionsTags: Boolean
+  collectionsImages: Boolean
+  collectionsSnapshots: Boolean
 }
 
 input BulkEditAsyncCollectionRemoveInput {


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [X] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Added custom handling logic for the `BulkEditItemChangeHandler` to care for the table `collection_relations` since it uses a `DEFERRABLE INITIALLY DEFERRED` syntax that is not supported together with `ON CONFLICT` syntax that the Bulk Edit plugin uses for `ADD_RELATED_ENTITY`
