### PR TITLE
[AB#52922] fix: adjust genre filter to follow sort order

### DIFF
--- a/services/media/workflows/src/Stations/Episodes/EpisodeExplorerBase/EpisodeExplorer.filters.ts
+++ b/services/media/workflows/src/Stations/Episodes/EpisodeExplorerBase/EpisodeExplorer.filters.ts
@@ -15,13 +15,13 @@ import {
   EpisodesProductionCountriesOrderBy,
   EpisodesTagsFilterOptionsQuery,
   EpisodesTagsOrderBy,
-  EpisodesTvshowGenresFilterOptionsQuery,
-  EpisodesTvshowGenresOrderBy,
   PublishStatus,
+  TvShowGenresFilterOptionsQuery,
+  TvshowGenresOrderBy,
   useEpisodesCastsFilterOptionsQuery,
   useEpisodesProductionCountriesFilterOptionsQuery,
   useEpisodesTagsFilterOptionsQuery,
-  useEpisodesTvshowGenresFilterOptionsQuery,
+  useTvShowGenresFilterOptionsQuery,
 } from '../../../generated/graphql';
 import {
   createDateRangeFilters,
@@ -183,18 +183,16 @@ export function useEpisodesFilters(): {
 const fetchPolicy = 'network-only';
 
 function useEpisodeFilterData(): {
-  genres: NonNullable<
-    EpisodesTvshowGenresFilterOptionsQuery['episodesTvshowGenres']
-  >['nodes'][number]['tvshowGenres'][];
+  genres: NonNullable<TvShowGenresFilterOptionsQuery['tvshowGenres']>['nodes'];
   tags: NonNullable<EpisodesTagsFilterOptionsQuery['episodesTags']>['nodes'];
   casts: NonNullable<EpisodesCastsFilterOptionsQuery['episodesCasts']>['nodes'];
   countries: NonNullable<
     EpisodesProductionCountriesFilterOptionsQuery['episodesProductionCountries']
   >['nodes'];
 } {
-  const genres = useEpisodesTvshowGenresFilterOptionsQuery({
+  const genres = useTvShowGenresFilterOptionsQuery({
     client,
-    variables: { orderBy: [EpisodesTvshowGenresOrderBy.Natural] },
+    variables: { orderBy: [TvshowGenresOrderBy.SortOrderAsc] },
     fetchPolicy,
   });
 
@@ -217,10 +215,7 @@ function useEpisodeFilterData(): {
   });
 
   return {
-    genres:
-      genres.data?.episodesTvshowGenres?.nodes
-        ?.map((node) => node.tvshowGenres)
-        .filter(Boolean) ?? [],
+    genres: genres.data?.tvshowGenres?.nodes ?? [],
     tags: tags.data?.episodesTags?.nodes ?? [],
     casts: casts.data?.episodesCasts?.nodes ?? [],
     countries: countries.data?.episodesProductionCountries?.nodes ?? [],

--- a/services/media/workflows/src/Stations/Movies/MovieExplorerBase/MovieExplorer.filters.ts
+++ b/services/media/workflows/src/Stations/Movies/MovieExplorerBase/MovieExplorer.filters.ts
@@ -177,7 +177,7 @@ function useMovieFilterData(): {
 } {
   const genres = useMovieGenresFilterOptionsQuery({
     client,
-    variables: { orderBy: [MovieGenresOrderBy.TitleAsc] },
+    variables: { orderBy: [MovieGenresOrderBy.SortOrderAsc] },
     fetchPolicy,
   });
 

--- a/services/media/workflows/src/Stations/Seasons/SeasonExplorerBase/SeasonExplorer.filters.ts
+++ b/services/media/workflows/src/Stations/Seasons/SeasonExplorerBase/SeasonExplorer.filters.ts
@@ -12,16 +12,16 @@ import {
   SeasonFilter,
   SeasonsCastsFilterOptionsQuery,
   SeasonsCastsOrderBy,
-  SeasonsGenresFilterOptionsQuery,
   SeasonsProductionCountriesFilterOptionsQuery,
   SeasonsProductionCountriesOrderBy,
   SeasonsTagsFilterOptionsQuery,
   SeasonsTagsOrderBy,
-  SeasonsTvshowGenresOrderBy,
+  TvShowGenresFilterOptionsQuery,
+  TvshowGenresOrderBy,
   useSeasonsCastsFilterOptionsQuery,
-  useSeasonsGenresFilterOptionsQuery,
   useSeasonsProductionCountriesFilterOptionsQuery,
   useSeasonsTagsFilterOptionsQuery,
+  useTvShowGenresFilterOptionsQuery,
 } from '../../../generated/graphql';
 import {
   createDateRangeFilters,
@@ -166,18 +166,16 @@ export function useSeasonsFilters(): {
 const fetchPolicy = 'network-only';
 
 function useSeasonFilterData(): {
-  genres: NonNullable<
-    SeasonsGenresFilterOptionsQuery['seasonsTvshowGenres']
-  >['nodes'][number]['tvshowGenres'][];
+  genres: NonNullable<TvShowGenresFilterOptionsQuery['tvshowGenres']>['nodes'];
   tags: NonNullable<SeasonsTagsFilterOptionsQuery['seasonsTags']>['nodes'];
   casts: NonNullable<SeasonsCastsFilterOptionsQuery['seasonsCasts']>['nodes'];
   countries: NonNullable<
     SeasonsProductionCountriesFilterOptionsQuery['seasonsProductionCountries']
   >['nodes'];
 } {
-  const genres = useSeasonsGenresFilterOptionsQuery({
+  const genres = useTvShowGenresFilterOptionsQuery({
     client,
-    variables: { orderBy: [SeasonsTvshowGenresOrderBy.Natural] },
+    variables: { orderBy: [TvshowGenresOrderBy.SortOrderAsc] },
     fetchPolicy,
   });
 
@@ -200,10 +198,7 @@ function useSeasonFilterData(): {
   });
 
   return {
-    genres:
-      genres.data?.seasonsTvshowGenres?.nodes
-        ?.map((node) => node.tvshowGenres)
-        .filter(Boolean) ?? [],
+    genres: genres.data?.tvshowGenres?.nodes ?? [],
     tags: tags.data?.seasonsTags?.nodes ?? [],
     casts: casts.data?.seasonsCasts?.nodes ?? [],
     countries: countries.data?.seasonsProductionCountries?.nodes ?? [],

--- a/services/media/workflows/src/Stations/TvShows/TvShowExplorerBase/TvShowExplorer.filters.ts
+++ b/services/media/workflows/src/Stations/TvShows/TvShowExplorerBase/TvShowExplorer.filters.ts
@@ -131,7 +131,8 @@ export function useTvShowsFilters(): {
       studio: 'includesInsensitive',
       publishStatus: 'in',
       id: (value) => {
-        if (typeof value === 'number') {          return {
+        if (typeof value === 'number') {
+          return {
             equalTo: value,
             notIn: excludeItems,
           };
@@ -162,7 +163,7 @@ function useTvShowFilterData(): {
 } {
   const genres = useTvShowGenresFilterOptionsQuery({
     client,
-    variables: { orderBy: [TvshowGenresOrderBy.TitleAsc] },
+    variables: { orderBy: [TvshowGenresOrderBy.SortOrderAsc] },
     fetchPolicy,
   });
 


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [ ] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

This PR updates the filters for Movies, TV Series, Seasons and Episodes to adhere to the sort order defined in the respective media settings pages. 
