### PR TITLE
[AB#52082] fix: BulkEdit assignment fields not showing errors

### DIFF
--- a/services/media/workflows/src/Util/BulkEdit/ImageSelectField.tsx
+++ b/services/media/workflows/src/Util/BulkEdit/ImageSelectField.tsx
@@ -1,5 +1,5 @@
 import { ImageSelectFieldProps } from '@axinom/mosaic-managed-workflow-integration';
-import { BulkEditEnumType } from '@axinom/mosaic-ui';
+import { BulkEditEnumType, useFormikError } from '@axinom/mosaic-ui';
 import React, { useContext } from 'react';
 import { ExtensionsContext } from '../../externals';
 
@@ -10,6 +10,7 @@ export const getBulkEditImageSelectField: (
 ) => React.FC<ImageSelectFieldProps> = (type, scope, maxItems) => {
   const Component: React.FC<ImageSelectFieldProps> = (props) => {
     const { ImageSelectField } = useContext(ExtensionsContext);
+    const error = useFormikError(props.name);
     return (
       <ImageSelectField
         {...props}
@@ -31,6 +32,7 @@ export const getBulkEditImageSelectField: (
         }}
         imageType={`${scope}_${type.toLowerCase()}`}
         maxItems={maxItems}
+        error={error}
       />
     );
   };

--- a/services/media/workflows/src/Util/BulkEdit/MainVideoSelectField.tsx
+++ b/services/media/workflows/src/Util/BulkEdit/MainVideoSelectField.tsx
@@ -1,4 +1,4 @@
-import { SingleLineTextProps } from '@axinom/mosaic-ui';
+import { SingleLineTextProps, useFormikError } from '@axinom/mosaic-ui';
 import React, { useContext } from 'react';
 import { ExtensionsContext } from '../../externals';
 
@@ -7,6 +7,7 @@ export const MainVideoSelectionField: React.FC<SingleLineTextProps> = (
 ) => {
   const { VideoSelectField } = useContext(ExtensionsContext);
   const { value, onChange, name, label = '' } = props;
+  const error = useFormikError(props.name);
 
   return (
     <VideoSelectField
@@ -27,6 +28,7 @@ export const MainVideoSelectionField: React.FC<SingleLineTextProps> = (
         });
       }}
       maxItems={1}
+      error={error}
     />
   );
 };

--- a/services/media/workflows/src/Util/BulkEdit/VideoSelectField.tsx
+++ b/services/media/workflows/src/Util/BulkEdit/VideoSelectField.tsx
@@ -1,6 +1,7 @@
 import { VideoSelectFieldProps } from '@axinom/mosaic-video-workflow-integration';
 import React, { useContext } from 'react';
 import { ExtensionsContext } from '../../externals';
+import { useFormikError } from '@axinom/mosaic-ui';
 
 export const getVideoSelectField: (
   type: string,
@@ -8,6 +9,7 @@ export const getVideoSelectField: (
 ) => React.FC<VideoSelectFieldProps> = (type, maxItems) => {
   const Component: React.FC<VideoSelectFieldProps> = (props) => {
     const { VideoSelectField } = useContext(ExtensionsContext);
+    const error = useFormikError(props.name);
     const { value, onChange, name } = props;
 
     return (
@@ -29,6 +31,7 @@ export const getVideoSelectField: (
           });
         }}
         maxItems={maxItems}
+        error={error}
       />
     );
   };


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [ ] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

This PR fixes an issue where bulk edit assignment fields are not showing error messages. 
