### PR TITLE
[AB#53731] fix: issue in Safari where the SVG icon exceeds the container dimensions

### DIFF
--- a/services/channel/workflows/src/util/Publishing/SeverityRenderer/SeverityRenderer.tsx
+++ b/services/channel/workflows/src/util/Publishing/SeverityRenderer/SeverityRenderer.tsx
@@ -20,7 +20,8 @@ export const SeverityRenderer: ColumnRenderer<Data> = (val): ReactNode => {
 
     return (
       <div className={classes.severityRendererContainer}>
-        {image}
+        {/* Adding an empty div to support Safari browser which renders SVG icon differently */}
+        <div>{image}</div>
         <div className={classes.text}>{formatTitleCase(val as string)}</div>
       </div>
     );

--- a/services/media/workflows/src/Stations/Publishing/PublishingSnapshotDetails/SeverityRenderer/SeverityRenderer.tsx
+++ b/services/media/workflows/src/Stations/Publishing/PublishingSnapshotDetails/SeverityRenderer/SeverityRenderer.tsx
@@ -29,7 +29,8 @@ export const SeverityRenderer: ColumnRenderer<Data> = (val): ReactNode => {
 
     return (
       <div className={classes.severityRendererContainer}>
-        {image}
+        {/* Adding an empty div to support Safari browser which renders SVG icon differently */}
+        <div>{image}</div>
         <div className={classes.text}>{formatTitleCase(val as string)}</div>
       </div>
     );


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [ ] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

PR fixes an issue in SVG rendering where the icon dimensions exceed the container dimensions. The solution was to wrap the SVG in a `div` element with `display: block`
