### PR TITLE
[AB#54488] fix: remediate Dependabot vulnerabilities (shell-quote, ws, postcss, qs)

### DIFF
--- a/.claude/skills/fix-vulnerabilities/SKILL.md
+++ b/.claude/skills/fix-vulnerabilities/SKILL.md
@@ -21,6 +21,7 @@ Before scanning for new vulnerabilities, check if any existing resolutions in `R
 1. Read `RESOLUTIONS.md` if it exists
 2. For each **Active Resolution**: check if the forced version is now satisfied naturally by the parent's semver range (`yarn why <package-name>`). If so, remove the resolution from root `package.json`, remove the entry from `RESOLUTIONS.md`, and run `yarn install`.
 3. For each **Waiting for Upstream** entry: check if the blocking parent package has released a new version that fixes the issue (verify via Dependabot alerts in step 3). If so, remove the entry and proceed with a normal lockfile fix.
+4. For each **Deferred (Tolerated For Now)** entry: check whether its "Next step / done when" condition is now met (e.g. the `@axinom/mosaic-*` bump in step 2 widened the range). If so, fix it and remove the entry. These alerts are kept open in Dependabot, so they will reappear in step 3 — that is expected; do not re-triage them from scratch, just re-check the done-when condition.
 
 The goal is to minimize resolutions and return to normal dependency resolution when possible.
 
@@ -69,18 +70,36 @@ Look for patterns: if multiple vulnerable packages all trace back to the same pa
 
 **Do NOT manually patch `checksum:`, `version:`, or `resolution:` values** — the Berry checksum format is not an npm integrity hash and cannot be sourced from `npm view`. Instead, delete the entry and let Yarn re-resolve it.
 
-1. **Delete the lockfile entry** for the vulnerable package:
+1. **Delete the lockfile entry** for the vulnerable package. **Match by the exact header line, not by hardcoded line numbers** — line-number arithmetic is error-prone (an off-by-one can delete the *next* entry's header and silently merge two packages into one corrupt entry, which breaks the install/build in non-obvious ways). The snippet below finds each entry by its full header string and deletes from the header through the trailing blank line:
 
 ```python
-# Find the entry's line range with:
-# grep -n "^\"<package>@npm:" yarn.lock
-# Then delete that range (start line to blank line inclusive):
 python3 << 'EOF'
 lockfile = "yarn.lock"
 with open(lockfile) as f:
     lines = f.readlines()
-# Delete in reverse order if removing multiple entries
-del lines[START-1:END]  # 1-indexed, inclusive of trailing blank line
+
+# Paste the FULL header line(s) exactly as they appear in yarn.lock,
+# including quotes, all comma-joined selectors, the trailing ":" and "\n".
+# Get them with:  grep -nE '^"?<package>@npm' yarn.lock
+targets = [
+    '"ws@npm:^8.12.0, ws@npm:^8.13.0, ws@npm:^8.15.0":\n',
+    '"postcss@npm:^8.0.0, postcss@npm:^8.4.4":\n',
+]
+
+ranges = []
+for t in targets:
+    if t not in lines:
+        print("NOT FOUND (check exact header):", t.strip()); continue
+    i = lines.index(t)            # header line index (0-based)
+    j = i + 1
+    while j < len(lines) and lines[j].strip() != "":  # walk to the blank line
+        j += 1
+    ranges.append((i, j + 1))     # j+1 = exclusive end, includes trailing blank
+    print(f"deleting {t.strip()[:60]}  ({i+1}..{j+1})")
+
+for (i, end) in sorted(ranges, reverse=True):  # reverse so indices stay valid
+    del lines[i:end]
+
 with open(lockfile, 'w') as f:
     f.writelines(lines)
 EOF
@@ -88,7 +107,7 @@ EOF
 
 2. **Run `yarn install --no-immutable`** — Yarn re-resolves to the latest satisfying version and computes the correct checksum automatically.
 
-Multiple entries can be deleted in one pass (process ranges in reverse order to preserve line numbers). Yarn will re-resolve all of them in a single `install` run.
+Multiple entries can be deleted in one pass (the snippet handles reverse-order deletion). Yarn will re-resolve all of them in a single `install` run. **After reinstalling, sanity-check that no entries were merged** — e.g. `grep -nE '^"?<pkg>@npm' yarn.lock` should still show each package as its own header, and a quick `yarn build` catches corruption early.
 
 **Note:** `yarn up <package>` only works for direct dependencies — not usable for transitive packages. For transitive packages, always use the delete-and-reinstall approach.
 
@@ -142,23 +161,32 @@ Some vulnerabilities cannot be fixed via lockfile updates:
 - **Breaking changes**: When the patch is in a new major version
 - **Upstream not updated**: Parent package hasn't updated its dependency range
 
-For these, **ask the user** using AskUserQuestion before taking action:
+For these, **ask the user** using AskUserQuestion before taking action. Offer these options:
 
 **Option A: Add a resolution (requires user approval)**
 - Use yarn `resolutions` in root `package.json` to force the patched version
 - Document the resolution in `RESOLUTIONS.md` (see section 9)
 
-**Option B: Ignore the vulnerability**
-- User accepts the risk for now
-- Document the decision and reason in `RESOLUTIONS.md` under "Ignored Vulnerabilities"
+**Option B: Defer — tolerate for now, keep the alert open**
+- The user wants to fix it eventually but the fix is bigger/involved work (e.g. a major-version migration that needs upstream coordination, like bumping `@axinom/mosaic-*` ranges). This also fits cases where "waiting for upstream" doesn't apply because the package itself is deprecated and the project genuinely needs to move off it.
+- **Do NOT dismiss the Dependabot alert** — leave it open as a tracking reminder.
+- Document under "Deferred (Tolerated For Now)" in `RESOLUTIONS.md` with the concrete next step / done-when condition.
+
+**Option C: Ignore — accept the risk permanently**
+- The vulnerability is not relevant to this project (e.g. an unreachable code path, dev-only tooling not in any deployed runtime) and there is no intent to fix it.
+- Document under "Ignored Vulnerabilities" in `RESOLUTIONS.md`.
 - Dismiss the Dependabot alert: `gh api --method PATCH /repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/dependabot/alerts/<number> -f state=dismissed -f dismissed_reason=tolerable_risk -f dismissed_comment="<reason>"`
 
-**Option C: Wait for upstream fix**
-- No action taken now, but document it in `RESOLUTIONS.md` under "Waiting for Upstream" so it isn't re-examined from scratch next run
+**Option D: Wait for upstream fix**
+- No action taken and no intent to force anything — a parent package simply needs to release an updated dependency range. Document under "Waiting for Upstream" so it isn't re-examined from scratch next run. Leave the alert open.
+
+The difference between **Defer** and **Wait for upstream**: *Defer* is "we own this, it's on our backlog as non-trivial work"; *Wait for upstream* is "we're blocked on someone else releasing and there's nothing for us to do but check back". Both keep the alert open. **Ignore** is the only option that dismisses the alert.
 
 ### 9. Document resolutions
 
-When a resolution is added to root `package.json`, create or update `RESOLUTIONS.md` with the following format:
+When a resolution is added to root `package.json`, or a vulnerability is deferred/ignored/waiting, create or update `RESOLUTIONS.md` with the following format.
+
+**Do NOT reference Dependabot alert IDs** (`#123`) anywhere in `RESOLUTIONS.md` — those numbers are only meaningful to people with access to this repo's Dependabot alerts, and they churn. Identify vulnerabilities by package name + CVE/GHSA ID + a short description instead.
 
 ```markdown
 # Dependency Resolutions
@@ -171,18 +199,32 @@ The goal is to minimize resolutions and remove them when no longer needed.
 ### <package-name>
 
 - **Forced version**: `<version>`
-- **Reason**: <vulnerability CVE or description>
+- **Reason**: <vulnerability CVE/GHSA or description>
 - **Parent packages**: <which packages depend on this>
 - **Original selector**: `<semver-range>` (e.g., `^1.1.7`)
 - **Date added**: <YYYY-MM-DD>
 - **Can be removed when**: <condition, e.g., "parent-package updates to >=2.0.0">
 
+## Deferred (Tolerated For Now)
+
+Vulnerabilities we intend to fix eventually, but where the fix is bigger/involved
+work. The Dependabot alert is intentionally kept **open** as a tracking reminder.
+
+### <package-name>
+
+- **Vulnerability**: <CVE/GHSA or description>
+- **Current versions**: <versions in tree>
+- **Patched in**: <version> (note if it's a major-version jump)
+- **Why deferred**: <why it's low-risk for now AND why the fix is non-trivial>
+- **Date**: <YYYY-MM-DD>
+- **Next step / done when**: <the concrete work that closes this, e.g. "bump @axinom/mosaic-* to accept uuid@^11">
+
 ## Ignored Vulnerabilities
 
 ### <package-name>
 
-- **Vulnerability**: <CVE or description>
-- **Reason for ignoring**: <explanation>
+- **Vulnerability**: <CVE/GHSA or description>
+- **Reason for ignoring**: <why it's irrelevant to this project — alert was dismissed>
 - **Date**: <YYYY-MM-DD>
 - **Review again when**: <condition or date>
 
@@ -190,7 +232,7 @@ The goal is to minimize resolutions and remove them when no longer needed.
 
 ### <package-name>
 
-- **Vulnerability**: <CVE or description>
+- **Vulnerability**: <CVE/GHSA or description>
 - **Blocked by**: <parent-package> needs to update its dependency range
 - **Date**: <YYYY-MM-DD>
 - **Check again when**: <parent-package> releases a new version
@@ -208,3 +250,6 @@ This documentation enables step 1 to check whether resolutions can be removed.
 - Add resolutions without asking the user first
 - Add resolutions without documenting them in `RESOLUTIONS.md`
 - Manually dismiss Dependabot alerts for fixed vulnerabilities (Dependabot does this automatically)
+- Dismiss a Dependabot alert when the user chose **Defer** or **Wait for upstream** — only **Ignore** dismisses; the others keep the alert open
+- Reference Dependabot alert IDs (`#123`) in `RESOLUTIONS.md` — they're only meaningful with repo Dependabot access; use package name + CVE/GHSA + description instead
+- Delete lockfile entries by hardcoded line numbers — match the exact header string (an off-by-one merges adjacent entries and corrupts the lockfile)

--- a/RESOLUTIONS.md
+++ b/RESOLUTIONS.md
@@ -89,11 +89,22 @@ The goal is to minimize resolutions and remove them when no longer needed.
 - **Date**: 2026-04-14
 - **Check again when**: `minimatch@3.x` updates to use `brace-expansion@^2.x` (unlikely for 3.x line)
 
-### tmp@^0.0.33 (Dependabot #168)
+## Ignored Vulnerabilities
 
-- **Vulnerability**: Arbitrary temp file/dir write via symlink (low severity)
+### uuid (Dependabot #297, #299, #301–#305)
+
+- **Vulnerability**: Missing buffer bounds check in `v3`/`v5`/`v6` when `buf` is provided (medium severity)
+- **Current versions**: 8.3.2, 9.0.1
+- **Patched in**: 11.1.1 (major version jump)
+- **Reason for ignoring**: The bug only affects `v3`/`v5`/`v6` generation when an explicit output `buf` is passed. All consumers (`@axinom/mosaic-message-bus`, `@axinom/mosaic-service-common`, `@azure/core-http`, `rascal`, `pg-transactional-outbox`, `jest-junit`) pin `uuid@^8.3.2` / `^9.0.x` and use `v4` (random), which is unaffected. Reaching the patched 11.x requires a forced major-version resolution with real breakage risk, for a code path the project does not exercise.
+- **Date**: 2026-06-09
+- **Review again when**: A consumer bumps its `uuid` range to `^11`, or the project starts using `v3`/`v5`/`v6` with an explicit `buf`
+
+### tmp (Dependabot #168, #306)
+
+- **Vulnerability**: Arbitrary temp file/dir write via symlink `dir` parameter (low, #168); path traversal via unsanitized prefix/postfix (high, #306)
 - **Current version**: 0.0.33
-- **Patched in**: 0.2.4
-- **Blocked by**: `external-editor@3.1.0` (latest) pins `tmp@^0.0.33`; `^0.0.33` resolves only `0.0.33` in strict semver. `external-editor` has not released a new version since 3.1.0.
-- **Date**: 2026-03-12
-- **Check again when**: `external-editor` releases a new version with an updated `tmp` dep, or `@graphql-codegen/cli` stops depending on `inquirer@8`
+- **Patched in**: 0.2.4 (#168) / 0.2.6 (#306) — both major-line jumps with API changes
+- **Reason for ignoring**: `tmp@0.0.33` is dev-only — pulled solely via `external-editor@3.1.0` (`@graphql-codegen/cli` → `inquirer@8`). It is not present in any deployed service runtime. `external-editor@3.1.0` (latest, unreleased since) pins `tmp@^0.0.33`; reaching 0.2.6 requires a forced resolution that risks breaking `external-editor`'s use of the old `tmp` API.
+- **Date**: 2026-06-09
+- **Review again when**: `external-editor` releases a new version with an updated `tmp` dep, or `@graphql-codegen/cli` stops depending on `inquirer@8`

--- a/RESOLUTIONS.md
+++ b/RESOLUTIONS.md
@@ -44,7 +44,7 @@ The goal is to minimize resolutions and remove them when no longer needed.
 
 ## Waiting for Upstream Fix
 
-### ajv@5.x / 6.x (Dependabot #86, npm audit)
+### ajv@5.x / 6.x
 
 - **Vulnerability**: Prototype Pollution (medium severity), ReDoS (medium severity)
 - **Current versions**: 5.5.2, 6.5.2, 6.12.6
@@ -53,7 +53,7 @@ The goal is to minimize resolutions and remove them when no longer needed.
 - **Date**: 2026-02-23
 - **Check again when**: `@axinom/mosaic-cli` updates `@asyncapi/parser` to `^3.x`
 
-### lodash@4.17.23 via tilde ranges (Dependabot #254, #255)
+### lodash@4.17.23 via tilde ranges
 
 - **Vulnerability**: Prototype Pollution via array path bypass (medium), Code Injection via `_.template` imports (high)
 - **Current version**: 4.17.23
@@ -62,16 +62,16 @@ The goal is to minimize resolutions and remove them when no longer needed.
 - **Date**: 2026-04-14
 - **Check again when**: `@graphql-codegen/plugin-helpers` or `@stoplight/spectral-core` update their lodash range to `^4.18.0`
 
-### serialize-javascript (Dependabot #223, #247)
+### serialize-javascript
 
 - **Vulnerability**: RCE via RegExp.flags/Date.prototype.toISOString (high), CPU Exhaustion DoS (medium)
 - **Current version**: 6.0.2
-- **Patched in**: 7.0.3 (#223), 7.0.5 (#247)
+- **Patched in**: 7.0.3 / 7.0.5
 - **Blocked by**: `css-minimizer-webpack-plugin@5.0.1` requires `^6.0.1`. Only 5.0.0 and 5.0.1 exist for 5.x. Latest css-minimizer-webpack-plugin (7.x) uses `^7.0.3`, but `piral-cli-webpack5@1.5.3` requires `^5.0.1`.
 - **Date**: 2026-03-03
 - **Check again when**: `piral-cli-webpack5` updates its css-minimizer-webpack-plugin range
 
-### immutable@~3.7.6 (Dependabot #229)
+### immutable@~3.7.6
 
 - **Vulnerability**: Prototype Pollution (high severity)
 - **Current version**: 3.7.6
@@ -89,22 +89,27 @@ The goal is to minimize resolutions and remove them when no longer needed.
 - **Date**: 2026-04-14
 - **Check again when**: `minimatch@3.x` updates to use `brace-expansion@^2.x` (unlikely for 3.x line)
 
-## Ignored Vulnerabilities
+## Deferred (Tolerated For Now)
 
-### uuid (Dependabot #297, #299, #301–#305)
+Vulnerabilities we intend to fix eventually, but where the fix is bigger/involved
+work (e.g. a major-version migration that needs upstream coordination). The
+Dependabot alert is intentionally kept **open** as a tracking reminder — these are
+not dismissed and not passively "waiting for upstream".
+
+### uuid
 
 - **Vulnerability**: Missing buffer bounds check in `v3`/`v5`/`v6` when `buf` is provided (medium severity)
 - **Current versions**: 8.3.2, 9.0.1
 - **Patched in**: 11.1.1 (major version jump)
-- **Reason for ignoring**: The bug only affects `v3`/`v5`/`v6` generation when an explicit output `buf` is passed. All consumers (`@axinom/mosaic-message-bus`, `@axinom/mosaic-service-common`, `@azure/core-http`, `rascal`, `pg-transactional-outbox`, `jest-junit`) pin `uuid@^8.3.2` / `^9.0.x` and use `v4` (random), which is unaffected. Reaching the patched 11.x requires a forced major-version resolution with real breakage risk, for a code path the project does not exercise.
+- **Why deferred**: The bug only affects `v3`/`v5`/`v6` generation when an explicit output `buf` is passed; all consumers (`@axinom/mosaic-message-bus`, `@axinom/mosaic-service-common`, `@azure/core-http`, `rascal`, `pg-transactional-outbox`, `jest-junit`) pin `uuid@^8.3.2` / `^9.0.x` and use `v4` (random), which is unaffected. uuid <11 is also deprecated, so we do want to move off it — but reaching 11.x means coordinating upstream (`@axinom/mosaic-*` ranges) rather than passively waiting, so it is tracked as future work.
 - **Date**: 2026-06-09
-- **Review again when**: A consumer bumps its `uuid` range to `^11`, or the project starts using `v3`/`v5`/`v6` with an explicit `buf`
+- **Next step / done when**: Bump the `@axinom/mosaic-*` libraries (and other consumers) so they accept `uuid@^11`, then drop any need for a resolution. Until then the alert stays open.
 
-### tmp (Dependabot #168, #306)
+### tmp
 
-- **Vulnerability**: Arbitrary temp file/dir write via symlink `dir` parameter (low, #168); path traversal via unsanitized prefix/postfix (high, #306)
+- **Vulnerability**: Arbitrary temp file/dir write via symlink `dir` parameter (low); path traversal via unsanitized prefix/postfix (high)
 - **Current version**: 0.0.33
-- **Patched in**: 0.2.4 (#168) / 0.2.6 (#306) — both major-line jumps with API changes
-- **Reason for ignoring**: `tmp@0.0.33` is dev-only — pulled solely via `external-editor@3.1.0` (`@graphql-codegen/cli` → `inquirer@8`). It is not present in any deployed service runtime. `external-editor@3.1.0` (latest, unreleased since) pins `tmp@^0.0.33`; reaching 0.2.6 requires a forced resolution that risks breaking `external-editor`'s use of the old `tmp` API.
+- **Patched in**: 0.2.4 / 0.2.6 — both major-line jumps with API changes
+- **Why deferred**: `tmp@0.0.33` is dev-only — pulled solely via `external-editor@3.1.0` (`@graphql-codegen/cli` → `inquirer@8`), not present in any deployed service runtime. `external-editor@3.1.0` (latest, unreleased since) pins `tmp@^0.0.33`; reaching 0.2.6 needs either a forced resolution that risks breaking `external-editor`'s use of the old `tmp` API, or migrating off the `inquirer@8` toolchain. Worth doing eventually, so the alert stays open.
 - **Date**: 2026-06-09
-- **Review again when**: `external-editor` releases a new version with an updated `tmp` dep, or `@graphql-codegen/cli` stops depending on `inquirer@8`
+- **Next step / done when**: `external-editor` releases a version with an updated `tmp` dep, `@graphql-codegen/cli` stops depending on `inquirer@8`, or a vetted forced resolution to `tmp@^0.2.6` is confirmed safe for `external-editor`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6887,9 +6887,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:^1.15.2, body-parser@npm:~1.20.3":
-  version: 1.20.4
-  resolution: "body-parser@npm:1.20.4"
+"body-parser@npm:^1.15.2, body-parser@npm:~1.20.5":
+  version: 1.20.5
+  resolution: "body-parser@npm:1.20.5"
   dependencies:
     bytes: "npm:~3.1.2"
     content-type: "npm:~1.0.5"
@@ -6899,11 +6899,11 @@ __metadata:
     http-errors: "npm:~2.0.1"
     iconv-lite: "npm:~0.4.24"
     on-finished: "npm:~2.4.1"
-    qs: "npm:~6.14.0"
+    qs: "npm:~6.15.1"
     raw-body: "npm:~2.5.3"
     type-is: "npm:~1.6.18"
     unpipe: "npm:~1.0.0"
-  checksum: 10c0/569c1e896297d1fcd8f34026c8d0ab70b90d45343c15c5d8dff5de2bad08125fc1e2f8c2f3f4c1ac6c0caaad115218202594d37dcb8d89d9b5dcae1c2b736aa9
+  checksum: 10c0/ad777ca5e4711eae253c93f50fdc4608c60b76a9710d79e5e5b84581c76691e6ad21ecc9158986d9ea2b365df73e403ca33c27a8bccc1a7cfc2ccc248548118d
   languageName: node
   linkType: hard
 
@@ -9687,12 +9687,12 @@ __metadata:
   linkType: hard
 
 "express@npm:^4.16.2, express@npm:^4.17.1, express@npm:^4.18.1":
-  version: 4.22.1
-  resolution: "express@npm:4.22.1"
+  version: 4.22.2
+  resolution: "express@npm:4.22.2"
   dependencies:
     accepts: "npm:~1.3.8"
     array-flatten: "npm:1.1.1"
-    body-parser: "npm:~1.20.3"
+    body-parser: "npm:~1.20.5"
     content-disposition: "npm:~0.5.4"
     content-type: "npm:~1.0.4"
     cookie: "npm:~0.7.1"
@@ -9711,7 +9711,7 @@ __metadata:
     parseurl: "npm:~1.3.3"
     path-to-regexp: "npm:~0.1.12"
     proxy-addr: "npm:~2.0.7"
-    qs: "npm:~6.14.0"
+    qs: "npm:~6.15.1"
     range-parser: "npm:~1.2.1"
     safe-buffer: "npm:5.2.1"
     send: "npm:~0.19.0"
@@ -9721,7 +9721,7 @@ __metadata:
     type-is: "npm:~1.6.18"
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
-  checksum: 10c0/ea57f512ab1e05e26b53a14fd432f65a10ec735ece342b37d0b63a7bcb8d337ffbb830ecb8ca15bcdfe423fbff88cea09786277baff200e8cde3ab40faa665cd
+  checksum: 10c0/d06dd4379fd217440b30f8abbe45f0e74931114c1395034f03e7d635196ecdab530d4835a1962a6aa34838d61967dc6f1f77846999bba3032373e9e714222c44
   languageName: node
   linkType: hard
 
@@ -13958,12 +13958,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.8":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.12":
+  version: 3.3.12
+  resolution: "nanoid@npm:3.3.12"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
   languageName: node
   linkType: hard
 
@@ -15656,13 +15656,13 @@ __metadata:
   linkType: hard
 
 "postcss@npm:^8.0.0, postcss@npm:^8.4.19, postcss@npm:^8.4.21, postcss@npm:^8.4.24, postcss@npm:^8.4.33, postcss@npm:^8.4.4":
-  version: 8.5.3
-  resolution: "postcss@npm:8.5.3"
+  version: 8.5.15
+  resolution: "postcss@npm:8.5.15"
   dependencies:
-    nanoid: "npm:^3.3.8"
+    nanoid: "npm:^3.3.12"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/b75510d7b28c3ab728c8733dd01538314a18c52af426f199a3c9177e63eb08602a3938bfb66b62dc01350b9aed62087eabbf229af97a1659eb8d3513cec823b3
+  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
   languageName: node
   linkType: hard
 
@@ -16040,21 +16040,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.10.3, qs@npm:^6.11.0":
-  version: 6.15.0
-  resolution: "qs@npm:6.15.0"
+"qs@npm:^6.10.3, qs@npm:^6.11.0, qs@npm:~6.15.1":
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
   dependencies:
     side-channel: "npm:^1.1.0"
-  checksum: 10c0/ff341078a78a991d8a48b4524d52949211447b4b1ad907f489cac0770cbc346a28e47304455c0320e5fb000f8762d64b03331e3b71865f663bf351bcba8cdb4b
-  languageName: node
-  linkType: hard
-
-"qs@npm:~6.14.0":
-  version: 6.14.2
-  resolution: "qs@npm:6.14.2"
-  dependencies:
-    side-channel: "npm:^1.1.0"
-  checksum: 10c0/646110124476fc9acf3c80994c8c3a0600cbad06a4ede1c9e93341006e8426d64e85e048baf8f0c4995f0f1bf0f37d1f3acc5ec1455850b81978792969a60ef6
+  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
   languageName: node
   linkType: hard
 
@@ -17341,9 +17332,9 @@ __metadata:
   linkType: hard
 
 "shell-quote@npm:^1.7.2, shell-quote@npm:^1.7.3":
-  version: 1.8.1
-  resolution: "shell-quote@npm:1.8.1"
-  checksum: 10c0/8cec6fd827bad74d0a49347057d40dfea1e01f12a6123bf82c4649f3ef152fc2bc6d6176e6376bffcd205d9d0ccb4f1f9acae889384d20baff92186f01ea455a
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 
@@ -19608,8 +19599,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^8.12.0, ws@npm:^8.13.0, ws@npm:^8.15.0":
-  version: 8.18.0
-  resolution: "ws@npm:8.18.0"
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -19618,7 +19609,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/25eb33aff17edcb90721ed6b0eb250976328533ad3cd1a28a274bd263682e7296a6591ff1436d6cbc50fa67463158b062f9d1122013b361cec99a05f84680e06
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [x] The PR is targeting the `dev` branch
- [x] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Remediates open Dependabot alerts. Changes are confined to `yarn.lock`, `RESOLUTIONS.md`, and the `fix-vulnerabilities` skill.

### Fixed via lockfile re-resolution (within existing semver ranges)

| Package | Before | After | Severity |
|---|---|---|---|
| `shell-quote` | 1.8.1 | **1.8.4** | critical |
| `ws` (8.x) | 8.18.0 | **8.21.0** | medium |
| `postcss` | 8.5.3 | **8.5.15** | medium |
| `qs` | 6.14.2 / 6.15.0 | **6.15.2** | medium |

The `qs` fix required bumping `express` 4.22.1 → **4.22.2** and `body-parser` 1.20.4 → **1.20.5**: the 4.22.1 line pinned `qs@~6.14.0` (capped below the patched 6.15.2), while 4.22.2 uses `~6.15.1`. Both stay within the workspaces' `express@^4.18.1` range. These alerts auto-dismiss on Dependabot's next scan.

### Deferred — tolerated for now, alerts kept open (documented in `RESOLUTIONS.md`)

- **`uuid`** (medium): the buffer-bounds bug only affects `v3`/`v5`/`v6` with an explicit `buf`; all consumers pin `^8`/`^9` and use `v4` (unaffected). The patch is in 11.x (major jump). `uuid` <11 is deprecated, so this is real future work — bumping `@axinom/mosaic-*` and other consumers to accept `uuid@^11`. Alert kept open as a tracking reminder.
- **`tmp`** (high + low): dev-only via `external-editor@3.1.0` (`@graphql-codegen/cli` → `inquirer@8`), not in any deployed runtime. Reaching the patched 0.2.6 needs an `external-editor`/`inquirer` migration or a vetted forced resolution. Alert kept open.

### Unchanged — genuinely blocked upstream (documented under "Waiting for Upstream")

`serialize-javascript`, `lodash`, `immutable`, `ajv` — all capped by tilde ranges, exact pins, or major-version gaps in parent packages that have not released fixes.

### Process improvements (`fix-vulnerabilities` skill)

- Added a **Defer** option (tolerate for now, keep the alert open) distinct from **Ignore** (dismiss) and **Wait for upstream**.
- Stopped referencing Dependabot alert IDs in `RESOLUTIONS.md` (only meaningful with repo Dependabot access).
- Replaced the line-number-based lockfile deletion snippet with a header-matching one — the old approach had an off-by-one that could merge adjacent entries and corrupt the lockfile.

## Release notes

Security: updated vulnerable transitive dependencies (`shell-quote`, `ws`, `postcss`, `qs`, `express`, `body-parser`). No runtime behavior changes expected.

## Testing notes

- `yarn build` passes (including TypeScript declaration generation).
- All bumps are within-range patch/minor updates; no source code changed.
- The full `yarn test` suite was **not** run (requires DB infra: `yarn infra:up` + `yarn test:reset:dbs`). Recommend running it in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)