### PR TITLE
[AB#54300] Add support to declare acquisition and publishing profiles in ingestion jobs

### DIFF
--- a/libs/media-messages/src/media/types/video-ingest-data.ts
+++ b/libs/media-messages/src/media/types/video-ingest-data.ts
@@ -1,4 +1,8 @@
 export interface VideoIngestData {
   source: string;
+  /** @deprecated Use processing_profile instead */
   profile?: string;
+  processing_profile?: string;
+  acquisition_profile?: string;
+  publishing_profile?: string;
 }

--- a/services/media/service/package.json
+++ b/services/media/service/package.json
@@ -55,7 +55,7 @@
     "@axinom/mosaic-messages": "0.66.0",
     "@axinom/mosaic-service-common": "0.68.0",
     "@axinom/mosaic-transactional-inbox-outbox": "0.28.0",
-    "@axinom/mosaic-video-messages": "0.7.0",
+    "@axinom/mosaic-video-messages": "0.8.0",
     "@faker-js/faker": "^7.6.0",
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "ajv": "^8.18.0",

--- a/services/media/service/package.json
+++ b/services/media/service/package.json
@@ -55,7 +55,7 @@
     "@axinom/mosaic-messages": "0.66.0",
     "@axinom/mosaic-service-common": "0.68.0",
     "@axinom/mosaic-transactional-inbox-outbox": "0.28.0",
-    "@axinom/mosaic-video-messages": "0.8.0",
+    "@axinom/mosaic-video-messages": "0.8.1",
     "@faker-js/faker": "^7.6.0",
     "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "ajv": "^8.18.0",

--- a/services/media/service/scripts/ingest-gen.ts
+++ b/services/media/service/scripts/ingest-gen.ts
@@ -75,7 +75,7 @@ interface ParsedCliArgs {
  * Returns a readable timestamp in current locale time, e.g. `[2021-05-13 13:02:12.685]`
  */
 const getTimestamp = (): string => {
-  const offset = new Date().getTimezoneOffset() * 60000; //offset in milliseconds
+  const offset = new Date().getTimezoneOffset() * 60000; // offset in milliseconds
   const localISOTime = new Date(Date.now() - offset)
     .toISOString()
     .slice(0, -1)
@@ -112,7 +112,9 @@ const getNonCommonProperties = (params: {
   const main_video = params.mainVideo
     ? {
         source: params.mainVideo,
-        profile: faker.helpers.arrayElement(params.processingProfiles ?? []),
+        processing_profile: faker.helpers.arrayElement(
+          params.processingProfiles ?? [],
+        ),
       }
     : undefined;
   const parentInfo = faker.helpers.arrayElement(params.parentInfo ?? []);
@@ -198,7 +200,8 @@ const generateIngestItem = (
         trailers.length > 0
           ? trailers.map((path) => ({
               source: path,
-              profile: faker.helpers.arrayElement(processingProfiles),
+              processing_profile:
+                faker.helpers.arrayElement(processingProfiles),
             }))
           : undefined,
       images: coverPath || teaserPath ? [] : undefined,

--- a/services/media/service/src/domains/common/handlers/default-ingest-entity-processor.ts
+++ b/services/media/service/src/domains/common/handlers/default-ingest-entity-processor.ts
@@ -178,6 +178,8 @@ export abstract class DefaultIngestEntityProcessor implements IngestEntityProces
       const type = 'MAIN';
       const stepId = uuid();
       const video = element.main_video as VideoIngestData;
+      const acquisitionProfile = video.acquisition_profile?.trim();
+      const publishingProfile = video.publishing_profile?.trim();
       const ingestItemStep: ingest_item_steps.Insertable = {
         id: stepId,
         type: 'VIDEO',
@@ -186,9 +188,16 @@ export abstract class DefaultIngestEntityProcessor implements IngestEntityProces
       };
       const messagePayload: EnsureVideoExistsCommand = {
         video_location: normalizeRelativePath(video.source),
-        video_profile: video.profile?.trim() || 'DEFAULT',
+        video_profile:
+          (video.processing_profile ?? video.profile)?.trim() || 'DEFAULT',
         tags: [type],
       };
+      if (acquisitionProfile) {
+        messagePayload.acquisition_profile = acquisitionProfile;
+      }
+      if (publishingProfile) {
+        messagePayload.publishing_profile = publishingProfile;
+      }
       const messageContext: VideoMessageContext = {
         ingestItemStepId: stepId,
         ingestItemId,
@@ -219,6 +228,8 @@ export abstract class DefaultIngestEntityProcessor implements IngestEntityProces
     for (const trailer of ingestibleTrailers) {
       const stepId = uuid();
       const normalizedPath = normalizeRelativePath(trailer.source);
+      const acquisitionProfile = trailer.acquisition_profile?.trim();
+      const publishingProfile = trailer.publishing_profile?.trim();
       const ingestItemStep: ingest_item_steps.Insertable = {
         id: stepId,
         type: 'VIDEO',
@@ -227,9 +238,16 @@ export abstract class DefaultIngestEntityProcessor implements IngestEntityProces
       };
       const messagePayload: EnsureVideoExistsCommand = {
         video_location: normalizedPath,
-        video_profile: trailer.profile?.trim() || 'DEFAULT',
+        video_profile:
+          (trailer.processing_profile ?? trailer.profile)?.trim() || 'DEFAULT',
         tags: [type],
       };
+      if (acquisitionProfile) {
+        messagePayload.acquisition_profile = acquisitionProfile;
+      }
+      if (publishingProfile) {
+        messagePayload.publishing_profile = publishingProfile;
+      }
       const messageContext: VideoMessageContext = {
         ingestItemStepId: stepId,
         ingestItemId,

--- a/services/media/service/src/domains/common/handlers/default-ingest-entity-processor.ts
+++ b/services/media/service/src/domains/common/handlers/default-ingest-entity-processor.ts
@@ -189,7 +189,7 @@ export abstract class DefaultIngestEntityProcessor implements IngestEntityProces
       const messagePayload: EnsureVideoExistsCommand = {
         video_location: normalizeRelativePath(video.source),
         video_profile:
-          (video.processing_profile ?? video.profile)?.trim() || 'DEFAULT',
+          video.processing_profile?.trim() || video.profile?.trim() || 'DEFAULT',
         tags: [type],
       };
       if (acquisitionProfile) {
@@ -239,7 +239,7 @@ export abstract class DefaultIngestEntityProcessor implements IngestEntityProces
       const messagePayload: EnsureVideoExistsCommand = {
         video_location: normalizedPath,
         video_profile:
-          (trailer.processing_profile ?? trailer.profile)?.trim() || 'DEFAULT',
+          trailer.processing_profile?.trim() || trailer.profile?.trim() || 'DEFAULT',
         tags: [type],
       };
       if (acquisitionProfile) {

--- a/services/media/service/src/domains/movies/handlers/ingest-movie-processor-orchestration.spec.ts
+++ b/services/media/service/src/domains/movies/handlers/ingest-movie-processor-orchestration.spec.ts
@@ -19,6 +19,22 @@ describe('IngestMovieProcessor', () => {
   const ingestItemId = 1;
   const mediaId = 2;
 
+  const videoPayload = (
+    video: Record<string, string | undefined>,
+    videoLocation: string,
+    tag: 'MAIN' | 'TRAILER',
+  ) => ({
+    tags: [tag],
+    video_location: videoLocation,
+    processing_profile: video.processing_profile?.trim() || 'DEFAULT',
+    ...(video.acquisition_profile?.trim() && {
+      acquisition_profile: video.acquisition_profile.trim(),
+    }),
+    ...(video.publishing_profile?.trim() && {
+      publishing_profile: video.publishing_profile.trim(),
+    }),
+  });
+
   const metaData = (item: StartIngestItemCommand['item']) => ({
     aggregateId: mediaId.toString(),
     ingestItemStep: {
@@ -51,11 +67,11 @@ describe('IngestMovieProcessor', () => {
       ingestItemStepId: ingestStepId,
       videoType: 'MAIN',
     },
-    messagePayload: {
-      tags: ['MAIN'],
-      video_location: 'v1',
-      video_profile: (item.data.main_video as any).profile ?? 'DEFAULT',
-    },
+    messagePayload: videoPayload(
+      item.data.main_video as Record<string, string | undefined>,
+      'v1',
+      'MAIN',
+    ),
     messagingSettings:
       VideoServiceMultiTenantMessagingSettings.EnsureVideoExists,
   });
@@ -72,11 +88,11 @@ describe('IngestMovieProcessor', () => {
       ingestItemStepId: ingestStepId,
       videoType: 'TRAILER',
     },
-    messagePayload: {
-      tags: ['TRAILER'],
-      video_location: 't1',
-      video_profile: (item.data.main_video as any).profile ?? 'DEFAULT',
-    },
+    messagePayload: videoPayload(
+      (item.data.trailers as Record<string, string | undefined>[])[0],
+      't1',
+      'TRAILER',
+    ),
     messagingSettings:
       VideoServiceMultiTenantMessagingSettings.EnsureVideoExists,
   });
@@ -93,11 +109,11 @@ describe('IngestMovieProcessor', () => {
       ingestItemStepId: ingestStepId,
       videoType: 'TRAILER',
     },
-    messagePayload: {
-      tags: ['TRAILER'],
-      video_location: 't2',
-      video_profile: (item.data.main_video as any).profile ?? 'DEFAULT',
-    },
+    messagePayload: videoPayload(
+      (item.data.trailers as Record<string, string | undefined>[])[1],
+      't2',
+      'TRAILER',
+    ),
     messagingSettings:
       VideoServiceMultiTenantMessagingSettings.EnsureVideoExists,
   });
@@ -175,31 +191,46 @@ describe('IngestMovieProcessor', () => {
         [metaData, localizationsData],
       ],
       [
-        { source: 'v1', profile: 'DEFAULT' },
+        { source: 'v1', processing_profile: 'DEFAULT' },
         null,
         [{ path: 'images\\teasers\\test2.jpg', type: 'TEASER' }],
         [],
         [metaData, videoData, teaserData],
       ],
       [
-        { source: 'v1', profile: 'DEFAULT' },
+        { source: 'v1', processing_profile: 'DEFAULT' },
         [{ source: 't1' }],
         null,
         null,
         [metaData, videoData, trailer1Data],
       ],
       [
-        { source: 'v1', profile: 'DEFAULT' },
-        [{ source: 't1', profile: 'DEFAULT' }],
+        { source: 'v1', processing_profile: 'DEFAULT' },
+        [{ source: 't1', processing_profile: 'DEFAULT' }],
         [{ path: 'images/covers/test.jpg', type: 'COVER' }],
         null,
         [metaData, videoData, trailer1Data, coverData],
       ],
       [
-        { source: 'v1', profile: 'SomeProfile' },
+        {
+          source: 'v1',
+          processing_profile: 'SomeProfile',
+          acquisition_profile: 'Main Acquisition',
+          publishing_profile: 'Main Publishing',
+        },
         [
-          { source: 't1', profile: 'SomeProfile' },
-          { source: 't2', profile: 'SomeProfile' },
+          {
+            source: 't1',
+            processing_profile: 'TrailerProfile1',
+            acquisition_profile: 'Trailer Acquisition 1',
+            publishing_profile: 'Trailer Publishing 1',
+          },
+          {
+            source: 't2',
+            processing_profile: 'TrailerProfile2',
+            acquisition_profile: 'Trailer Acquisition 2',
+            publishing_profile: 'Trailer Publishing 2',
+          },
         ],
         [
           { path: 'images/covers/test.jpg', type: 'COVER' },

--- a/services/media/service/src/domains/movies/handlers/ingest-movie-processor-orchestration.spec.ts
+++ b/services/media/service/src/domains/movies/handlers/ingest-movie-processor-orchestration.spec.ts
@@ -26,7 +26,7 @@ describe('IngestMovieProcessor', () => {
   ) => ({
     tags: [tag],
     video_location: videoLocation,
-    processing_profile: video.processing_profile?.trim() || 'DEFAULT',
+    video_profile: video.processing_profile?.trim() || 'DEFAULT',
     ...(video.acquisition_profile?.trim() && {
       acquisition_profile: video.acquisition_profile.trim(),
     }),

--- a/services/media/service/src/domains/movies/handlers/ingest-movie-processor-process-video.db.spec.ts
+++ b/services/media/service/src/domains/movies/handlers/ingest-movie-processor-process-video.db.spec.ts
@@ -50,7 +50,7 @@ describe('IngestMovieProcessor', () => {
         external_id: 'externalId',
         data: {
           title: 'title',
-          trailers: [{ source: 'test', profile: 'DEFAULT' }],
+          trailers: [{ source: 'test', processing_profile: 'DEFAULT' }],
         },
       },
     }).run(ctx.ownerPool);
@@ -109,7 +109,7 @@ describe('IngestMovieProcessor', () => {
                 title: 'title',
                 trailers: allTrailersToIngest.map((trailer) => ({
                   source: trailer,
-                  profile: 'DEFAULT',
+                  processing_profile: 'DEFAULT',
                 })),
               },
             },

--- a/services/media/service/src/ingest/handlers/image-failed-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/image-failed-handler.db.spec.ts
@@ -67,7 +67,7 @@ describe('ImageFailedHandler', () => {
         external_id: 'externalId',
         data: {
           title: 'title',
-          trailers: [{ source: 'test', profile: 'DEFAULT' }],
+          trailers: [{ source: 'test', processing_profile: 'DEFAULT' }],
         },
       },
     }).run(ctx.ownerPool);

--- a/services/media/service/src/ingest/handlers/image-succeeded-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/image-succeeded-handler.db.spec.ts
@@ -69,7 +69,7 @@ describe('ImageSucceededHandler', () => {
         external_id: 'externalId',
         data: {
           title: 'title',
-          trailers: [{ source: 'test', profile: 'DEFAULT' }],
+          trailers: [{ source: 'test', processing_profile: 'DEFAULT' }],
         },
       },
     }).run(ctx.ownerPool);

--- a/services/media/service/src/ingest/handlers/localize-entity-failed-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/localize-entity-failed-handler.db.spec.ts
@@ -67,7 +67,7 @@ describe('LocalizeEntityFailedHandler', () => {
         external_id: 'externalId',
         data: {
           title: 'title',
-          trailers: [{ source: 'test', profile: 'DEFAULT' }],
+          trailers: [{ source: 'test', processing_profile: 'DEFAULT' }],
         },
       },
     }).run(ctx.ownerPool);

--- a/services/media/service/src/ingest/handlers/localize-entity-finished-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/localize-entity-finished-handler.db.spec.ts
@@ -67,7 +67,7 @@ describe('LocalizeEntityFinishedHandler', () => {
         external_id: 'externalId',
         data: {
           title: 'title',
-          trailers: [{ source: 'test', profile: 'DEFAULT' }],
+          trailers: [{ source: 'test', processing_profile: 'DEFAULT' }],
         },
       },
     }).run(ctx.ownerPool);

--- a/services/media/service/src/ingest/handlers/update-metadata-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/update-metadata-handler.db.spec.ts
@@ -73,7 +73,7 @@ describe('UpdateMetadataHandler', () => {
         external_id: 'externalId',
         data: {
           title: 'title',
-          trailers: [{ source: 'test', profile: 'DEFAULT' }],
+          trailers: [{ source: 'test', processing_profile: 'DEFAULT' }],
         },
       },
     }).run(ctx.ownerPool);

--- a/services/media/service/src/ingest/handlers/video-failed-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/video-failed-handler.db.spec.ts
@@ -67,7 +67,7 @@ describe('VideoFailedHandler', () => {
         external_id: 'externalId',
         data: {
           title: 'title',
-          trailers: [{ source: 'test', profile: 'DEFAULT' }],
+          trailers: [{ source: 'test', processing_profile: 'DEFAULT' }],
         },
       },
     }).run(ctx.ownerPool);

--- a/services/media/service/src/ingest/handlers/video-succeeded-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/video-succeeded-handler.db.spec.ts
@@ -72,7 +72,7 @@ describe('VideoSucceededHandler', () => {
         external_id: 'externalId',
         data: {
           title: 'title',
-          trailers: [{ source: 'test', profile: 'DEFAULT' }],
+          trailers: [{ source: 'test', processing_profile: 'DEFAULT' }],
         },
       },
     }).run(ctx.ownerPool);

--- a/services/media/service/src/ingest/schemas/ingest-validation-schema.json
+++ b/services/media/service/src/ingest/schemas/ingest-validation-schema.json
@@ -123,6 +123,7 @@
       "description": "An object describing a path to main video files and a way to process it. If empty object is defined - main video will be unassigned on media item update. If any profile selection is defined - then source must be defined as well.",
       "required": [],
       "dependencies": {
+        "profile": { "required": ["source"] },
         "processing_profile": { "required": ["source"] },
         "acquisition_profile": { "required": ["source"] },
         "publishing_profile": { "required": ["source"] }
@@ -131,6 +132,10 @@
         "source": {
           "$ref": "#/definitions/non-empty-string",
           "description": "Path to video files in file storage, including video itself, audio, subtitle and closed caption files."
+        },
+        "profile": {
+          "$ref": "#/definitions/non-empty-string",
+          "description": "Deprecated. Use processing_profile instead."
         },
         "processing_profile": {
           "$ref": "#/definitions/non-empty-string",
@@ -157,6 +162,10 @@
           "source": {
             "$ref": "#/definitions/non-empty-string",
             "description": "Path to video files in file storage, including video itself, audio, subtitle and closed caption files."
+          },
+          "profile": {
+            "$ref": "#/definitions/non-empty-string",
+            "description": "Deprecated. Use processing_profile instead."
           },
           "processing_profile": {
             "$ref": "#/definitions/non-empty-string",

--- a/services/media/service/src/ingest/schemas/ingest-validation-schema.json
+++ b/services/media/service/src/ingest/schemas/ingest-validation-schema.json
@@ -120,19 +120,29 @@
     },
     "main_video": {
       "type": ["object", "null"],
-      "description": "An object describing a path to main video files and a way to process it. If empty object is defined - main video will be unassigned on media item update. If profile is defined - then source must be defined as well.",
+      "description": "An object describing a path to main video files and a way to process it. If empty object is defined - main video will be unassigned on media item update. If any profile selection is defined - then source must be defined as well.",
       "required": [],
       "dependencies": {
-        "profile": { "required": ["source"] }
+        "processing_profile": { "required": ["source"] },
+        "acquisition_profile": { "required": ["source"] },
+        "publishing_profile": { "required": ["source"] }
       },
       "properties": {
         "source": {
           "$ref": "#/definitions/non-empty-string",
           "description": "Path to video files in file storage, including video itself, audio, subtitle and closed caption files."
         },
-        "profile": {
+        "processing_profile": {
           "$ref": "#/definitions/non-empty-string",
-          "description": "Name of processing profile to be used to encode video files. If not specified - default profile will be used."
+          "description": "Name of processing profile to be used to encode video files. If not specified - default processing profile will be used."
+        },
+        "acquisition_profile": {
+          "$ref": "#/definitions/non-empty-string",
+          "description": "Name of acquisition profile to be used to ingest video files. If not specified - default acquisition profile will be used."
+        },
+        "publishing_profile": {
+          "$ref": "#/definitions/non-empty-string",
+          "description": "Name of publishing profile to be used to deliver encoded video files. If not specified - default publishing profile will be used."
         }
       }
     },
@@ -148,9 +158,17 @@
             "$ref": "#/definitions/non-empty-string",
             "description": "Path to video files in file storage, including video itself, audio, subtitle and closed caption files."
           },
-          "profile": {
+          "processing_profile": {
             "$ref": "#/definitions/non-empty-string",
             "description": "Name of processing profile to be used to encode video files."
+          },
+          "acquisition_profile": {
+            "$ref": "#/definitions/non-empty-string",
+            "description": "Name of acquisition profile to be used to ingest video files. If not specified - default acquisition profile will be used."
+          },
+          "publishing_profile": {
+            "$ref": "#/definitions/non-empty-string",
+            "description": "Name of publishing profile to be used to deliver encoded video files. If not specified - default publishing profile will be used."
           }
         }
       }
@@ -302,7 +320,7 @@
                       "examples": [
                         {
                           "source": "test-videos/videos/avatar",
-                          "profile": "DEFAULT"
+                          "processing_profile": "DEFAULT"
                         }
                       ]
                     },
@@ -313,7 +331,7 @@
                           { "source": "test-videos/trailers/avatar_1" },
                           {
                             "source": "test-videos/trailers/avatar_2",
-                            "profile": "DEFAULT"
+                            "processing_profile": "DEFAULT"
                           }
                         ]
                       ]
@@ -435,7 +453,7 @@
                           { "source": "test-videos/trailers/mandalorian_1" },
                           {
                             "source": "test-videos/trailers/mandalorian_2",
-                            "profile": "DEFAULT"
+                            "processing_profile": "DEFAULT"
                           }
                         ]
                       ]
@@ -557,7 +575,7 @@
                           { "source": "test-videos/trailers/mandalorian_s1" },
                           {
                             "source": "test-videos/trailers/mandalorian_s2",
-                            "profile": "DEFAULT"
+                            "processing_profile": "DEFAULT"
                           }
                         ]
                       ]
@@ -683,7 +701,7 @@
                       "examples": [
                         {
                           "source": "test-videos/videos/mandalorian_s2_e1",
-                          "profile": "DEFAULT"
+                          "processing_profile": "DEFAULT"
                         }
                       ]
                     },
@@ -696,7 +714,7 @@
                           },
                           {
                             "source": "test-videos/trailers/mandalorian_s2_e1_t2",
-                            "profile": "DEFAULT"
+                            "processing_profile": "DEFAULT"
                           }
                         ]
                       ]

--- a/services/media/service/src/ingest/utils/ingest-validation.spec.ts
+++ b/services/media/service/src/ingest/utils/ingest-validation.spec.ts
@@ -89,7 +89,7 @@ describe('Ingest validation helpers', () => {
               title: 'title',
               main_video: {
                 source: 'avatar',
-                profile: 'DEFAULT',
+                processing_profile: 'DEFAULT',
               },
             },
           },
@@ -115,16 +115,16 @@ describe('Ingest validation helpers', () => {
               title: 'title',
               main_video: {
                 source: 'avatar',
-                profile: 'DEFAULT',
+                processing_profile: 'DEFAULT',
               },
               trailers: [
                 {
                   source: 'avatar1',
-                  profile: 'DEFAULT',
+                  processing_profile: 'DEFAULT',
                 },
                 {
                   source: 'trailers/avatar1',
-                  profile: 'DEFAULT',
+                  processing_profile: 'DEFAULT',
                 },
               ],
             },
@@ -151,16 +151,16 @@ describe('Ingest validation helpers', () => {
               title: 'title',
               main_video: {
                 source: 'avatar',
-                profile: 'DEFAULT',
+                processing_profile: 'DEFAULT',
               },
               trailers: [
                 {
                   source: 'avatar1',
-                  profile: 'DEFAULT',
+                  processing_profile: 'DEFAULT',
                 },
                 {
                   source: 'trailers/avatar1',
-                  profile: 'DEFAULT',
+                  processing_profile: 'DEFAULT',
                 },
               ],
             },
@@ -172,16 +172,16 @@ describe('Ingest validation helpers', () => {
               title: 'title',
               main_video: {
                 source: 'avatar1',
-                profile: 'DEFAULT',
+                processing_profile: 'DEFAULT',
               },
               trailers: [
                 {
                   source: 'avatar',
-                  profile: 'DEFAULT',
+                  processing_profile: 'DEFAULT',
                 },
                 {
                   source: 'trailers/avatar1',
-                  profile: 'DEFAULT',
+                  processing_profile: 'DEFAULT',
                 },
               ],
             },
@@ -214,11 +214,11 @@ describe('Ingest validation helpers', () => {
                 trailers: [
                   {
                     source: emptyValue,
-                    profile: 'DEFAULT',
+                    processing_profile: 'DEFAULT',
                   },
                   {
                     source: emptyValue,
-                    profile: 'DEFAULT',
+                    processing_profile: 'DEFAULT',
                   },
                 ],
               },
@@ -377,16 +377,16 @@ describe('Ingest validation helpers', () => {
               title: 'title',
               main_video: {
                 source: 'avatar',
-                profile: 'DEFAULT',
+                processing_profile: 'DEFAULT',
               },
               trailers: [
                 {
                   source: 'avatar1',
-                  profile: 'DEFAULT',
+                  processing_profile: 'DEFAULT',
                 },
                 {
                   source: 'avatar1',
-                  profile: 'DEFAULT',
+                  processing_profile: 'DEFAULT',
                 },
               ],
             },
@@ -419,16 +419,16 @@ describe('Ingest validation helpers', () => {
               title: 'title',
               main_video: {
                 source: 'avatar',
-                profile: 'DEFAULT',
+                processing_profile: 'DEFAULT',
               },
               trailers: [
                 {
                   source: 'avatar',
-                  profile: 'DEFAULT',
+                  processing_profile: 'DEFAULT',
                 },
                 {
                   source: 'avatar1',
-                  profile: 'DEFAULT',
+                  processing_profile: 'DEFAULT',
                 },
               ],
             },

--- a/services/media/service/src/tests/ingest/documents/all-types-with-videos-and-images.json
+++ b/services/media/service/src/tests/ingest/documents/all-types-with-videos-and-images.json
@@ -30,13 +30,13 @@
         ],
         "main_video": {
           "source": " test-videos/videos/avatar",
-          "profile": "DEFAULT "
+          "processing_profile": "DEFAULT "
         },
         "trailers": [
           { "source": "test-videos/trailers/avatar_1 " },
           {
             "source": " test-videos/trailers/avatar_2",
-            "profile": " DEFAULT"
+            "processing_profile": " DEFAULT"
           }
         ],
         "images": [
@@ -76,13 +76,13 @@
         ],
         "main_video": {
           "source": " test-videos/videos/mandalorian_s2_e1",
-          "profile": "DEFAULT"
+          "processing_profile": "DEFAULT"
         },
         "trailers": [
           { "source": "test-videos/trailers/mandalorian_s2_e1_t1" },
           {
             "source": "test-videos/trailers/mandalorian_s2_e1_t2",
-            "profile": "DEFAULT"
+            "processing_profile": "DEFAULT"
           }
         ],
         "images": [
@@ -122,7 +122,7 @@
           { "source": "test-videos/trailers/mandalorian_s2_t1" },
           {
             "source": "test-videos/trailers/mandalorian_s2_t2",
-            "profile": "DEFAULT"
+            "processing_profile": "DEFAULT"
           }
         ],
         "images": [
@@ -162,7 +162,7 @@
           { "source": "test-videos/trailers/mandalorian_t1" },
           {
             "source": "test-videos/trailers/mandalorian_t2",
-            "profile": "DEFAULT"
+            "processing_profile": "DEFAULT"
           }
         ],
         "images": [

--- a/services/media/service/src/tests/ingest/documents/movie-with-videos.json
+++ b/services/media/service/src/tests/ingest/documents/movie-with-videos.json
@@ -24,13 +24,13 @@
         ],
         "main_video": {
           "source": " test-videos/videos/avatar",
-          "profile": "DEFAULT"
+          "processing_profile": "DEFAULT"
         },
         "trailers": [
           { "source": "test-videos/trailers/avatar_1 " },
           {
             "source": " test-videos/trailers/avatar_2",
-            "profile": "DEFAULT"
+            "processing_profile": "DEFAULT"
           }
         ]
       }

--- a/services/media/service/src/tests/ingest/ingest-validation-schema.spec.ts
+++ b/services/media/service/src/tests/ingest/ingest-validation-schema.spec.ts
@@ -1867,12 +1867,12 @@ describe('ingest-validation-schema.json', () => {
       expect(isValid).toBe(true);
     });
 
-    it('Data with main video with profile and without source -> document is invalid', () => {
+    it('Data with main video with processing_profile and without source -> document is invalid', () => {
       // Arrange
       const doc = createDocument({
         title: 'avatar',
         main_video: {
-          profile: 'DEFAULT',
+          processing_profile: 'DEFAULT',
         },
       });
 
@@ -1885,7 +1885,7 @@ describe('ingest-validation-schema.json', () => {
         {
           message:
             'JSON path "document/items/0/data/main_video" must have required property \'source\' (line: 9, column: 23)',
-          schemaPath: '#/dependencies/profile/required', // TODO: Open issue: https://github.com/ajv-validator/ajv/issues/512
+          schemaPath: '#/dependencies/processing_profile/required', // TODO: Open issue: https://github.com/ajv-validator/ajv/issues/512
           type: 'JsonSchemaValidation',
         },
         {
@@ -2018,13 +2018,13 @@ describe('ingest-validation-schema.json', () => {
       },
     );
 
-    it('Data with main video with null profile -> document is invalid', () => {
+    it('Data with main video with null processing_profile -> document is invalid', () => {
       // Arrange
       const doc = createDocument({
         title: 'avatar',
         main_video: {
           source: 'valid source',
-          profile: null,
+          processing_profile: null,
         },
       });
 
@@ -2036,7 +2036,7 @@ describe('ingest-validation-schema.json', () => {
       expect(errors).toIncludeSameMembers([
         {
           message:
-            'JSON path "document/items/0/data/main_video/profile" must be string (line: 11, column: 22)',
+            'JSON path "document/items/0/data/main_video/processing_profile" must be string (line: 11, column: 33)',
           schemaPath: '#/definitions/non-empty-string/type',
           type: 'JsonSchemaValidation',
         },
@@ -2050,13 +2050,13 @@ describe('ingest-validation-schema.json', () => {
       expect(isValid).toBe(false);
     });
 
-    it('Data with main video with empty profile -> document is invalid', () => {
+    it('Data with main video with empty processing_profile -> document is invalid', () => {
       // Arrange
       const doc = createDocument({
         title: 'avatar',
         main_video: {
           source: 'valid source',
-          profile: '',
+          processing_profile: '',
         },
       });
 
@@ -2068,7 +2068,7 @@ describe('ingest-validation-schema.json', () => {
       expect(errors).toIncludeSameMembers([
         {
           message:
-            'JSON path "document/items/0/data/main_video/profile" must NOT have fewer than 1 characters (line: 11, column: 22)',
+            'JSON path "document/items/0/data/main_video/processing_profile" must NOT have fewer than 1 characters (line: 11, column: 33)',
           schemaPath: '#/definitions/non-empty-string/minLength',
           type: 'JsonSchemaValidation',
         },
@@ -2083,14 +2083,14 @@ describe('ingest-validation-schema.json', () => {
     });
 
     it.each(whitespaceValues)(
-      'Data with main video with whitespace "%s" profile -> document is invalid',
+      'Data with main video with whitespace "%s" processing_profile -> document is invalid',
       (whitespace) => {
         // Arrange
         const doc = createDocument({
           title: 'avatar',
           main_video: {
             source: 'valid source',
-            profile: whitespace,
+            processing_profile: whitespace,
           },
         });
 
@@ -2102,7 +2102,7 @@ describe('ingest-validation-schema.json', () => {
         expect(errors).toIncludeSameMembers([
           {
             message:
-              'JSON path "document/items/0/data/main_video/profile" must match pattern "^$|.*\\S.*" (line: 11, column: 22)',
+              'JSON path "document/items/0/data/main_video/processing_profile" must match pattern "^$|.*\\S.*" (line: 11, column: 33)',
             schemaPath: '#/definitions/non-empty-string/pattern',
             type: 'JsonSchemaValidation',
           },
@@ -2123,14 +2123,14 @@ describe('ingest-validation-schema.json', () => {
       'avatar.the.movie',
       'DEFAULT',
     ])(
-      'Data with main video with valid profile "%s" -> document is valid',
+      'Data with main video with valid processing_profile "%s" -> document is valid',
       (profile) => {
         // Arrange
         const doc = createDocument({
           title: 'avatar',
           main_video: {
             source: 'valid source',
-            profile,
+            processing_profile: profile,
           },
         });
 
@@ -2144,11 +2144,71 @@ describe('ingest-validation-schema.json', () => {
       },
     );
 
+    it.each(['acquisition_profile', 'publishing_profile'])(
+      'Data with main video with %s and without source -> document is invalid',
+      (profileField) => {
+        // Arrange
+        const doc = createDocument({
+          title: 'avatar',
+          main_video: {
+            [profileField]: 'DEFAULT',
+          },
+        });
+
+        // Act
+        const isValid = ajv.validate(ingestSchema, doc);
+        const errors = transformAjvErrors(ajv.errors, doc);
+
+        // Assert
+        expect(
+          errors.some(
+            (error) =>
+              error.schemaPath === `#/dependencies/${profileField}/required`,
+          ),
+        ).toBe(true);
+        expect(isValid).toBe(false);
+      },
+    );
+
+    it.each(['acquisition_profile', 'publishing_profile'])(
+      'Data with main video with invalid %s -> document is invalid',
+      (profileField) => {
+        for (const value of [null, '', ...whitespaceValues]) {
+          // Arrange
+          const doc = createDocument({
+            title: 'avatar',
+            main_video: {
+              source: 'valid source',
+              [profileField]: value,
+            },
+          });
+
+          // Act
+          const isValid = ajv.validate(ingestSchema, doc);
+          const errors = transformAjvErrors(ajv.errors, doc);
+
+          // Assert
+          expect(
+            errors.some((error) =>
+              error.message.includes(`/main_video/${profileField}"`),
+            ),
+          ).toBe(true);
+          expect(isValid).toBe(false);
+        }
+      },
+    );
+
     it.each([
       null,
       {},
       { source: 'test-videos/videos/avatar_1' },
-      { source: 'test-videos/videos/avatar_1', profile: 'DEFAULT' },
+      { source: 'test-videos/videos/avatar_1', processing_profile: 'DEFAULT' },
+      {
+        source: 'test-videos/videos/avatar_1',
+        processing_profile: 'DEFAULT',
+        acquisition_profile: 'Acquisition',
+        publishing_profile: 'Publishing',
+      },
     ])('Data with valid main_video %p -> document is valid', (main_video) => {
       // Arrange
       const doc = createDocument({ title: 'avatar', main_video });
@@ -2302,11 +2362,11 @@ describe('ingest-validation-schema.json', () => {
       },
     );
 
-    it('Data with trailer with null profile -> document is invalid', () => {
+    it('Data with trailer with null processing_profile -> document is invalid', () => {
       // Arrange
       const doc = createDocument({
         title: 'avatar',
-        trailers: [{ source: 'valid source', profile: null }],
+        trailers: [{ source: 'valid source', processing_profile: null }],
       });
 
       // Act
@@ -2317,7 +2377,7 @@ describe('ingest-validation-schema.json', () => {
       expect(errors).toIncludeSameMembers([
         {
           message:
-            'JSON path "document/items/0/data/trailers/0/profile" must be string (line: 12, column: 24)',
+            'JSON path "document/items/0/data/trailers/0/processing_profile" must be string (line: 12, column: 35)',
           schemaPath: '#/definitions/non-empty-string/type',
           type: 'JsonSchemaValidation',
         },
@@ -2331,11 +2391,11 @@ describe('ingest-validation-schema.json', () => {
       expect(isValid).toBe(false);
     });
 
-    it('Data with trailer with empty profile -> document is invalid', () => {
+    it('Data with trailer with empty processing_profile -> document is invalid', () => {
       // Arrange
       const doc = createDocument({
         title: 'avatar',
-        trailers: [{ source: 'valid source', profile: '' }],
+        trailers: [{ source: 'valid source', processing_profile: '' }],
       });
 
       // Act
@@ -2346,7 +2406,7 @@ describe('ingest-validation-schema.json', () => {
       expect(errors).toIncludeSameMembers([
         {
           message:
-            'JSON path "document/items/0/data/trailers/0/profile" must NOT have fewer than 1 characters (line: 12, column: 24)',
+            'JSON path "document/items/0/data/trailers/0/processing_profile" must NOT have fewer than 1 characters (line: 12, column: 35)',
           schemaPath: '#/definitions/non-empty-string/minLength',
           type: 'JsonSchemaValidation',
         },
@@ -2361,12 +2421,14 @@ describe('ingest-validation-schema.json', () => {
     });
 
     it.each(whitespaceValues)(
-      'Data with trailer with whitespace "%s" profile -> document is invalid',
+      'Data with trailer with whitespace "%s" processing_profile -> document is invalid',
       (whitespace) => {
         // Arrange
         const doc = createDocument({
           title: 'avatar',
-          trailers: [{ source: 'valid source', profile: whitespace }],
+          trailers: [
+            { source: 'valid source', processing_profile: whitespace },
+          ],
         });
 
         // Act
@@ -2377,7 +2439,7 @@ describe('ingest-validation-schema.json', () => {
         expect(errors).toIncludeSameMembers([
           {
             message:
-              'JSON path "document/items/0/data/trailers/0/profile" must match pattern "^$|.*\\S.*" (line: 12, column: 24)',
+              'JSON path "document/items/0/data/trailers/0/processing_profile" must match pattern "^$|.*\\S.*" (line: 12, column: 35)',
             schemaPath: '#/definitions/non-empty-string/pattern',
             type: 'JsonSchemaValidation',
           },
@@ -2398,12 +2460,12 @@ describe('ingest-validation-schema.json', () => {
       'avatar.the.movie',
       'DEFAULT',
     ])(
-      'Data with trailer with valid profile "%s" -> document is valid',
+      'Data with trailer with valid processing_profile "%s" -> document is valid',
       (profile) => {
         // Arrange
         const doc = createDocument({
           title: 'avatar',
-          trailers: [{ source: 'valid source', profile }],
+          trailers: [{ source: 'valid source', processing_profile: profile }],
         });
 
         // Act
@@ -2416,7 +2478,32 @@ describe('ingest-validation-schema.json', () => {
       },
     );
 
-    it.each([[[{}]], [[{ profile: 'DEFAULT' }]]])(
+    it.each(['acquisition_profile', 'publishing_profile'])(
+      'Data with trailer with invalid %s -> document is invalid',
+      (profileField) => {
+        for (const value of [null, '', ...whitespaceValues]) {
+          // Arrange
+          const doc = createDocument({
+            title: 'avatar',
+            trailers: [{ source: 'valid source', [profileField]: value }],
+          });
+
+          // Act
+          const isValid = ajv.validate(ingestSchema, doc);
+          const errors = transformAjvErrors(ajv.errors, doc);
+
+          // Assert
+          expect(
+            errors.some((error) =>
+              error.message.includes(`/trailers/0/${profileField}"`),
+            ),
+          ).toBe(true);
+          expect(isValid).toBe(false);
+        }
+      },
+    );
+
+    it.each([[[{}]], [[{ processing_profile: 'DEFAULT' }]]])(
       'Data with invalid trailers %j -> document is invalid',
       (trailers: any) => {
         // Arrange
@@ -2449,11 +2536,34 @@ describe('ingest-validation-schema.json', () => {
       [null],
       [[]],
       [[{ source: 'test-videos/trailers/avatar_1' }]],
-      [[{ source: 'test-videos/trailers/avatar_1', profile: 'DEFAULT' }]],
       [
         [
-          { source: 'test-videos/trailers/avatar_2', profile: 'DEFAULT' },
-          { source: 'test-videos/trailers/avatar_2', profile: 'DEFAULT' },
+          {
+            source: 'test-videos/trailers/avatar_1',
+            processing_profile: 'DEFAULT',
+          },
+        ],
+      ],
+      [
+        [
+          {
+            source: 'test-videos/trailers/avatar_1',
+            processing_profile: 'DEFAULT',
+            acquisition_profile: 'Acquisition',
+            publishing_profile: 'Publishing',
+          },
+        ],
+      ],
+      [
+        [
+          {
+            source: 'test-videos/trailers/avatar_2',
+            processing_profile: 'DEFAULT',
+          },
+          {
+            source: 'test-videos/trailers/avatar_2',
+            processing_profile: 'DEFAULT',
+          },
         ],
       ],
     ])('Data with valid trailers %j -> document is valid', (trailers) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,6 +652,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@axinom/mosaic-video-messages@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@axinom/mosaic-video-messages@npm:0.8.0"
+  checksum: 10c0/49f7bac7973b37c8784e428d23ad50db19553947632ca8db1de58ca0caa3d0cc4ba1d0f3cf8cbddf43e545226181887f3b0a1bd9608cef3c8227c69bcde84e81
+  languageName: node
+  linkType: hard
+
 "@axinom/mosaic-video-workflow-integration@npm:0.5.0":
   version: 0.5.0
   resolution: "@axinom/mosaic-video-workflow-integration@npm:0.5.0"
@@ -13440,7 +13447,7 @@ __metadata:
     "@axinom/mosaic-messages": "npm:0.66.0"
     "@axinom/mosaic-service-common": "npm:0.68.0"
     "@axinom/mosaic-transactional-inbox-outbox": "npm:0.28.0"
-    "@axinom/mosaic-video-messages": "npm:0.7.0"
+    "@axinom/mosaic-video-messages": "npm:0.8.0"
     "@azure/storage-blob": "npm:^12.14.0"
     "@faker-js/faker": "npm:^7.6.0"
     "@graphile-contrib/pg-simplify-inflector": "npm:^6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,10 +652,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@axinom/mosaic-video-messages@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@axinom/mosaic-video-messages@npm:0.8.0"
-  checksum: 10c0/49f7bac7973b37c8784e428d23ad50db19553947632ca8db1de58ca0caa3d0cc4ba1d0f3cf8cbddf43e545226181887f3b0a1bd9608cef3c8227c69bcde84e81
+"@axinom/mosaic-video-messages@npm:0.8.1":
+  version: 0.8.1
+  resolution: "@axinom/mosaic-video-messages@npm:0.8.1"
+  checksum: 10c0/381dcb706df2f3df2264bb69cd2a7743d76c062beec8303dd63180251befc45eaea68cc42ab75fe63f55c8878ca94d93611cca41e9657969cbe928302e8ba9d1
   languageName: node
   linkType: hard
 
@@ -13447,7 +13447,7 @@ __metadata:
     "@axinom/mosaic-messages": "npm:0.66.0"
     "@axinom/mosaic-service-common": "npm:0.68.0"
     "@axinom/mosaic-transactional-inbox-outbox": "npm:0.28.0"
-    "@axinom/mosaic-video-messages": "npm:0.8.0"
+    "@axinom/mosaic-video-messages": "npm:0.8.1"
     "@azure/storage-blob": "npm:^12.14.0"
     "@faker-js/faker": "npm:^7.6.0"
     "@graphile-contrib/pg-simplify-inflector": "npm:^6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12460,14 +12460,14 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1, js-yaml@npm:^3.14.0":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
+  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**feat: pass acquisition and publishing profiles in video ingest orchestration**

Updates the ingest orchestration layer to forward the new acquisition and publishing profile fields introduced in the video service, enabling per-ingest storage location selection.

- VideoIngestData gains processing_profile, acquisition_profile, and publishing_profile fields. The legacy profile field is retained as a deprecated alias for processing_profile so existing ingest documents continue to work unchanged.
- orchestrateMainVideo and orchestrateTrailers now conditionally include acquisition_profile and publishing_profile in the EnsureVideoExistsCommand payload when present in the ingest document.
- Profile resolution priority: processing_profile → profile → 'DEFAULT'.
- Removed the local EnsureVideoExistsCommand type shim — the processor now uses the @axinom/mosaic-video-messages 0.8.0 type directly (video_profile field), which the updated video service handles for both old and new clients.