### PR TITLE
[AB#54610] fix: surface video encoding failures on the Ingest Items page

### DIFF
--- a/services/media/service/src/ingest/handlers/index.ts
+++ b/services/media/service/src/ingest/handlers/index.ts
@@ -12,5 +12,7 @@ export * from './upsert-localization-source-entity-failed-handler';
 export * from './upsert-localization-source-entity-finished-handler';
 export * from './video-already-existed-handler';
 export * from './video-creation-started-handler';
+export * from './video-encoding-failed-handler';
+export * from './video-encoding-finished-handler';
 export * from './video-failed-handler';
 export * from './video-succeeded-handler';

--- a/services/media/service/src/ingest/handlers/video-encoding-failed-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/video-encoding-failed-handler.db.spec.ts
@@ -1,0 +1,205 @@
+import { AuthenticatedManagementSubject } from '@axinom/mosaic-id-guard';
+import { MosaicError } from '@axinom/mosaic-service-common';
+import { TypedTransactionalMessage } from '@axinom/mosaic-transactional-inbox-outbox';
+import { VideoEncodingFailedEvent } from '@axinom/mosaic-video-messages';
+import { stub } from 'jest-auto-stub';
+import 'jest-extended';
+import { randomUUID } from 'node:crypto';
+import { insert, selectOne } from 'zapatos/db';
+import {
+  ingest_documents,
+  ingest_items,
+  ingest_item_steps,
+} from 'zapatos/schema';
+import { CommonErrors } from '../../common';
+import {
+  createTestContext,
+  createTestUser,
+  ITestContext,
+} from '../../tests/test-utils';
+import { VideoEncodingFailedHandler } from './video-encoding-failed-handler';
+
+describe('VideoEncodingFailedHandler', () => {
+  let handler: VideoEncodingFailedHandler;
+  let ctx: ITestContext;
+  let step1: ingest_item_steps.JSONSelectable;
+  let item1: ingest_items.JSONSelectable;
+  let doc1: ingest_documents.JSONSelectable;
+  let user: AuthenticatedManagementSubject;
+  const videoId = randomUUID();
+
+  const createMessage = (payload: VideoEncodingFailedEvent) =>
+    stub<TypedTransactionalMessage<VideoEncodingFailedEvent>>({
+      payload,
+      metadata: {},
+    });
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    user = createTestUser(ctx.config.serviceId);
+    handler = new VideoEncodingFailedHandler(ctx.config);
+  });
+
+  beforeEach(async () => {
+    doc1 = await insert('ingest_documents', {
+      name: 'test1',
+      title: 'test1',
+      document: {
+        name: 'test1',
+        document_created: '2020-08-04T08:57:40.763+00:00',
+        items: [],
+      },
+      items_count: 0,
+    }).run(ctx.ownerPool);
+    item1 = await insert('ingest_items', {
+      ingest_document_id: doc1.id,
+      external_id: 'externalId',
+      entity_id: 1,
+      type: 'MOVIE',
+      exists_status: 'CREATED',
+      display_title: 'title',
+      item: {
+        type: 'MOVIE',
+        external_id: 'externalId',
+        data: { title: 'title' },
+      },
+    }).run(ctx.ownerPool);
+    step1 = await insert('ingest_item_steps', {
+      id: randomUUID(),
+      type: 'VIDEO',
+      ingest_item_id: item1.id,
+      sub_type: 'MAIN',
+      entity_id: videoId,
+      status: 'SUCCESS',
+    }).run(ctx.ownerPool);
+  });
+
+  afterEach(async () => {
+    await ctx.truncate('ingest_documents');
+  });
+
+  afterAll(async () => {
+    await ctx.dispose();
+    jest.restoreAllMocks();
+  });
+
+  describe('handleMessage', () => {
+    it('matching video step found -> step updated to ERROR', async () => {
+      // Arrange
+      const payload: VideoEncodingFailedEvent = {
+        video_id: videoId,
+        source_location: 'test-source',
+        message: 'The encoder reported a specific failure reason.',
+      };
+
+      // Act
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
+        handler.handleMessage(createMessage(payload), dbCtx),
+      );
+
+      // Assert
+      const step = await selectOne('ingest_item_steps', {
+        id: step1.id,
+      }).run(ctx.ownerPool);
+      expect(step?.status).toBe('ERROR');
+      expect(step?.response_message).toBe(
+        'The encoder reported a specific failure reason.',
+      );
+    });
+
+    it('no matching video step -> nothing updated', async () => {
+      // Arrange
+      const payload: VideoEncodingFailedEvent = {
+        video_id: randomUUID(),
+        source_location: 'test-source',
+        message: 'Should not be applied to any step.',
+      };
+
+      // Act
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
+        handler.handleMessage(createMessage(payload), dbCtx),
+      );
+
+      // Assert
+      const step = await selectOne('ingest_item_steps', {
+        id: step1.id,
+      }).run(ctx.ownerPool);
+      expect(step?.status).toBe('SUCCESS');
+      expect(step?.response_message).toBeNull();
+    });
+  });
+
+  describe('mapError', () => {
+    it('message failed with non-mosaic error -> default error mapped', async () => {
+      // Act
+      const error = handler.mapError(new Error('Unexpected failure'));
+
+      // Assert
+      expect(error).toMatchObject({
+        message:
+          'The video encoding has failed, but there was an error updating the ingest item step status.',
+        code: CommonErrors.IngestError.code,
+      });
+    });
+
+    it('message failed with mosaic error -> thrown error mapped', async () => {
+      // Arrange
+      const testErrorInfo = {
+        message: 'Handled test message',
+        code: 'HANDLED_TEST_CODE',
+      };
+
+      // Act
+      const error = handler.mapError(new MosaicError(testErrorInfo));
+
+      // Assert
+      expect(error).toMatchObject(testErrorInfo);
+    });
+  });
+
+  describe('handleErrorMessage', () => {
+    it('message failed on all retries -> step updated', async () => {
+      // Arrange
+      const payload: VideoEncodingFailedEvent = {
+        video_id: videoId,
+        source_location: 'test-source',
+        message: 'Original encoder message',
+      };
+      // mapError makes sure this error is appropriate
+      const error = new Error('Handled and mapped message');
+
+      // Act
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
+        handler.handleErrorMessage(error, createMessage(payload), dbCtx, false),
+      );
+
+      // Assert
+      const step = await selectOne('ingest_item_steps', {
+        id: step1.id,
+      }).run(ctx.ownerPool);
+      expect(step?.response_message).toEqual(error.message);
+      expect(step?.status).toBe('ERROR');
+    });
+
+    it('message will be retried -> step not updated', async () => {
+      // Arrange
+      const payload: VideoEncodingFailedEvent = {
+        video_id: videoId,
+        source_location: 'test-source',
+        message: 'Original encoder message',
+      };
+      const error = new Error('Handled and mapped message');
+
+      // Act
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
+        handler.handleErrorMessage(error, createMessage(payload), dbCtx, true),
+      );
+
+      // Assert
+      const step = await selectOne('ingest_item_steps', {
+        id: step1.id,
+      }).run(ctx.ownerPool);
+      expect(step?.status).toBe('SUCCESS');
+    });
+  });
+});

--- a/services/media/service/src/ingest/handlers/video-encoding-failed-handler.ts
+++ b/services/media/service/src/ingest/handlers/video-encoding-failed-handler.ts
@@ -1,0 +1,81 @@
+import { Logger } from '@axinom/mosaic-service-common';
+import { TypedTransactionalMessage } from '@axinom/mosaic-transactional-inbox-outbox';
+import {
+  VideoEncodingFailedEvent,
+  VideoServiceMultiTenantMessagingSettings,
+} from '@axinom/mosaic-video-messages';
+import { ClientBase } from 'pg';
+import { update } from 'zapatos/db';
+import { CommonErrors, Config, getMediaMappedError } from '../../common';
+import { MediaGuardedTransactionalInboxMessageHandler } from '../../messaging';
+import { findLatestVideoIngestItemStep } from '../utils/find-latest-video-ingest-item-step';
+
+const fallbackErrorMessage =
+  'The video encoding has failed, but there was an error updating the ingest item step status.';
+
+export class VideoEncodingFailedHandler extends MediaGuardedTransactionalInboxMessageHandler<VideoEncodingFailedEvent> {
+  constructor(config: Config) {
+    super(
+      VideoServiceMultiTenantMessagingSettings.VideoEncodingFailed,
+      ['INGESTS_EDIT', 'ADMIN'],
+      new Logger({
+        config,
+        context: VideoEncodingFailedHandler.name,
+      }),
+      config,
+    );
+  }
+
+  override async handleMessage(
+    { payload }: TypedTransactionalMessage<VideoEncodingFailedEvent>,
+    ownerClient: ClientBase,
+  ): Promise<void> {
+    const step = await findLatestVideoIngestItemStep(
+      payload.video_id,
+      ownerClient,
+    );
+
+    if (!step) {
+      return;
+    }
+
+    await update(
+      'ingest_item_steps',
+      { status: 'ERROR', response_message: payload.message },
+      { id: step.id },
+    ).run(ownerClient);
+  }
+
+  public override mapError(error: unknown): Error {
+    return getMediaMappedError(error, {
+      message: fallbackErrorMessage,
+      code: CommonErrors.IngestError.code,
+    });
+  }
+
+  override async handleErrorMessage(
+    error: Error,
+    { payload }: TypedTransactionalMessage<VideoEncodingFailedEvent>,
+    ownerClient: ClientBase,
+    retry: boolean,
+  ): Promise<void> {
+    if (retry) {
+      return;
+    }
+
+    const step = await findLatestVideoIngestItemStep(
+      payload.video_id,
+      ownerClient,
+    );
+
+    if (!step) {
+      return;
+    }
+
+    await update(
+      'ingest_item_steps',
+      { status: 'ERROR', response_message: error.message },
+      { id: step.id },
+    ).run(ownerClient);
+  }
+}

--- a/services/media/service/src/ingest/handlers/video-encoding-finished-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/video-encoding-finished-handler.db.spec.ts
@@ -153,4 +153,49 @@ describe('VideoEncodingFinishedHandler', () => {
       expect(error).toMatchObject(testErrorInfo);
     });
   });
+
+  describe('handleErrorMessage', () => {
+    it('message failed on all retries -> step updated', async () => {
+      // Arrange
+      const payload: VideoEncodingFinishedEvent = {
+        video_id: videoId,
+        source_location: 'test-source',
+      };
+      // mapError makes sure this error is appropriate
+      const error = new Error('Handled and mapped message');
+
+      // Act
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
+        handler.handleErrorMessage(error, createMessage(payload), dbCtx, false),
+      );
+
+      // Assert
+      const step = await selectOne('ingest_item_steps', {
+        id: step1.id,
+      }).run(ctx.ownerPool);
+      expect(step?.response_message).toEqual(error.message);
+      expect(step?.status).toBe('ERROR');
+    });
+
+    it('message will be retried -> step not updated', async () => {
+      // Arrange
+      const payload: VideoEncodingFinishedEvent = {
+        video_id: videoId,
+        source_location: 'test-source',
+      };
+      const error = new Error('Handled and mapped message');
+
+      // Act
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
+        handler.handleErrorMessage(error, createMessage(payload), dbCtx, true),
+      );
+
+      // Assert
+      const step = await selectOne('ingest_item_steps', {
+        id: step1.id,
+      }).run(ctx.ownerPool);
+      expect(step?.status).toBe('ERROR');
+      expect(step?.response_message).toBe('A previous encoding attempt failed.');
+    });
+  });
 });

--- a/services/media/service/src/ingest/handlers/video-encoding-finished-handler.db.spec.ts
+++ b/services/media/service/src/ingest/handlers/video-encoding-finished-handler.db.spec.ts
@@ -1,0 +1,156 @@
+import { AuthenticatedManagementSubject } from '@axinom/mosaic-id-guard';
+import { MosaicError } from '@axinom/mosaic-service-common';
+import { TypedTransactionalMessage } from '@axinom/mosaic-transactional-inbox-outbox';
+import { VideoEncodingFinishedEvent } from '@axinom/mosaic-video-messages';
+import { stub } from 'jest-auto-stub';
+import 'jest-extended';
+import { randomUUID } from 'node:crypto';
+import { insert, selectOne } from 'zapatos/db';
+import {
+  ingest_documents,
+  ingest_items,
+  ingest_item_steps,
+} from 'zapatos/schema';
+import { CommonErrors } from '../../common';
+import {
+  createTestContext,
+  createTestUser,
+  ITestContext,
+} from '../../tests/test-utils';
+import { VideoEncodingFinishedHandler } from './video-encoding-finished-handler';
+
+describe('VideoEncodingFinishedHandler', () => {
+  let handler: VideoEncodingFinishedHandler;
+  let ctx: ITestContext;
+  let step1: ingest_item_steps.JSONSelectable;
+  let item1: ingest_items.JSONSelectable;
+  let doc1: ingest_documents.JSONSelectable;
+  let user: AuthenticatedManagementSubject;
+  const videoId = randomUUID();
+
+  const createMessage = (payload: VideoEncodingFinishedEvent) =>
+    stub<TypedTransactionalMessage<VideoEncodingFinishedEvent>>({
+      payload,
+      metadata: {},
+    });
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+    user = createTestUser(ctx.config.serviceId);
+    handler = new VideoEncodingFinishedHandler(ctx.config);
+  });
+
+  beforeEach(async () => {
+    doc1 = await insert('ingest_documents', {
+      name: 'test1',
+      title: 'test1',
+      document: {
+        name: 'test1',
+        document_created: '2020-08-04T08:57:40.763+00:00',
+        items: [],
+      },
+      items_count: 0,
+    }).run(ctx.ownerPool);
+    item1 = await insert('ingest_items', {
+      ingest_document_id: doc1.id,
+      external_id: 'externalId',
+      entity_id: 1,
+      type: 'MOVIE',
+      exists_status: 'CREATED',
+      display_title: 'title',
+      item: {
+        type: 'MOVIE',
+        external_id: 'externalId',
+        data: { title: 'title' },
+      },
+    }).run(ctx.ownerPool);
+    step1 = await insert('ingest_item_steps', {
+      id: randomUUID(),
+      type: 'VIDEO',
+      ingest_item_id: item1.id,
+      sub_type: 'MAIN',
+      entity_id: videoId,
+      status: 'ERROR',
+      response_message: 'A previous encoding attempt failed.',
+    }).run(ctx.ownerPool);
+  });
+
+  afterEach(async () => {
+    await ctx.truncate('ingest_documents');
+  });
+
+  afterAll(async () => {
+    await ctx.dispose();
+    jest.restoreAllMocks();
+  });
+
+  describe('handleMessage', () => {
+    it('matching video step found -> step reset to SUCCESS', async () => {
+      // Arrange
+      const payload: VideoEncodingFinishedEvent = {
+        video_id: videoId,
+        source_location: 'test-source',
+      };
+
+      // Act
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
+        handler.handleMessage(createMessage(payload), dbCtx),
+      );
+
+      // Assert
+      const step = await selectOne('ingest_item_steps', {
+        id: step1.id,
+      }).run(ctx.ownerPool);
+      expect(step?.status).toBe('SUCCESS');
+      expect(step?.response_message).toBeNull();
+    });
+
+    it('no matching video step -> nothing updated', async () => {
+      // Arrange
+      const payload: VideoEncodingFinishedEvent = {
+        video_id: randomUUID(),
+        source_location: 'test-source',
+      };
+
+      // Act
+      await ctx.executeOwnerSql(user, async (dbCtx) =>
+        handler.handleMessage(createMessage(payload), dbCtx),
+      );
+
+      // Assert
+      const step = await selectOne('ingest_item_steps', {
+        id: step1.id,
+      }).run(ctx.ownerPool);
+      expect(step?.status).toBe('ERROR');
+      expect(step?.response_message).toBe('A previous encoding attempt failed.');
+    });
+  });
+
+  describe('mapError', () => {
+    it('message failed with non-mosaic error -> default error mapped', async () => {
+      // Act
+      const error = handler.mapError(new Error('Unexpected failure'));
+
+      // Assert
+      expect(error).toMatchObject({
+        message:
+          'The video encoding has finished, but there was an error updating the ingest item step status.',
+        code: CommonErrors.IngestError.code,
+      });
+    });
+
+    it('message failed with mosaic error -> thrown error mapped', async () => {
+      // Arrange
+      const testErrorInfo = {
+        message: 'Handled test message',
+        code: 'HANDLED_TEST_CODE',
+      };
+
+      // Act
+      const error = handler.mapError(new MosaicError(testErrorInfo));
+
+      // Assert
+      expect(error).toMatchObject(testErrorInfo);
+    });
+  });
+});

--- a/services/media/service/src/ingest/handlers/video-encoding-finished-handler.ts
+++ b/services/media/service/src/ingest/handlers/video-encoding-finished-handler.ts
@@ -1,0 +1,57 @@
+import { Logger } from '@axinom/mosaic-service-common';
+import { TypedTransactionalMessage } from '@axinom/mosaic-transactional-inbox-outbox';
+import {
+  VideoEncodingFinishedEvent,
+  VideoServiceMultiTenantMessagingSettings,
+} from '@axinom/mosaic-video-messages';
+import { ClientBase } from 'pg';
+import { update } from 'zapatos/db';
+import { CommonErrors, Config, getMediaMappedError } from '../../common';
+import { MediaGuardedTransactionalInboxMessageHandler } from '../../messaging';
+import { findLatestVideoIngestItemStep } from '../utils/find-latest-video-ingest-item-step';
+
+const fallbackErrorMessage =
+  'The video encoding has finished, but there was an error updating the ingest item step status.';
+
+export class VideoEncodingFinishedHandler extends MediaGuardedTransactionalInboxMessageHandler<VideoEncodingFinishedEvent> {
+  constructor(config: Config) {
+    super(
+      VideoServiceMultiTenantMessagingSettings.VideoEncodingFinished,
+      ['INGESTS_EDIT', 'ADMIN'],
+      new Logger({
+        config,
+        context: VideoEncodingFinishedHandler.name,
+      }),
+      config,
+    );
+  }
+
+  override async handleMessage(
+    { payload }: TypedTransactionalMessage<VideoEncodingFinishedEvent>,
+    ownerClient: ClientBase,
+  ): Promise<void> {
+    const step = await findLatestVideoIngestItemStep(
+      payload.video_id,
+      ownerClient,
+    );
+
+    if (!step) {
+      return;
+    }
+
+    // Clears a previously recorded ERROR (e.g. after a successful retry of a
+    // failed encoding) so the ingest item step reflects the current outcome.
+    await update(
+      'ingest_item_steps',
+      { status: 'SUCCESS', response_message: null },
+      { id: step.id },
+    ).run(ownerClient);
+  }
+
+  public override mapError(error: unknown): Error {
+    return getMediaMappedError(error, {
+      message: fallbackErrorMessage,
+      code: CommonErrors.IngestError.code,
+    });
+  }
+}

--- a/services/media/service/src/ingest/handlers/video-encoding-finished-handler.ts
+++ b/services/media/service/src/ingest/handlers/video-encoding-finished-handler.ts
@@ -54,4 +54,30 @@ export class VideoEncodingFinishedHandler extends MediaGuardedTransactionalInbox
       code: CommonErrors.IngestError.code,
     });
   }
+
+  override async handleErrorMessage(
+    error: Error,
+    { payload }: TypedTransactionalMessage<VideoEncodingFinishedEvent>,
+    ownerClient: ClientBase,
+    retry: boolean,
+  ): Promise<void> {
+    if (retry) {
+      return;
+    }
+
+    const step = await findLatestVideoIngestItemStep(
+      payload.video_id,
+      ownerClient,
+    );
+
+    if (!step) {
+      return;
+    }
+
+    await update(
+      'ingest_item_steps',
+      { status: 'ERROR', response_message: error.message },
+      { id: step.id },
+    ).run(ownerClient);
+  }
 }

--- a/services/media/service/src/ingest/utils/find-latest-video-ingest-item-step.ts
+++ b/services/media/service/src/ingest/utils/find-latest-video-ingest-item-step.ts
@@ -9,13 +9,19 @@ import { ingest_item_steps } from 'zapatos/schema';
  * the video ID that was stored on it (as entity_id) when the encoding job
  * was first accepted. If the same video was re-ingested, entity_id may match
  * more than one step, so the most recently created one is used.
+ *
+ * Only the id is selected since that is all callers need to target the
+ * update - this avoids pulling/parsing the full row for high-volume events.
  */
 export const findLatestVideoIngestItemStep = (
   videoId: string,
   ownerClient: ClientBase,
-): Promise<ingest_item_steps.JSONSelectable | undefined> =>
+): Promise<Pick<ingest_item_steps.JSONSelectable, 'id'> | undefined> =>
   selectOne(
     'ingest_item_steps',
     { type: 'VIDEO', entity_id: videoId },
-    { order: { by: 'created_date', direction: 'DESC' } },
+    {
+      columns: ['id'],
+      order: { by: 'created_date', direction: 'DESC' },
+    },
   ).run(ownerClient);

--- a/services/media/service/src/ingest/utils/find-latest-video-ingest-item-step.ts
+++ b/services/media/service/src/ingest/utils/find-latest-video-ingest-item-step.ts
@@ -1,0 +1,21 @@
+import { ClientBase } from 'pg';
+import { selectOne } from 'zapatos/db';
+import { ingest_item_steps } from 'zapatos/schema';
+
+/**
+ * VideoEncodingFinished/VideoEncodingFailed events are not correlated to an
+ * ingest item step via message context (they fire for any video, whether or
+ * not it originated from ingest), so the affected step must be looked up by
+ * the video ID that was stored on it (as entity_id) when the encoding job
+ * was first accepted. If the same video was re-ingested, entity_id may match
+ * more than one step, so the most recently created one is used.
+ */
+export const findLatestVideoIngestItemStep = (
+  videoId: string,
+  ownerClient: ClientBase,
+): Promise<ingest_item_steps.JSONSelectable | undefined> =>
+  selectOne(
+    'ingest_item_steps',
+    { type: 'VIDEO', entity_id: videoId },
+    { order: { by: 'created_date', direction: 'DESC' } },
+  ).run(ownerClient);

--- a/services/media/service/src/messaging/register-messaging.ts
+++ b/services/media/service/src/messaging/register-messaging.ts
@@ -110,6 +110,8 @@ import {
   UpsertLocalizationSourceEntityFinishedHandler,
   VideoAlreadyExistedHandler,
   VideoCreationStartedHandler,
+  VideoEncodingFailedHandler,
+  VideoEncodingFinishedHandler,
   VideoFailedHandler,
 } from '../ingest';
 import {
@@ -328,6 +330,8 @@ const registerTransactionalInboxHandlers = (
     new VideoAlreadyExistedHandler(ingestProcessors, config),
     new VideoCreationStartedHandler(ingestProcessors, config),
     new VideoFailedHandler(config),
+    new VideoEncodingFinishedHandler(config),
+    new VideoEncodingFailedHandler(config),
     new ImageAlreadyExistedHandler(ingestProcessors, config),
     new ImageCreatedHandler(ingestProcessors, config),
     new ImageFailedHandler(config),
@@ -408,6 +412,8 @@ const registerRabbitMqMessaging = async (
         VideoServiceMultiTenantMessagingSettings.EnsureVideoExistsAlreadyExisted,
         VideoServiceMultiTenantMessagingSettings.EnsureVideoExistsCreationStarted,
         VideoServiceMultiTenantMessagingSettings.EnsureVideoExistsFailed,
+        VideoServiceMultiTenantMessagingSettings.VideoEncodingFinished,
+        VideoServiceMultiTenantMessagingSettings.VideoEncodingFailed,
         ImageServiceMultiTenantMessagingSettings.EnsureImageExistsAlreadyExisted,
         ImageServiceMultiTenantMessagingSettings.EnsureImageExistsImageCreated,
         ImageServiceMultiTenantMessagingSettings.EnsureImageExistsFailed,
@@ -435,6 +441,10 @@ const registerRabbitMqMessaging = async (
           case VideoServiceMultiTenantMessagingSettings
             .EnsureVideoExistsCreationStarted.messageType:
           case VideoServiceMultiTenantMessagingSettings.EnsureVideoExistsFailed
+            .messageType:
+          case VideoServiceMultiTenantMessagingSettings.VideoEncodingFinished
+            .messageType:
+          case VideoServiceMultiTenantMessagingSettings.VideoEncodingFailed
             .messageType:
           case ImageServiceMultiTenantMessagingSettings
             .EnsureImageExistsAlreadyExisted.messageType:
@@ -492,6 +502,14 @@ const registerRabbitMqMessaging = async (
     ).subscribeForEvent(() => inboxWriter),
     new RascalTransactionalConfigBuilder(
       VideoServiceMultiTenantMessagingSettings.EnsureVideoExistsFailed,
+      config,
+    ).subscribeForEvent(() => inboxWriter),
+    new RascalTransactionalConfigBuilder(
+      VideoServiceMultiTenantMessagingSettings.VideoEncodingFinished,
+      config,
+    ).subscribeForEvent(() => inboxWriter),
+    new RascalTransactionalConfigBuilder(
+      VideoServiceMultiTenantMessagingSettings.VideoEncodingFailed,
       config,
     ).subscribeForEvent(() => inboxWriter),
     new RascalTransactionalConfigBuilder(


### PR DESCRIPTION
## Summary
- The Ingest module only listened to `EnsureVideoExists*` events (whether the encode job was *accepted*), never `VideoEncodingFinished`/`VideoEncodingFailed` (whether encoding actually *finished*). A real, asynchronous encoding failure never reached `ingest_item_steps`, so the Ingest Items page kept showing a stale "Success" (or, in the synchronous-failure case, a message unrelated to the true encoding outcome) instead of the real encoder failure reason.
- This is the counterpart, on the media/ingest side, to [mosaic-video-service#213](https://github.com/Axinom/mosaic-video-service/pull/213), which fixed the Video Details page to read the encoder's `PublicMessage`/`ExceptionMessage`. That fix alone didn't help Ingest because Ingest never consumed the event carrying that message at all.
- Added `VideoEncodingFailedHandler` and `VideoEncodingFinishedHandler`. Since these events aren't correlated via `messageContext` like `EnsureVideoExists*` (they fire for any video, not only ones created through ingest), they're correlated by `video_id` matching the `entity_id` recorded on the ingest item step (using the most recently created match, in case of re-ingestion).
- `VideoEncodingFailed` sets the step to `ERROR` with the real encoder message; `VideoEncodingFinished` resets it to `SUCCESS` and clears any stale error (covers retry-then-succeed).
- Registered both in `register-messaging.ts` (handler list, accepted message settings, concurrency config, RabbitMQ subscriptions).

## Test plan
- [x] `tsc --noEmit` passes across the service (including spec files)
- [x] `eslint` clean on all changed/added files
- [ ] `yarn test src/ingest/handlers/video-encoding-failed-handler.db.spec.ts src/ingest/handlers/video-encoding-finished-handler.db.spec.ts --runInBand` — could not run locally, local Postgres test DB isn't available/configured (`password authentication failed for user media_service_owner_t`), the same environment limitation noted in mosaic-video-service#213's own test notes. Tests follow the existing `video-failed-handler.db.spec.ts` / `video-succeeded-handler.db.spec.ts` patterns and should be run in CI or an environment with a working local Postgres.
- [ ] Manual verification against a real encoding failure end-to-end (Ingest Items page should now show the specific encoder error instead of a generic/stale one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)