### PR TITLE
[AB#54103] fix: remove bulk selection from single entity selection scenarios

### DIFF
--- a/services/media/workflows/src/Stations/Seasons/SeasonSelection/SeasonDataList/SeasonDataList.tsx
+++ b/services/media/workflows/src/Stations/Seasons/SeasonSelection/SeasonDataList/SeasonDataList.tsx
@@ -28,6 +28,7 @@ export const SeasonDataList: React.FC<SeasonDataListProps> = ({
 }) => {
   const { SeasonDataListDataEntry } = useSeasonDataListDataEntry({
     excludeItems: value,
+    allowBulkSelect: maxItems !== 1, // Bulk Selection should be disabled if we can only select one item
   });
 
   const handleUnassign = useCallback(

--- a/services/media/workflows/src/Stations/Seasons/SeasonSelection/SeasonDataList/SeasonDataListEntry.tsx
+++ b/services/media/workflows/src/Stations/Seasons/SeasonSelection/SeasonDataList/SeasonDataListEntry.tsx
@@ -9,6 +9,7 @@ import { useSeasonSelectExplorerModal } from '../SeasonSelectExplorerModal/Seaso
 
 interface UseSeasonDataListDataEntryOptions {
   excludeItems: SeasonData[];
+  allowBulkSelect?: boolean;
 }
 
 interface UseSeasonDataListDataEntryResult {
@@ -32,6 +33,7 @@ export const useSeasonDataListDataEntry = (
         closeModal,
       } = useSeasonSelectExplorerModal({
         excludeItems: options.excludeItems.map((item) => item.id),
+        allowBulkSelect: options.allowBulkSelect,
         onSelection: (selection) => {
           if (selection.mode === 'SINGLE_ITEMS') {
             const items = selection.items;
@@ -56,7 +58,7 @@ export const useSeasonDataListDataEntry = (
     };
 
     return SeasonDataListDataEntry;
-  }, [options.excludeItems]);
+  }, [options.allowBulkSelect, options.excludeItems]);
 
   return { SeasonDataListDataEntry };
 };

--- a/services/media/workflows/src/Stations/Seasons/SeasonSelection/SeasonSelectExplorerModal/SeasonSelectExplorerModal.tsx
+++ b/services/media/workflows/src/Stations/Seasons/SeasonSelection/SeasonSelectExplorerModal/SeasonSelectExplorerModal.tsx
@@ -6,6 +6,7 @@ import { UseSeasonSelectExplorerModalOptions } from './SeasonSelectExplorerModal
 export const useSeasonSelectExplorerModal = ({
   excludeItems,
   title = 'Select Season',
+  allowBulkSelect = true,
   onSelection,
 }: UseSeasonSelectExplorerModalOptions): UseModalResult =>
   useModal(({ closeModal }) => (
@@ -30,7 +31,7 @@ export const useSeasonSelectExplorerModal = ({
           onClick: closeModal,
         },
       ]}
-      allowBulkSelect={true}
+      allowBulkSelect={allowBulkSelect}
       enableSelectAll={false}
     />
   ));

--- a/services/media/workflows/src/Stations/Seasons/SeasonSelection/SeasonSelectExplorerModal/SeasonSelectExplorerModal.types.ts
+++ b/services/media/workflows/src/Stations/Seasons/SeasonSelection/SeasonSelectExplorerModal/SeasonSelectExplorerModal.types.ts
@@ -3,5 +3,6 @@ import { SeasonSelectionExplorerProps } from '../../SeasonExplorerBase/SeasonExp
 export interface UseSeasonSelectExplorerModalOptions {
   title?: string;
   excludeItems?: number[];
+  allowBulkSelect?: boolean;
   onSelection: SeasonSelectionExplorerProps['onSelection'];
 }

--- a/services/media/workflows/src/Stations/TvShows/TvShowSelection/TvShowDataList/TvShowDataList.tsx
+++ b/services/media/workflows/src/Stations/TvShows/TvShowSelection/TvShowDataList/TvShowDataList.tsx
@@ -28,6 +28,7 @@ export const TvShowDataList: React.FC<TvShowDataListProps> = ({
 }) => {
   const { TvShowDataListDataEntry } = useTvShowDataListDataEntry({
     excludeItems: value,
+    allowBulkSelect: maxItems !== 1, // Bulk Selection should be disabled if we can only select one item
   });
 
   const handleUnassign = useCallback(

--- a/services/media/workflows/src/Stations/TvShows/TvShowSelection/TvShowDataList/TvShowDataListEntry.tsx
+++ b/services/media/workflows/src/Stations/TvShows/TvShowSelection/TvShowDataList/TvShowDataListEntry.tsx
@@ -9,6 +9,7 @@ import { useTvShowSelectExplorerModal } from '../TvShowSelectExplorerModal/TvSho
 
 interface UseTvShowDataListDataEntryOptions {
   excludeItems: TvShowData[];
+  allowBulkSelect?: boolean;
 }
 
 interface UseTvShowDataListDataEntryResult {
@@ -32,6 +33,7 @@ export const useTvShowDataListDataEntry = (
         closeModal,
       } = useTvShowSelectExplorerModal({
         excludeItems: options.excludeItems.map((item) => item.id),
+        allowBulkSelect: options.allowBulkSelect,
         onSelection: (selection) => {
           if (selection.mode === 'SINGLE_ITEMS') {
             const items = selection.items;
@@ -56,7 +58,7 @@ export const useTvShowDataListDataEntry = (
     };
 
     return TvShowDataListDataEntry;
-  }, [options.excludeItems]);
+  }, [options.allowBulkSelect, options.excludeItems]);
 
   return { TvShowDataListDataEntry };
 };

--- a/services/media/workflows/src/Stations/TvShows/TvShowSelection/TvShowSelectExplorerModal/TvShowSelectExplorerModal.tsx
+++ b/services/media/workflows/src/Stations/TvShows/TvShowSelection/TvShowSelectExplorerModal/TvShowSelectExplorerModal.tsx
@@ -6,6 +6,7 @@ import { UseTvShowSelectExplorerModalOptions } from './TvShowSelectExplorerModal
 export const useTvShowSelectExplorerModal = ({
   excludeItems,
   title = 'Select TV Show',
+  allowBulkSelect = true,
   onSelection,
 }: UseTvShowSelectExplorerModalOptions): UseModalResult =>
   useModal(({ closeModal }) => (
@@ -30,7 +31,7 @@ export const useTvShowSelectExplorerModal = ({
           onClick: closeModal,
         },
       ]}
-      allowBulkSelect={true}
+      allowBulkSelect={allowBulkSelect}
       enableSelectAll={false}
     />
   ));

--- a/services/media/workflows/src/Stations/TvShows/TvShowSelection/TvShowSelectExplorerModal/TvShowSelectExplorerModal.types.ts
+++ b/services/media/workflows/src/Stations/TvShows/TvShowSelection/TvShowSelectExplorerModal/TvShowSelectExplorerModal.types.ts
@@ -3,5 +3,6 @@ import { TvShowSelectionExplorerProps } from '../../TvShowExplorerBase/TvShowExp
 export interface UseTvShowSelectExplorerModalOptions {
   title?: string;
   excludeItems?: number[];
+  allowBulkSelect?: boolean;
   onSelection: TvShowSelectionExplorerProps['onSelection'];
 }


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [ ] The PR is targeting the `dev` branch
- [ ] potential **release notes** to the PR description added
- [ ] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

This PR fixes an issue where bulk selection was available for scenarios where only one item should be selected, 
- Season selection in Episode Details station
- TV Show selection in Season Details station
