### PR TITLE
[AB#55001] fix(workflows): bind the id-proxy to loopback and end the response on failure

### DIFF
--- a/services/media/workflows/src/mocks/id-proxy-injector.js
+++ b/services/media/workflows/src/mocks/id-proxy-injector.js
@@ -31,15 +31,16 @@ async function startProxy() {
   const httpProxy = require('http-proxy');
 
   const proxyPort = process.env.ID_SERVICE_LOCAL_PROXY_PORT;
+  const target = process.env.ID_SERVICE_AUTH_BASE_URL;
 
   const proxy = httpProxy.createProxyServer();
-  const server = http.createServer((req, res) => {
+  const handleRequest = (req, res) => {
     proxy.web(
       req,
       res,
       {
         xfwd: true,
-        target: process.env.ID_SERVICE_AUTH_BASE_URL,
+        target,
         changeOrigin: true,
       },
       (error) => {
@@ -48,13 +49,33 @@ async function startProxy() {
           message: 'an exception occured while proxying, please try again.',
           details: error,
         });
+
+        // Otherwise the socket stays open and the browser hangs.
+        if (!res.headersSent) {
+          res.writeHead(502, { 'content-type': 'application/json' });
+        }
+        res.end(
+          JSON.stringify({
+            error: 'id-proxy could not reach the id service',
+            target,
+            details: error?.message ?? String(error),
+          }),
+        );
       },
     );
-  });
+  };
 
-  server.on('listening', () => {
-    console.log(`\n> id-proxy running at http://localhost:${proxyPort}`);
-  });
+  // Loopback only — `listen(port)` alone would bind every interface — but both
+  // families, since `localhost` resolves to ::1 before 127.0.0.1. A failed bind
+  // is logged, not thrown: one family is enough to work.
+  const listen = (host) =>
+    http
+      .createServer(handleRequest)
+      .on('error', (e) => console.log(`> id-proxy: no ${host} — ${e.message}`))
+      .listen(proxyPort, host);
 
-  server.listen(proxyPort);
+  listen('127.0.0.1');
+  listen('::1');
+
+  console.log(`\n> id-proxy running at http://localhost:${proxyPort}`);
 }


### PR DESCRIPTION
[AB#55001](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/55001)

Two defects in the kras id-proxy injector used for local pilet development (`services/media/workflows/src/mocks/id-proxy-injector.js`). Both were found by an automated review after these scripts were ported into the trial-service repository.

Dev-tooling only — the injectors are never imported by `src` and do not ship in the pilet bundle.

## 1. The proxy was reachable from the whole network

`server.listen(proxyPort)` with no host argument binds `0.0.0.0`. That puts an **unauthenticated** HTTP proxy, pointed at whatever `ID_SERVICE_AUTH_BASE_URL` holds, on every interface of the developer's machine — so on a shared office or cafe network any other host can drive it, including at an internal id service that is not otherwise reachable from there.

Nothing needs the wider binding: config-injector advertises the proxy to the shell as `http://localhost:<port>`, so loopback is the only address ever used. It now listens on `127.0.0.1`.

## 2. A failed proxy attempt left the browser hanging

The error callback passed to `proxy.web` only logged. The response was never ended, so when the id service is unreachable the browser's auth request sits open until it times out. That presents as a *slow* id service rather than a broken one — a poor first experience for anyone setting the template up against a misconfigured `ID_SERVICE_AUTH_BASE_URL`.

It now returns 502 with the target and the underlying error message, guarded by `headersSent` so a failure part-way through a streamed response does not attempt a second write.

## Verification

Against `http-proxy@1.18.1` (the version this repo declares) with a guaranteed-unreachable upstream:

```
bound to: 127.0.0.1:54251
status: 502 | elapsed: 33 ms
body: {"error":"id-proxy could not reach the id service","target":"http://127.0.0.1:1",...}
```

Previously the same request hung until timeout, and the listener bound `*:<port>`. ESLint clean.

## Deliberately not included

Both are judgement calls for this repository rather than defects, so they are left for maintainers:

- These injectors use `dotenv`, declared at the root. Node has had `process.loadEnvFile` built in since 20.12 and `.nvmrc` here is v22, so the dependency could be dropped — but it is a genuinely declared dependency, not a phantom one.
- `http-proxy` was last released as 1.18.1 in **May 2020**. `http-proxy-3` is a maintained rewrite with the same `createProxyServer`/`.web` API and is a drop-in swap, but changing it touches the root manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)